### PR TITLE
Close the hickey→police loop

### DIFF
--- a/.apm/prompts/do.prompt.md
+++ b/.apm/prompts/do.prompt.md
@@ -127,7 +127,7 @@ Evaluate the planned approach for structural simplicity. Invoke the `hickey` ski
 
 Use `ExitPlanMode` to present the plan. Once approved, continue autonomously from **branch**.
 
-**Verify**: Complecting concerns addressed or justified.
+**Verify**: Every finding has an action (fix or defer with issue link). No unactioned findings.
 
 ---
 
@@ -197,7 +197,9 @@ Otherwise, invoke the `/code-police` skill via the Skill tool. It runs three pas
 
 When `/code-police` asks about scope: **changes in the current branch/PR only**.
 
-**Verify**: All 3 passes clean ("All clear").
+**Cross-reference hickey actions**: After code-police completes, check every hickey finding marked **"Fix in this PR"**. For each one, verify the diff addresses it. An unaddressed "Fix in this PR" action is a police failure — fix it before proceeding, same as any other police violation. This closes the loop between hickey (which finds structural issues before implementation) and police (which verifies the implementation after).
+
+**Verify**: All 3 passes clean ("All clear") AND all hickey "Fix in this PR" actions addressed in the diff.
 **If violations found** (max 3 attempts): Fix the violations and re-invoke `/code-police`.
 
 ---

--- a/.apm/prompts/do.prompt.md
+++ b/.apm/prompts/do.prompt.md
@@ -267,7 +267,9 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 
 **If `forge == github`**: Re-check the PR title/body against current scope. If scope changed, update via `gh pr edit` per the `forge-pr` skill.
 
-**Verify**: PR title/body matches the delivered scope.
+**Surface deferred hickey findings**: If the hickey step produced any **"Defer `#issue`"** actions, append a `> **Deferred:** #123, #124` line to the PR body (via `gh pr edit`) so reviewers see the outstanding structural debt. These are easy to miss in a PR comment — the description is what reviewers actually read.
+
+**Verify**: PR title/body matches the delivered scope, and any deferred hickey issues are linked in the body.
 
 ---
 

--- a/.apm/skills/hickey/SKILL.md
+++ b/.apm/skills/hickey/SKILL.md
@@ -135,6 +135,8 @@ After completing all layers, **invoke `/fact-check` on your own output**. The fa
 - Bogus "essential complexity" labels without a concrete simplified alternative
 - Claims about code behavior that you didn't verify by reading the code
 
+**Also flag scope-based dismissals.** "Out of scope for this PR", "pre-existing issue", "appropriate scope for a bug fix", and "follow-up refactor" are not simplicity judgments — they are process judgments that let findings evaporate between hickey and implementation. If you find yourself writing one, either fix the finding in this PR or create an issue and defer it. The Actions section enforces this — if you can't fill it in, you're dismissing the finding.
+
 **Also flag your own output for phrase shapes that mean you stopped reasoning one step early.** These aren't findings you talked yourself out of — they're findings you never let form. If any of these phrase shapes appear in your evaluation, re-open the question they're dismissing:
 
 - _"X and Y share Z but are separate concerns"_ — verified at the *domain* level, or just at the current implementation layout? Shared input is a precondition; work it through.
@@ -158,6 +160,11 @@ If fact-check finds issues with your evaluation, revise before presenting to the
 5. **Severity** — For each finding: blast radius, change friction, reasoning load.
 6. **Simplifications** — Concrete alternative for every finding.
 7. **Fact-check result** — Output of `/fact-check` on this evaluation, including the phrase-shape check.
+8. **Actions** — One entry per finding. Each must be dispositioned as exactly one of:
+   - **Fix in this PR**: one-line description of what the implementation step must do. This is the default — prefer it.
+   - **Defer `#<issue-number>`**: create a GitHub/forge issue for the finding first, then reference it here. "Out of scope" without an issue link is a dismissal, not a deferral. If you can't be bothered to create the issue, the finding belongs in this PR.
+
+   "No findings" → "No actions." But if findings exist and the actions list is empty, the evaluation is incomplete.
 
 Do NOT include a "What's simple" section. Praise biases toward positive framing and makes findings feel like minor quibbles. Report what you found. The absence of findings is its own praise.
 


### PR DESCRIPTION
**Hickey findings were getting acknowledged then silently dropped during implementation.** The evaluation would flag fragmentation or complecting, the fact-check would rubber-stamp a scope dismissal ("pre-existing issue, appropriate for a bug fix"), and the finding would evaporate before police ever saw it. Real example: hickey flagged "focused terminal ID" fragmentation across two state stores, implementation patched one call site inline, police reviewed the diff in isolation and said "all clear."

Three changes close the loop:

**Hickey now produces an Actions section** — every finding must be dispositioned as "Fix in this PR" (default) or "Defer `#issue`" with an actual issue link. No unactioned findings. "Out of scope" without an issue number is a dismissal, not a deferral. _If you can't be bothered to create the issue, the finding belongs in this PR._

**Police cross-references hickey actions** after its three passes. Every "Fix in this PR" action gets checked against the diff. An unaddressed action is a police failure, same as any other violation — fix it before proceeding.

**Hickey's fact-check flags scope dismissals.** "Out of scope for this PR", "pre-existing issue", "appropriate scope for a bug fix", and "follow-up refactor" are process judgments, not simplicity judgments. The fact-check now catches these and routes them into the Actions section instead of letting them serve as exits.