### PR TITLE
fix(apm-sources): detect .apm/ at any directory level

### DIFF
--- a/.apm/instructions/apm-sources.instructions.md
+++ b/.apm/instructions/apm-sources.instructions.md
@@ -1,12 +1,12 @@
 ---
-description: Redirects agents to edit .apm/ sources instead of generated agent config files
+description: Redirects agents to edit .apm/ sources (at any directory level) instead of generated agent config files
 applyTo: ".claude/**,.opencode/**"
 ---
 
 ## Generated Files — Do Not Edit Directly
 
-> **This rule only applies if an `.apm/` directory exists in the project root.** If there is no `.apm/` directory, `.claude/` and `.opencode/` files are vendored directly and can be edited in place.
+> **This rule only applies if an `.apm/` directory exists somewhere in the project.** If there is no `.apm/` directory at any level, `.claude/` and `.opencode/` files are vendored directly and can be edited in place. To locate it, search for a directory matching `**/.apm/` from the project root.
 
 Everything under `.claude/` and `.opencode/` is **generated** from `.apm/` sources by APM. Direct edits will be overwritten on the next `apm install` run.
 
-To modify agent configuration, edit the source files in `.apm/`, then run `apm install` to regenerate.
+To modify agent configuration, find the `.apm/` directory (it may be at the project root or nested under a subdirectory such as `agents/.apm/`), edit the source files there, then run `apm install` to regenerate.


### PR DESCRIPTION
## Summary
- Updates the `apm-sources` instruction rule to detect `.apm/` anywhere in the project tree, not just at the root
- Instructs agents to search for `**/.apm/` and use whichever location they find
- Fixes the case where projects nest APM sources under a subdirectory (e.g. `agents/.apm/`)

Closes #52

## Test plan
- [ ] In a project with `.apm/` at root, verify agents still get redirected to `.apm/` sources
- [ ] In a project with `.apm/` nested (e.g. `agents/.apm/`), verify the rule now fires and agents edit the correct source directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)