### PR TITLE
Brand /do results comment with repo link

### DIFF
--- a/.apm/prompts/do.prompt.md
+++ b/.apm/prompts/do.prompt.md
@@ -232,7 +232,7 @@ Report the PR URL. Then post the final step status table as a **PR comment** usi
 
 ```
 gh pr comment --body "$(cat <<'COMMENT'
-## Execute Results
+## [`/do`](https://github.com/srid/agency) results
 
 | Step | Status | Duration | Verification |
 |------|--------|----------|-------------|


### PR DESCRIPTION
**PR comment header changes from generic "Execute Results" to `/do results"** with a clickable link back to [srid/agency](https://github.com/srid/agency), so readers know where the workflow comes from.

Closes #19