### PR TITLE
feat(do): auto-generate timestamps in do-results script

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -52,10 +52,10 @@ After each step's verification, record results via the `do-results` script. The 
 - Set `status` to `"completed"` when **done** is reached, or `"failed"` if halted. This field is informational only.
 - **Always use the `do-results` script** (in this skill's directory) — never write the JSON file directly. Commands:
   - **Initialize**: `do-results init <forge> <noGit>` — creates the skeleton with a timestamp
-  - **Record a step**: `do-results step <name> <status> "<verification>" "<startedAt>" "<completedAt>" ["<reason>"]`
+  - **Record a step**: `do-results step <name> <status> "<verification>" <startedAt> <completedAt> ["<reason>"]` — pass `now` for either timestamp to auto-generate the current UTC time
   - **Update top-level field**: `do-results set <field> <value>` (e.g., `set active waiting`, `set status completed`)
   - **Patch last step**: `do-results patch-last <field> <value>` (e.g., `patch-last completedAt "2026-..."`)
-- Capture timestamps via Bash: `date -u +%Y-%m-%dT%H:%M:%SZ`. Do not guess or hallucinate timestamps.
+- Pass `now` as a timestamp argument to `do-results step` — the script resolves it to UTC internally. Do not run `date` yourself or guess timestamps.
 
 ## Progress tracking
 

--- a/.apm/skills/do/do-results
+++ b/.apm/skills/do/do-results
@@ -6,6 +6,7 @@
 #   do-results init <forge> <noGit>           — create initial skeleton
 #   do-results step <name> <status> <verif> <startedAt> <completedAt> [reason]
 #                                             — append a completed step
+#                                               pass "now" for startedAt/completedAt to auto-generate UTC timestamp
 #   do-results set <field> <value>            — update a top-level field (active, status)
 #   do-results patch-last <field> <value>     — patch a field on the last step
 
@@ -48,6 +49,10 @@ ENDJSON
     startedAt="${4:?startedAt required}"
     completedAt="${5:?completedAt required}"
     reason="${6:-}"
+
+    # Resolve "now" sentinel to current UTC timestamp
+    [[ "$startedAt" == "now" ]] && startedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    [[ "$completedAt" == "now" ]] && completedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
     if [ -n "$reason" ]; then
       $JQ --arg n "$name" --arg s "$status" --arg v "$verif" \


### PR DESCRIPTION
## Summary
- Accept `now` as a sentinel value for `startedAt`/`completedAt` in `do-results step`, resolving it to UTC internally via `date`
- Update SKILL.md to instruct the agent to pass `now` instead of running `date` separately
- Eliminates 2-3 redundant `date` Bash calls per step recording

Follow-up to #60.

## Test plan
- [x] Verified `do-results step sync passed "test" now now` produces correct timestamps in `.do-results.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)