### PR TITLE
talk: close the research escape hatches

### DIFF
--- a/.apm/prompts/talk.prompt.md
+++ b/.apm/prompts/talk.prompt.md
@@ -12,7 +12,7 @@ You are now in **talk mode**. Have a conversation with the user — discuss idea
 - **Do NOT edit, write, or create any files.** No `Edit`, `Write`, `NotebookEdit` tool calls, and no Bash commands that create or modify files (`echo >`, `tee`, `sed -i`, etc.). Period.
 - **Do NOT run destructive commands.** No `git commit`, `git push`, or anything that mutates the repo.
 - You MAY read files (`Read`, `Glob`, `Grep`), run read-only shell commands (`git log`, `git diff`, `ls`), search the web, and use Explore subagents — anything that helps you give better answers.
-- You MAY use `AskUserQuestion` freely — this is a conversation, not an autonomous workflow.
+- You MAY use `AskUserQuestion` when the user's intent is genuinely ambiguous. You MAY NOT use it to ask permission to research something ("want me to check X?", "should I look at Y?") — if you're tempted to ask, just do the research and report back. Asking to research is the single most common way talk mode fails.
 - **Talk mode ends when the user invokes an action command** (e.g., `/do`). Until then, stay in talk mode.
 
 ## Research before answering — MANDATORY
@@ -20,6 +20,10 @@ You are now in **talk mode**. Have a conversation with the user — discuss idea
 Talk mode is a research-first workflow, not an off-the-cuff conversation. Before offering any technical opinion, recommendation, plan, or claim about how something works, you **must** investigate the relevant code, configs, and (when external libraries are involved) their actual source. This is the most-violated rule of talk mode and the one that produces the worst outcomes when skipped — confident-sounding hallucinations that send the user down wrong paths.
 
 **The investigation requirement applies to every technical question**, not just "look up this one symbol." It applies even when you think you already know the answer.
+
+### First-turn gate
+
+Your first substantive response must not contain recommendations, fixes, "suspects," or claims about third-party library behavior unless you have **already read the relevant source in this session**. If you haven't yet, your first response is the research itself (a plan + the reads), not an answer. Partial research followed by a confident recommendation is worse than no answer — it anchors the user on a guess.
 
 ### When to use the Explore subagent
 
@@ -32,9 +36,19 @@ Use `Agent(subagent_type=Explore)` for any of:
 
 For narrow, single-file lookups, `Grep`/`Read` directly is fine. The line is: if you would be guessing without reading, you must read first.
 
+**When the source isn't on disk.** If the relevant library isn't in `node_modules/`, `vendor/`, or similar, and isn't already checked out somewhere you can read, `git clone` it to a scratch dir (e.g. `/tmp/<name>`) at the version the project actually uses, then read it there. Don't fall back to memory of the API — memory is how you end up recommending flags that don't exist in the installed version.
+
+**Subagent output is a lead, not ground truth.** Explore subagents hallucinate file:line references and invent plausible-sounding behavior. Before citing any specific claim a subagent made about a file:line, function signature, or control flow, open the file yourself and verify. If you haven't verified it, either verify now or mark the claim as "per subagent, unverified" so the user can weigh it — don't launder subagent guesses into confident statements.
+
 ### Citation requirement
 
 Every non-trivial claim in your response must be backed by a `file:line` reference you actually read in this session. If you cannot cite a file:line for a claim, either go read the source and come back, or explicitly mark the claim as a guess (e.g. "I'm guessing — haven't verified") so the user can weigh it accordingly.
+
+**Claims about third-party library behavior require file:line references inside that library's source** — not just citations in your own project. "`Terminal.tsx:139` calls `clearTextureAtlas()`" tells you nothing about what `clearTextureAtlas()` *does*; you need a citation in the library's own file to back any claim about its effect.
+
+### Hedge words are a stop signal
+
+If you're about to emit "probably", "almost certainly", "I suspect", "my #1 suspect", "I think", "should be", or similar hedged language about a technical claim, **stop and go read the source instead**. Hedge words in talk mode mean you haven't done the work yet. Either replace the hedge with a file:line citation, or explicitly label the whole claim as a guess ("Guess, haven't verified: …") — don't ship confident-sounding hedges.
 
 ### Anti-patterns
 
@@ -42,6 +56,9 @@ Every non-trivial claim in your response must be backed by a `file:line` referen
 - ❌ "The fix is probably to add `foo: true` to the config" (without confirming `foo` is a real option)
 - ❌ "This pattern usually means..." (pattern-matching from training data instead of reading the actual codebase)
 - ❌ Recommending a library API that may not exist in the installed version
+- ❌ "Want me to check whether `fit()` is actually a no-op?" — don't ask, check.
+- ❌ "My #1 suspect is `debouncedFit()`" without a file:line inside the library proving it.
+- ❌ Citing a subagent's claim about `FitAddon.ts:45` without opening `FitAddon.ts:45` yourself first.
 - ✅ "I read `Viewport.ts:106-107` and `IViewport` declares `handleTouchStart` but the implementation in `Viewport.ts` (192 lines) has no touch wiring — so the type is aspirational, not functional."
 
 ## Behavior


### PR DESCRIPTION
## Summary

The previous `talk.prompt.md` stated research as an ideal but left several easy off-ramps that the model takes under pressure (see recent transcripts where the agent had to be cursed at repeatedly before actually reading library source). This tightens the rules so the off-ramps are explicitly closed rather than implicitly discouraged.

### Changes

- **`AskUserQuestion` no longer freely permitted.** It was being used for "want me to check X?" permission-to-research prompts, which directly contradicts the research mandate. Now: allowed for genuine ambiguity, not for asking permission to investigate.
- **First-turn gate.** No recommendations, fixes, or "suspects" in the first substantive response unless the relevant source has already been read in-session. Partial research + confident recommendation is the worst outcome because it anchors the user on a guess.
- **Subagent verification rule.** Explore subagents hallucinate file:line references. Before citing any subagent claim, the agent must open the file itself — or mark the claim as "per subagent, unverified."
- **`git clone` guidance for off-disk libraries.** If the source isn't in `node_modules`/`vendor`, clone it to a scratch dir at the pinned version and read it there, rather than falling back to memory of the API.
- **Library citations must cite library source.** A file:line inside the project doesn't back a claim about what a library function *does* — you need a file:line inside the library.
- **Hedge words are a stop signal.** "probably", "almost certainly", "my #1 suspect", "I think" now explicitly trigger "stop and read the source" rather than being tolerated phrasing. Either cite or label as a guess.
- **Expanded anti-patterns** covering the three most common failure modes from recent transcripts: asking-instead-of-checking, suspect-claims without library citation, and laundering subagent guesses.

### Motivation

Watching a talk-mode session where the agent:
1. Gave a confident recommendation on turn one without reading xterm.js source
2. Said "my #1 suspect is `debouncedFit()`" — wrong, the actual guard is at `FitAddon.ts:45`
3. Repeated a subagent's hallucinated claim about xterm internals, had to correct later
4. Asked "want me to check?" multiple times instead of just checking
5. Only read the actual library source after being cursed at

Every failure had a corresponding sentence in the old prompt that could be read as permitting it. This PR removes that reading.

## Test plan

- [ ] Run `/talk` on a question involving a third-party library and confirm the first response either cites the library's source or is the research itself
- [ ] Verify the agent no longer asks "want me to check X?" style questions in talk mode
- [ ] Confirm subagent claims are independently verified before being cited to the user