### PR TITLE
fix(do): replace ambiguous `<default-branch>` with `origin/HEAD` in police & test steps

### DIFF
--- a/.apm/prompts/do.prompt.md
+++ b/.apm/prompts/do.prompt.md
@@ -191,7 +191,7 @@ If no documentation files are documented, skip this step with a note.
 
 ### police
 
-Use `git diff <default-branch>...HEAD --name-only` to check if the PR contains code changes. If all changed files are documentation-only (e.g., `.md`, `.txt`, `README`, docs/) — skip this step with a note.
+Use `git diff origin/HEAD...HEAD --name-only` to check if the PR contains code changes. If all changed files are documentation-only (e.g., `.md`, `.txt`, `README`, docs/) — skip this step with a note.
 
 Otherwise, invoke the `/code-police` skill via the Skill tool. It runs three passes: rule checklist, fact-check, and elegance.
 
@@ -226,7 +226,7 @@ Create a NEW commit (never amend) with a conventional commit message. Push to th
 
 Read the project's instructions to find the test command and strategy. Run only the tests relevant to the code paths changed in this PR.
 
-Use `git diff <default-branch>...HEAD --name-only` to identify changed files and determine which tests are relevant.
+Use `git diff origin/HEAD...HEAD --name-only` to identify changed files and determine which tests are relevant.
 
 If changes are purely internal with no user-facing impact, unit tests may suffice — skip e2e if no relevant scenarios exist. If no test command is documented, skip with a note.
 


### PR DESCRIPTION
## Summary

- The `police` and `test` steps used `<default-branch>` as a placeholder in `git diff` commands, which agents could misinterpret or run literally
- Replaced with `origin/HEAD`, a concrete git ref that works directly since `sync` already runs `git remote set-head origin --auto`

Closes #39

## Test plan

- [ ] Run `/do` on a repo and verify the police step runs `git diff origin/HEAD...HEAD --name-only` correctly
- [ ] Verify the test step similarly uses `origin/HEAD` to identify changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)