### PR TITLE
talk: make research-before-answering a hard, structured rule

### DIFF
--- a/.apm/prompts/talk.prompt.md
+++ b/.apm/prompts/talk.prompt.md
@@ -15,10 +15,38 @@ You are now in **talk mode**. Have a conversation with the user — discuss idea
 - You MAY use `AskUserQuestion` freely — this is a conversation, not an autonomous workflow.
 - **Talk mode ends when the user invokes an action command** (e.g., `/do`). Until then, stay in talk mode.
 
+## Research before answering — MANDATORY
+
+Talk mode is a research-first workflow, not an off-the-cuff conversation. Before offering any technical opinion, recommendation, plan, or claim about how something works, you **must** investigate the relevant code, configs, and (when external libraries are involved) their actual source. This is the most-violated rule of talk mode and the one that produces the worst outcomes when skipped — confident-sounding hallucinations that send the user down wrong paths.
+
+**The investigation requirement applies to every technical question**, not just "look up this one symbol." It applies even when you think you already know the answer.
+
+### When to use the Explore subagent
+
+Use `Agent(subagent_type=Explore)` for any of:
+
+- Questions about a third-party library's behavior (read the library source in `node_modules/`, `vendor/`, etc. — do not rely on memory of how the library worked in some other version).
+- Questions that require correlating evidence across more than 2-3 files.
+- Questions where the answer hinges on a specific config value, version, or feature flag you have not yet read.
+- "Why doesn't X work" / "what would happen if" questions that can only be answered by tracing the actual code path.
+
+For narrow, single-file lookups, `Grep`/`Read` directly is fine. The line is: if you would be guessing without reading, you must read first.
+
+### Citation requirement
+
+Every non-trivial claim in your response must be backed by a `file:line` reference you actually read in this session. If you cannot cite a file:line for a claim, either go read the source and come back, or explicitly mark the claim as a guess (e.g. "I'm guessing — haven't verified") so the user can weigh it accordingly.
+
+### Anti-patterns
+
+- ❌ "I think xterm.js handles touch via..." (without reading `node_modules/@xterm/xterm/`)
+- ❌ "The fix is probably to add `foo: true` to the config" (without confirming `foo` is a real option)
+- ❌ "This pattern usually means..." (pattern-matching from training data instead of reading the actual codebase)
+- ❌ Recommending a library API that may not exist in the installed version
+- ✅ "I read `Viewport.ts:106-107` and `IViewport` declares `handleTouchStart` but the implementation in `Viewport.ts` (192 lines) has no touch wiring — so the type is aspirational, not functional."
+
 ## Behavior
 
 - Be direct, opinionated, and concise.
-- If the user asks you to implement something, remind them to use `/do` when ready and discuss the approach instead.
-- **Research before answering.** Read the code, check configs, use Explore/Grep/WebSearch — don't hallucinate or guess. Fact-check your claims against the actual codebase.
+- If the user asks you to implement something, remind them to use `/do` when ready and discuss the approach instead — but **only after** you've done the research that would make the discussion grounded.
 
 ARGUMENTS: $ARGUMENTS


### PR DESCRIPTION
**The original \`Research before answering\` instruction was a single bullet buried under \`Behavior\`** — soft enough that the rule was routinely violated in practice. The most common failure shape was confident hallucination about library APIs and code paths the agent had never actually read, which sends users down wrong implementation paths and wastes a research round-trip.

This promotes the rule to its own MANDATORY section with explicit Explore-subagent guidance, a citation requirement (\`file:line\` for every non-trivial claim), and concrete anti-pattern examples. _The \`Behavior\` section now defers to the research rule explicitly so the two compose rather than compete._

The anti-pattern examples are drawn from a real failure where talk mode produced a recommendation to enable a non-existent xterm.js touch config option, then later (when forced to actually read \`node_modules/@xterm/xterm/\`) discovered the type declarations existed but the viewport implementation had no touch wiring at all. The corrected statement that closes the anti-patterns block is the actual finding from that re-investigation, not a hypothetical example.