### PR TITLE
fix: let agents find .apm/ wherever it lives, not just the project root

### DIFF
--- a/.apm/instructions/apm-sources.instructions.md
+++ b/.apm/instructions/apm-sources.instructions.md
@@ -5,8 +5,8 @@ applyTo: ".claude/**,.opencode/**"
 
 ## Generated Files — Do Not Edit Directly
 
-> **This rule only applies if an `.apm/` directory exists in the project root.** If there is no `.apm/` directory, `.claude/` and `.opencode/` files are vendored directly and can be edited in place.
+> **This rule only applies if an `.apm/` directory exists somewhere in the project** (e.g., `.apm/`, `agents/.apm/`, or any other path). If no `.apm/` directory exists anywhere, `.claude/` and `.opencode/` files are vendored directly and can be edited in place.
 
 Everything under `.claude/` and `.opencode/` is **generated** from `.apm/` sources by APM. Direct edits will be overwritten on the next `apm install` run.
 
-To modify agent configuration, edit the source files in `.apm/`, then run `apm install` to regenerate.
+To modify agent configuration, find the nearest `.apm/` directory in the project (it may be at the root or nested under a subdirectory like `agents/.apm/`), edit the source files there, then run `apm install` to regenerate.


### PR DESCRIPTION
The `apm-sources` instruction rule previously assumed `.apm/` always sits at the project root. Projects like **kolu** put their APM sources under `agents/.apm/`, so the guard clause ("only applies if `.apm/` exists in the project root") silently skipped them — agents would happily edit generated files in `.claude/` without being redirected to the real sources.

The updated rule drops the root-only assumption and tells agents to look for the **nearest `.apm/` directory anywhere in the project tree**. If no `.apm/` directory exists at all, the fallback stays the same: files are vendored directly and can be edited in place.

Closes #52