### PR TITLE
Polish /do workflow: optimization PR comments, skip police for docs

### DIFF
--- a/.apm/prompts/do.prompt.md
+++ b/.apm/prompts/do.prompt.md
@@ -132,7 +132,9 @@ If no documentation files are documented, skip this step with a note.
 
 ### police
 
-Invoke the `/code-police` skill via the Skill tool. It runs three passes: rule checklist, fact-check, and elegance.
+Use `git diff <default-branch>...HEAD --name-only` to check if the PR contains code changes. If all changed files are documentation-only (e.g., `.md`, `.txt`, `README`, docs/) — skip this step with a note.
+
+Otherwise, invoke the `/code-police` skill via the Skill tool. It runs three passes: rule checklist, fact-check, and elegance.
 
 When `/code-police` asks about scope: **changes in the current branch/PR only**.
 


### PR DESCRIPTION
Two small improvements to the `/do` workflow in `do.prompt.md`:

**Optimization suggestions now appear in the PR comment** alongside the step status table. Previously these were only printed to the terminal — now they're persisted on the PR for future reference.

**Code-police skips documentation-only PRs.** The police step now checks `git diff --name-only` first. If all changed files are docs (`.md`, `.txt`, etc.), the three-pass code review is skipped — *it adds no value when there's no code to review.*