### PR TITLE
Document the setup guide for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ dependencies:
 Then run:
 
 ```bash
-apm install
+apm install              # uses target from apm.yml
+apm install -t claude    # or pass --target via CLI
 ```
 
 This generates `.claude/` with agency's commands, skills, and hooks. You now have `/do` and `/talk` available in Claude Code.


### PR DESCRIPTION
The Usage section was a WIP stub. **Now it walks a new user through the full setup**: install APM, declare the dependency, configure workflow commands, and optionally add custom quality rules.

The guide is written from the perspective of someone who just found this repo and wants to wire it into their project. It covers the `target: claude` config in `apm.yml` (with other agents noted), the `uvx` alternative for avoiding a global install, and how to write the workflow instruction file that `/do` reads for fmt/test/ci/docs commands. *The Kolu example is referenced at the end as a real-world reference rather than the only documentation.*