### PR TITLE
Make docs step configurable like fmt and test

### DIFF
--- a/.apm/prompts/do.prompt.md
+++ b/.apm/prompts/do.prompt.md
@@ -121,7 +121,7 @@ Otherwise: implement the planned changes. Prefer simplicity. Do the boring obvio
 
 ### docs
 
-Read the project's instructions to find which documentation files to keep in sync (e.g., README.md, CLAUDE.md). Compare those files against changes in this PR.
+Read the project's instructions to find which documentation files to keep in sync (e.g., README.md). Compare those files against changes in this PR.
 
 If no documentation files are documented, skip this step with a note.
 


### PR DESCRIPTION
The **docs step hardcoded `README.md` and `CLAUDE.md`** as the files to check, while `fmt` and `test` both defer to project instructions for configuration. Now `docs` follows the same pattern — it reads project instructions to find which documentation files to keep in sync, and *skips with a note if none are configured*.