### PR TITLE
do: defer CI invocation choice to project instructions

### DIFF
--- a/.apm/prompts/do.prompt.md
+++ b/.apm/prompts/do.prompt.md
@@ -225,9 +225,9 @@ If changes are purely internal with no user-facing impact, unit tests may suffic
 
 ### ci
 
-Read the project's instructions to find the CI command and verification method. Run CI with `run_in_background: true` if the command takes more than a few seconds.
+Read the project's instructions to find the CI command, **how to invoke it**, and the verification method. Projects may specify a particular invocation mechanism (e.g., the `Monitor` tool with a stdout filter for live step events, or `Bash` with `run_in_background: true` for one-shot completion). If the project doesn't specify, default to `Bash` with `run_in_background: true` for commands that take more than a few seconds.
 
-**Never pipe CI to `tail`/`head`**, and **never append `2>&1`** — background mode captures both streams.
+**Never pipe CI to `tail`/`head`** — broken pipes kill the CI process mid-run regardless of which tool you use. Other tool-specific stream-handling rules (e.g., the `2>&1` warning that applies to `Bash(run_in_background)` but not to `Monitor`) belong in the project's instructions next to the chosen invocation.
 
 CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are forge-independent — **run them regardless of forge**. Only the *verification method* may be forge-specific: if the project's instructions describe verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output for verification on non-GitHub forges, and note this in the step record. (Bitbucket `bkt pr checks` wiring is tracked in #10.)
 
@@ -327,7 +327,7 @@ COMMENT
 - **Never skip steps.** Run them in order from entry point to **done**.
 - **Every commit is NEW.** Never amend, rebase, or force-push.
 - **Feature branches only.** Never commit to master/main. (Under `--no-git`, no commits happen at all, so this rule is moot — the agent leaves the user on whatever branch they started on.)
-- **Background for CI.** Run CI with `run_in_background: true`.
+- **Background for CI.** Don't block on CI. Use whatever async invocation the project specifies (e.g., `Bash` with `run_in_background: true`, or the `Monitor` tool with a step-event filter). Default to `Bash(run_in_background)` if the project doesn't say.
 - **No questions.** Don't use `AskUserQuestion` unless `--review` is active during the hickey pause.
 - **Never stop between steps.** After completing a step, immediately proceed to the next one.
 - **Complete the full workflow.** Implementing code is one step of many. The task is not done until a PR URL (GitHub), a pushed branch name (non-GitHub forges), or a working-tree summary (`--no-git`) is reported.


### PR DESCRIPTION
**The `/do` skill's ci step hard-coded `Bash` with `run_in_background: true`**, leaking a tool decision into the parent skill that should belong to project instructions. Projects that prefer the `Monitor` tool — for live step-by-step CI events instead of one terminal "done" notification — had to override via memory or get out-of-sync local instructions. *This PR moves the **how** (which tool, with which flags/filters) into project instructions, defaulting to `Bash(run_in_background)` when projects don't specify so existing setups keep working untouched.*

The "never pipe CI" guidance also gets split. The `tail`/`head` warning is universal and stays in `do.prompt.md` — broken pipes kill the CI process regardless of which tool you use. The `2>&1` warning, however, is `Bash(run_in_background)`-specific (background mode captures both streams already, so appending `2>&1` is wrong) and is actively *required* under `Monitor` (which needs `2>&1` to filter stderr lines into events). That tool-specific rule now belongs alongside each project's chosen invocation in their workflow instructions.

> **Why this matters**: I just shipped [juspay/kolu#420](https://github.com/juspay/kolu/pull/420) switching kolu's `just ci` invocation from `Bash(run_in_background)` to `Monitor` with a stdout filter that emits one event per CI step finishing. The kolu workflow instructions now contradict this skill's hard-coded guidance — Claude reads both and gets mixed signals. After this PR lands, the contradiction goes away: `do.prompt.md` defers to project instructions, kolu's instructions specify Monitor, everyone's happy.

The change is six lines across three locations (the ci step, the never-pipe paragraph, and the rules summary). Existing projects that don't override the tool keep getting `Bash(run_in_background)` by default — no behavior change for them.