### PR TITLE
Require CI to cover HEAD before passing

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -244,7 +244,7 @@ Read the project's instructions to find the CI command and verification method. 
 
 CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are forge-independent — **run them regardless of forge**. Only the *verification method* may be forge-specific: if the project's instructions describe verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output for verification on non-GitHub forges, and note this in the step record. (Bitbucket `bkt pr checks` wiring is tracked in #10.)
 
-**Verify**: Use the verification method described in the project's instructions (e.g., checking commit statuses on GitHub, reading CI output elsewhere). If no CI command is documented, skip with a note.
+**Verify**: Use the verification method described in the project's instructions (e.g., checking commit statuses on GitHub, reading CI output elsewhere). If no CI command is documented, skip with a note. **The CI result must cover `HEAD`.** Before recording the step as passed, compare the commit SHA that CI ran against with `git rev-parse HEAD`. If they differ (e.g., a commit was pushed after CI started — whether from a fix retry, user-requested changes, or any other source), re-run CI against the current HEAD. CI passing on a stale commit does not satisfy verification.
 
 **On failure** — read logs or output to diagnose.
 


### PR DESCRIPTION
**CI can silently pass on a stale commit** if new commits land mid-workflow — the ci step records success against the commit it ran on, even if HEAD has moved.

Observed in [juspay/kolu#503](https://github.com/juspay/kolu/pull/503): CI ran against `cd5b8c5`, then a followup commit `2f86f10` (expanded unit tests) was pushed after the user requested more coverage. The ci step was already recorded as passed without ever covering the latest code.

The fix adds a **HEAD-freshness guard** to the ci step's verification clause: before recording the step as passed, the agent must compare the commit SHA that CI ran against with `git rev-parse HEAD`. If they differ, CI must re-run. *This closes the gap regardless of why HEAD moved* — fix retries, user-requested changes, or any other source of new commits.