### PR TITLE
Use nix run for APM install instead of curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dependencies:
 
 ### 2. Run APM
 
-With [Nix](https://nixos.org/) (no install needed):
+With [Nix](https://nixos.asia/en/install) (no install needed):
 
 ```bash
 nix run github:numtide/llm-agents.nix#apm -- install           # uses target from apm.yml


### PR DESCRIPTION
**README now shows `nix run github:numtide/llm-agents.nix#apm` as the primary way to run APM**, with `uvx` as an alternative. The curl-pipe-to-shell install is removed entirely.

Restructured the steps so the `apm.yml` config comes first, then the "run APM" step shows concrete `nix run ... -- install` and `uvx` commands. *Neither method requires a global install — the heading and flow now reflect that.*

See [numtide/llm-agents.nix#3666](https://github.com/numtide/llm-agents.nix/pull/3666) for the apm nix package.