### PR TITLE
Allow projects to extend hickey complecting catalog

### DIFF
--- a/.apm/skills/hickey/SKILL.md
+++ b/.apm/skills/hickey/SKILL.md
@@ -43,7 +43,7 @@ Two abstractions serving one user-level concern = accidental concept multiplicat
 
 ### Layer 3: Check the Complecting Catalog
 
-Scan for known complecting patterns:
+Scan for known complecting patterns **and any additional complecting patterns from project instructions**:
 
 | Construct | What it complects | Simpler alternative |
 |---|---|---|


### PR DESCRIPTION
**Projects can now add domain-specific complecting patterns** to the hickey evaluation via project instructions, mirroring the existing code-police extension mechanism.

The change is one line in Layer 3: *"Scan for known complecting patterns **and any additional complecting patterns from project instructions**"*. Projects create an instructions file (e.g., `hickey-catalog.instructions.md`) with additional catalog entries that the skill loads alongside its built-in table.

*Motivated by a real miss*: in a SolidJS project, Claude Code repeatedly reached for imperative `Map` + `AbortController` + `createEffect` lifecycle management when the framework's built-in `mapArray` primitive handles it declaratively. The built-in catalog covers general patterns (mutable state, ORM, inheritance) but not framework-specific ones like "imperative lifecycle in a reactive framework." A project-level extension would have caught this during the hickey step before implementation.