### PR TITLE
Post hickey analysis as PR comment

### DIFF
--- a/.apm/prompts/do.prompt.md
+++ b/.apm/prompts/do.prompt.md
@@ -105,7 +105,9 @@ Detect the default branch: `git symbolic-ref refs/remotes/origin/HEAD`
 
 **MANDATORY**: Load the `github-pr` skill (via Skill tool) BEFORE writing the PR title/body.
 
-**Verify**: On a feature branch (not master/main), draft PR exists (`gh pr view` succeeds).
+5. **Post hickey results**: If the hickey step produced findings with suggestions, post the full hickey analysis as a PR comment using `gh pr comment`. Use a `## Hickey Analysis` header. Skip this if hickey found no issues.
+
+**Verify**: On a feature branch (not master/main), draft PR exists (`gh pr view` succeeds). If hickey had findings, a PR comment exists.
 
 ---
 


### PR DESCRIPTION
**Hickey analysis results now get posted as a GitHub PR comment** whenever the analysis produces findings with suggestions. Previously, the analysis stayed in conversation context and was never surfaced on the PR itself.

The change lives in `do.prompt.md` — the `branch` step gains one instruction to post hickey output after creating the draft PR. *The hickey skill itself stays pure (no GitHub coupling); the orchestrator handles integration, which is where that concern belongs.*

Closes #13