### PR TITLE
Require e2e coverage for all behavioral paths

### DIFF
--- a/.apm/prompts/do.prompt.md
+++ b/.apm/prompts/do.prompt.md
@@ -117,9 +117,9 @@ If the task is a bug fix: write a failing test first (e2e or unit, whichever is 
 
 Otherwise: implement the planned changes. Prefer simplicity. Do the boring obvious thing.
 
-**E2E coverage**: When the change introduces multiple behavioral paths (e.g., a dialog that appears under different conditions), write e2e scenarios for **each distinct path**, not just one. Enumerate the paths from the code, then check that every path has a corresponding test. A single "happy path" test that covers one condition is insufficient when the feature has combinatorial triggers.
+**E2E coverage**: When the change introduces multiple user-facing paths (e.g., a dialog that appears under different conditions), write e2e scenarios for **each distinct path**. Enumerate the user-visible paths, then check that every one has a corresponding test.
 
-**Verify**: Code changes match the planned approach. All distinct behavioral paths have test coverage.
+**Verify**: Code changes match the planned approach. All distinct user-facing paths have test coverage.
 
 ---
 


### PR DESCRIPTION
**The implement step now explicitly requires e2e scenarios for every distinct behavioral path**, not just one happy-path test. Previously, a feature with combinatorial triggers (e.g., a confirmation dialog that appears for worktrees, splits, or both) could pass review with only one scenario covering one condition — leaving other paths untested.

This came up in juspay/kolu#356 where a unified close-confirmation dialog had 3 distinct trigger conditions but only 2 were initially tested. _The worktree+splits combination was missed until manual review caught it._

The new guidance goes in the `implement` step so the agent thinks about coverage at implementation time, not as an afterthought during `test`.