### PR TITLE
Move /do from prompt to skill with colocated do-results script

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -65,7 +65,7 @@ Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a 
 sync, research, hickey, branch, implement, check, docs, police, fmt, commit, test, ci, update-pr, done
 ```
 
-At each step boundary, update task state **alongside** the `.do-results.json` write — they are not redundant. The JSON file is machine state for the stop hook; the task list is the human-facing UI. Miss either and the workflow is inconsistent.
+At each step boundary, update task state **alongside** the `do-results` script call — they are not redundant. The JSON file is machine state for the stop hook; the task list is the human-facing UI. Miss either and the workflow is inconsistent.
 
 Rules:
 
@@ -73,7 +73,7 @@ Rules:
 - **Retries stay `in_progress`.** If `check`, `test`, or `ci` loop through their retry budget, do **not** bounce the task state back to `pending` or flicker it — leave it `in_progress` until the step finally verifies (or the retries exhaust and the workflow fails).
 - **`--from <step>` entry points**: still seed all 14 steps. Mark steps earlier than the entry point as `completed` immediately after seeding, so the checklist shows a consistent 14-item view regardless of entry point.
 - **Skipped steps** (e.g. `branch`/`commit`/`update-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. The skip reason lives in `.do-results.json`; the task list just shows the step as done.
-- **Failure**: if retries exhaust and the workflow halts, leave the failing step `in_progress`, mark `done` `completed` after the failure summary is written, and set the JSON `status: "failed"`.
+- **Failure**: if retries exhaust and the workflow halts, leave the failing step `in_progress`, mark `done` `completed` after the failure summary is written, and run `do-results set status failed`.
 
 ## Steps
 
@@ -97,7 +97,7 @@ Do **not** pause or ask — just print and continue. The user's default-mode inv
 - URL contains `bitbucket.` (covers `bitbucket.org` and self-hosted Bitbucket Server, e.g. `bitbucket.juspay.net`) → `bitbucket`
 - Otherwise → `unknown`
 
-Record the result in `.do-results.json` as the top-level `forge` field. Subsequent steps branch on this value. **Only `github` has an active code path today.** Both `bitbucket` and `unknown` cause forge-dependent steps (PR creation, PR comments, PR edits, CI status) to skip gracefully. Bitbucket support is planned — see [srid/agency#10](https://github.com/srid/agency/issues/10).
+Record the result via `do-results set forge <value>`. Subsequent steps branch on this value. **Only `github` has an active code path today.** Both `bitbucket` and `unknown` cause forge-dependent steps (PR creation, PR comments, PR edits, CI status) to skip gracefully. Bitbucket support is planned — see [srid/agency#10](https://github.com/srid/agency/issues/10).
 
 **Verify**: git fetch ran without error, `forge` is recorded, and `noGit` is recorded.
 
@@ -240,7 +240,7 @@ Read the project's instructions to find the CI command and verification method. 
 
 **Never pipe CI to `tail`/`head`**, and **never append `2>&1`** — background mode captures both streams.
 
-**Active state**: Before waiting for background CI, set `active` to `"waiting"` in `.do-results.json`. When CI returns (success or failure), set it back to `"working"` before proceeding. This lets the stop hook allow graceful exits while the agent is idle.
+**Active state**: Before waiting for background CI, run `do-results set active waiting`. When CI returns (success or failure), run `do-results set active working` before proceeding. This lets the stop hook allow graceful exits while the agent is idle.
 
 CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are forge-independent — **run them regardless of forge**. Only the *verification method* may be forge-specific: if the project's instructions describe verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output for verification on non-GitHub forges, and note this in the step record. (Bitbucket `bkt pr checks` wiring is tracked in #10.)
 
@@ -293,7 +293,7 @@ Present a summary of all steps with their verification status. If any step has a
 1. A step `skipped` with `reason` beginning `"non-<forge> forge:"` (detected forge isn't GitHub).
 2. A step `skipped` with `reason` `"--no-git"` (user opted out of git operations).
 
-A `failed` step always blocks `"completed"`. No redefining "passed," no footnote caveats. Update `.do-results.json` accordingly.
+A `failed` step always blocks `"completed"`. No redefining "passed," no footnote caveats. Update via `do-results set status completed` or `do-results set status failed` accordingly.
 
 #### Timing summary
 

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: do
 description: Do a task end-to-end — implement, PR, CI loop, ship
 argument-hint: "<issue-url | prompt> [--review] [--no-git] [--from <step>]"
 ---
@@ -49,7 +50,11 @@ After each step's verification, write/update `.do-results.json`:
 
 - `active` is a state enum, not a boolean. Set it to `"working"` when the workflow starts (**sync**), `"waiting"` when the agent is idle waiting for an external process (e.g., background CI), back to `"working"` when the external process returns, and `false` when the workflow ends (**done**). The stop hook uses this field: `"working"` blocks exits, `"waiting"` allows them (with a resume hint), `false` allows them.
 - Set `status` to `"completed"` when **done** is reached, or `"failed"` if halted. This field is informational only.
-- Use the Write tool to update the file after each step.
+- **Updating `.do-results.json`**: Use the `do-results` script (in this skill's directory) — never rewrite the entire file with the Write tool. This avoids the LLM regenerating the full (and growing) JSON on every step. Commands:
+  - **Initialize**: `do-results init <forge> <noGit>` — creates the skeleton with a timestamp
+  - **Record a step**: `do-results step <name> <status> "<verification>" "<startedAt>" "<completedAt>" ["<reason>"]`
+  - **Update top-level field**: `do-results set <field> <value>` (e.g., `set active waiting`, `set status completed`)
+  - **Patch last step**: `do-results patch-last <field> <value>` (e.g., `patch-last completedAt "2026-..."`)
 - Capture timestamps via Bash: `date -u +%Y-%m-%dT%H:%M:%SZ`. Do not guess or hallucinate timestamps.
 
 ## Progress tracking

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -22,7 +22,7 @@ The workflow is **forge-aware**: it auto-detects whether the repo lives on GitHu
 
 ## Results Tracking
 
-After each step's verification, write/update `.do-results.json`:
+After each step's verification, record results via the `do-results` script. The script manages a JSON file with this schema:
 
 ```json
 {
@@ -50,7 +50,7 @@ After each step's verification, write/update `.do-results.json`:
 
 - `active` is a state enum, not a boolean. Set it to `"working"` when the workflow starts (**sync**), `"waiting"` when the agent is idle waiting for an external process (e.g., background CI), back to `"working"` when the external process returns, and `false` when the workflow ends (**done**). The stop hook uses this field: `"working"` blocks exits, `"waiting"` allows them (with a resume hint), `false` allows them.
 - Set `status` to `"completed"` when **done** is reached, or `"failed"` if halted. This field is informational only.
-- **Updating `.do-results.json`**: Use the `do-results` script (in this skill's directory) — never rewrite the entire file with the Write tool. This avoids the LLM regenerating the full (and growing) JSON on every step. Commands:
+- **Always use the `do-results` script** (in this skill's directory) — never write the JSON file directly. Commands:
   - **Initialize**: `do-results init <forge> <noGit>` — creates the skeleton with a timestamp
   - **Record a step**: `do-results step <name> <status> "<verification>" "<startedAt>" "<completedAt>" ["<reason>"]`
   - **Update top-level field**: `do-results set <field> <value>` (e.g., `set active waiting`, `set status completed`)
@@ -72,7 +72,7 @@ Rules:
 - **Flip to `in_progress` when a step starts, `completed` when it verifies.** One step `in_progress` at a time.
 - **Retries stay `in_progress`.** If `check`, `test`, or `ci` loop through their retry budget, do **not** bounce the task state back to `pending` or flicker it — leave it `in_progress` until the step finally verifies (or the retries exhaust and the workflow fails).
 - **`--from <step>` entry points**: still seed all 14 steps. Mark steps earlier than the entry point as `completed` immediately after seeding, so the checklist shows a consistent 14-item view regardless of entry point.
-- **Skipped steps** (e.g. `branch`/`commit`/`update-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. The skip reason lives in `.do-results.json`; the task list just shows the step as done.
+- **Skipped steps** (e.g. `branch`/`commit`/`update-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. The skip reason is recorded via `do-results step <name> skipped ... "<reason>"`; the task list just shows the step as done.
 - **Failure**: if retries exhaust and the workflow halts, leave the failing step `in_progress`, mark `done` `completed` after the failure summary is written, and run `do-results set status failed`.
 
 ## Steps

--- a/.apm/skills/do/do-results
+++ b/.apm/skills/do/do-results
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Manages .do-results.json for the /do workflow.
+# Avoids LLM token generation by handling all JSON mutations in bash+jq.
+#
+# Usage:
+#   do-results init <forge> <noGit>           — create initial skeleton
+#   do-results step <name> <status> <verif> <startedAt> <completedAt> [reason]
+#                                             — append a completed step
+#   do-results set <field> <value>            — update a top-level field (active, status)
+#   do-results patch-last <field> <value>     — patch a field on the last step
+
+set -euo pipefail
+
+FILE=".do-results.json"
+
+cmd="${1:?Usage: do-results <init|step|set|patch-last> ...}"
+shift
+
+case "$cmd" in
+  init)
+    forge="${1:?forge required (github|bitbucket|unknown)}"
+    noGit="${2:?noGit required (true|false)}"
+    startedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    cat > "$FILE" <<ENDJSON
+{
+  "workflow": "do",
+  "startedAt": "$startedAt",
+  "active": "working",
+  "status": "running",
+  "forge": "$forge",
+  "noGit": $noGit,
+  "steps": []
+}
+ENDJSON
+    ;;
+
+  step)
+    name="${1:?name required}"
+    status="${2:?status required (passed|failed|skipped)}"
+    verif="${3:?verification required}"
+    startedAt="${4:?startedAt required}"
+    completedAt="${5:?completedAt required}"
+    reason="${6:-}"
+
+    if [ -n "$reason" ]; then
+      jq --arg n "$name" --arg s "$status" --arg v "$verif" \
+         --arg sa "$startedAt" --arg ca "$completedAt" --arg r "$reason" \
+         '.steps += [{"name":$n,"status":$s,"verification":$v,"startedAt":$sa,"completedAt":$ca,"reason":$r}]' \
+         "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+    else
+      jq --arg n "$name" --arg s "$status" --arg v "$verif" \
+         --arg sa "$startedAt" --arg ca "$completedAt" \
+         '.steps += [{"name":$n,"status":$s,"verification":$v,"startedAt":$sa,"completedAt":$ca}]' \
+         "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+    fi
+    ;;
+
+  set)
+    field="${1:?field required}"
+    value="${2:?value required}"
+    # Handle booleans and strings
+    if [ "$value" = "true" ] || [ "$value" = "false" ]; then
+      jq --arg f "$field" --argjson v "$value" '.[$f] = $v' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+    else
+      jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+    fi
+    ;;
+
+  patch-last)
+    field="${1:?field required}"
+    value="${2:?value required}"
+    jq --arg f "$field" --arg v "$value" '.steps[-1][$f] = $v' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+    ;;
+
+  *)
+    echo "Unknown command: $cmd" >&2
+    echo "Usage: do-results <init|step|set|patch-last> ..." >&2
+    exit 1
+    ;;
+esac

--- a/.apm/skills/do/do-results
+++ b/.apm/skills/do/do-results
@@ -11,6 +11,13 @@
 
 set -euo pipefail
 
+# Resolve jq, falling back to nix if not on PATH
+if command -v jq &>/dev/null; then
+  JQ=jq
+else
+  JQ="nix run nixpkgs#jq --"
+fi
+
 FILE=".do-results.json"
 
 cmd="${1:?Usage: do-results <init|step|set|patch-last> ...}"
@@ -43,12 +50,12 @@ ENDJSON
     reason="${6:-}"
 
     if [ -n "$reason" ]; then
-      jq --arg n "$name" --arg s "$status" --arg v "$verif" \
+      $JQ --arg n "$name" --arg s "$status" --arg v "$verif" \
          --arg sa "$startedAt" --arg ca "$completedAt" --arg r "$reason" \
          '.steps += [{"name":$n,"status":$s,"verification":$v,"startedAt":$sa,"completedAt":$ca,"reason":$r}]' \
          "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
     else
-      jq --arg n "$name" --arg s "$status" --arg v "$verif" \
+      $JQ --arg n "$name" --arg s "$status" --arg v "$verif" \
          --arg sa "$startedAt" --arg ca "$completedAt" \
          '.steps += [{"name":$n,"status":$s,"verification":$v,"startedAt":$sa,"completedAt":$ca}]' \
          "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
@@ -60,16 +67,16 @@ ENDJSON
     value="${2:?value required}"
     # Handle booleans and strings
     if [ "$value" = "true" ] || [ "$value" = "false" ]; then
-      jq --arg f "$field" --argjson v "$value" '.[$f] = $v' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+      $JQ --arg f "$field" --argjson v "$value" '.[$f] = $v' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
     else
-      jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+      $JQ --arg f "$field" --arg v "$value" '.[$f] = $v' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
     fi
     ;;
 
   patch-last)
     field="${1:?field required}"
     value="${2:?value required}"
-    jq --arg f "$field" --arg v "$value" '.steps[-1][$f] = $v' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+    $JQ --arg f "$field" --arg v "$value" '.steps[-1][$f] = $v' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
     ;;
 
   *)


### PR DESCRIPTION
**`/do` is now a skill instead of a prompt.** As a prompt, APM deployed it to Copilot (as a `.prompt.md`) and Claude (as a custom command via `CommandIntegrator`), but not to Cursor or OpenCode. As a skill, APM deploys it universally to all agents. The `do-results` bash script lives alongside `SKILL.md` in the same skill directory and gets copied everywhere automatically via `shutil.copytree`.

The real win is the **`do-results` script** — a `jq`-based bash helper that handles all `.do-results.json` mutations. Previously the LLM used the Write tool to rewrite the entire growing JSON file on every step boundary, which got noticeably slow by step 8-10. Now each update is a short Bash call like `do-results step fmt passed "..." "..." "..."` — the LLM only generates the command string, not the full JSON.

> *The script supports four operations: `init` (create skeleton), `step` (append entry), `set` (update top-level field), and `patch-last` (modify last step). All use the standard `jq` read-modify-write pattern (`jq ... > .tmp && mv .tmp file`).*