### PR TITLE
feat: add standalone fact-check and elegance skills

### DIFF
--- a/.apm/skills/code-police/SKILL.md
+++ b/.apm/skills/code-police/SKILL.md
@@ -79,6 +79,12 @@ Flag:
 
 For each finding: file, line, one-line risk, concrete fix. If no issues, say so — don't invent problems.
 
+**Principles:**
+
+- **Fail loud over fail silent**: Code should scream when something is wrong, not quietly do the wrong thing.
+- **Fallbacks must be justified**: Every default/fallback needs a reason why that value is correct for the failure case, not just convenient.
+- **Precision over coverage**: Better to catch 3 real issues than flag 20 maybes.
+
 **Anti-patterns in YOUR review (strictly banned):**
 
 - NEVER talk yourself out of a finding. If you identified a problem, it IS a problem. No "However..." or "acceptable tradeoff."
@@ -101,6 +107,7 @@ Principles:
 - **Simple over clever**: Elegant code is simple code.
 - **Readable over terse**: Brevity is good, but not at the cost of clarity.
 - **Idiomatic over generic**: Use the language's strengths.
+- **Each iteration builds on the last**: Don't undo previous improvements. Deepen them.
 
 ## Output
 

--- a/.apm/skills/elegance/SKILL.md
+++ b/.apm/skills/elegance/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: elegance
+description: Iteratively study and apply elegant coding patterns. Each iteration - understand the code, research what simple and elegant code looks like, apply learnings, verify with CI. Use as a standalone refactoring pass or when the user asks to make code more elegant, simple, or idiomatic.
+---
+
+# Elegance
+
+Iteratively study and apply elegant coding patterns. Each iteration: understand the code, research what simple & elegant code looks like, apply learnings, verify with CI.
+
+Run for **3 iterations** (or as specified by the user — can be a number or a duration like `2h`).
+
+## 0. Determine Scope
+
+- Before starting, use the `AskUserQuestion` tool to ask: should this operate on the **whole codebase** or only on **changes in the current branch/PR**?
+- If scoped to current branch/PR, use `git diff main...HEAD` (or the appropriate base branch) to identify changed files and limit all subsequent steps to those files only.
+
+## For each iteration (1 to N):
+
+### 1. Understand
+
+- Read through the relevant source files.
+- Note patterns, repetition, unnecessary complexity, non-idiomatic code.
+
+### 2. Research
+
+- Use WebSearch/WebFetch to research what simple, elegant (yet readable!) code looks like for the relevant technology.
+- Look for idiomatic patterns, standard simplifications, and community best practices.
+- Focus on: simplicity, readability, removing unnecessary abstraction, leveraging language features.
+
+### 3. Apply
+
+- Refactor based on what you learned.
+- This can include: edits, code reorganization, or even rewrites where simplicity demands it.
+- Prefer fewer lines, clearer intent, and idiomatic style.
+- Don't add abstractions — remove them.
+
+### 4. Verify
+
+- Run tests/CI to check edits.
+- If CI fails, fix the issues before proceeding to the next iteration.
+
+### 5. Log Progress
+
+- Briefly note what changed in this iteration and why.
+
+## After all iterations
+
+- Do **not** git commit. Leave all changes in the working directory for the user to review.
+- Present a summary of what changed across all iterations.
+
+## Principles
+
+- **Simple over clever**: Elegant code is simple code.
+- **Readable over terse**: Brevity is good, but not at the cost of clarity.
+- **Idiomatic over generic**: Use the language's strengths. Write TypeScript like TypeScript, not like Java.
+- **Each iteration builds on the last**: Don't undo previous improvements. Deepen them.

--- a/.apm/skills/fact-check/SKILL.md
+++ b/.apm/skills/fact-check/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: fact-check
+description: Audit code for correctness and rigor — logic errors, silent error swallowing, wishful thinking, and unjustified fallbacks. This is not a style review; it's a logic review. Use when you want a focused correctness audit separate from the full code-police pass.
+---
+
+# Fact-Check
+
+Audit code for **correctness and rigor**. This is not a style review — it's a logic review. Find places where the code lies to itself.
+
+## 0. Determine Scope
+
+- Before starting, use the `AskUserQuestion` tool to ask: should this operate on the **whole codebase** or only on **changes in the current branch/PR**?
+- If scoped to current branch/PR, use `git diff main...HEAD` (or the appropriate base branch) to identify changed files and limit all subsequent steps to those files only.
+
+## What to flag
+
+### 1. Silent error swallowing
+- Bare `try/except: pass`, empty `catch {}`, `|| true` hiding real failures.
+- Errors caught and logged but not propagated when callers depend on failure signals.
+- `Result`/`Option`/`Maybe` types silently defaulted without justification.
+
+### 2. Inaccurate fallbacks
+- Default values that mask misconfiguration (e.g., falling back to `""` or `null` when the real fix is to fail loud).
+- "Sensible defaults" that aren't actually sensible for the failure case.
+- Fallback paths that silently degrade correctness (e.g., returning stale data without indicating staleness).
+
+### 3. Wishful thinking
+- Assumptions about input shape/type without validation at system boundaries.
+- Code that "can't fail" but actually can (network, filesystem, permissions).
+- Race conditions papered over with comments like "this should be fine".
+
+### 4. Logic errors
+- Conditions that are always true/false.
+- Off-by-one errors, wrong comparison operators.
+- Variables shadowed or unused in a way that changes behavior.
+
+### 5. Slow leaks
+- Collections that grow without bound, event handlers doing heavy work on every fire without debounce, watchers/listeners registered per-caller instead of shared, buffers sized to the full input when streaming would work.
+
+## Workflow
+
+1. Read the diff (or full files if scoped to whole codebase).
+2. For each changed file, read enough surrounding context to understand intent.
+3. List every finding with file, line, and a one-line explanation of the risk.
+4. For each finding, propose a concrete fix (code snippet or direction).
+5. If no issues found, say so — don't invent problems.
+
+## Principles
+
+- **Fail loud over fail silent**: Code should scream when something is wrong, not quietly do the wrong thing.
+- **No wishful thinking**: If it can fail, handle the failure explicitly.
+- **Fallbacks must be justified**: Every default/fallback needs a reason why that value is correct for the failure case, not just convenient.
+- **Precision over coverage**: Better to catch 3 real issues than flag 20 maybes.
+
+## Anti-patterns in YOUR review (strictly banned)
+
+You are an LLM reviewing code. LLMs have a strong bias toward declaring code "acceptable" to avoid conflict. This command exists precisely to counteract that. Follow these rules absolutely:
+
+- **NEVER talk yourself out of a finding.** If you identified a problem, it IS a problem. Do not follow up with "However..." or "Verdict: acceptable tradeoff" or "practically safe." If the code has a bogus fallback, say so and propose a fix. Period.
+- **NEVER use "theoretically X but practically Y" to dismiss.** "Theoretically fragile but practically safe" is exactly the kind of wishful thinking this command is supposed to catch. If it's fragile, flag it and fix it.
+- **NEVER issue a verdict of "no action needed" on a finding you just described.** If it wasn't worth acting on, you shouldn't have listed it. Every finding you report MUST have a concrete fix.
+- **NEVER end with reassurance.** No "the logic is sound", no "the approach correctly targets the root cause", no "no other issues found" unless you genuinely found zero issues. Your job is to find problems, not to make the author feel good.
+- **Assume the code is wrong until proven right.** The default posture is skepticism, not charity. You are a prosecutor, not a defense attorney.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Near-autonomous workflow for coding agents, packaged as an [APM](https://github.
 
 - **`hickey`** — Structural simplicity evaluation using [Rich Hickey's "Simple Made Easy"](https://www.infoq.com/presentations/Simple-Made-Easy/) framework. Catches accidental complexity that tests can't.
 - **`code-police`** — Three-pass quality gate: rule checklist, fact-check for logic errors, and elegance review with iterative refinement.
+- **`fact-check`** — Standalone correctness audit: finds silent error swallowing, unjustified fallbacks, wishful thinking, and logic errors. Prosecutor posture — no self-dismissals.
+- **`elegance`** — Iterative elegance pass: understand, research, apply, verify. Runs 3 iterations by default, each building on the last.
 - **`forge-pr`** — Writes PR titles and descriptions that devs actually want to read. Paragraphs over bullet lists, substance over boilerplate. GitHub today; Bitbucket support tracked in [#10](https://github.com/srid/agency/issues/10).
 
 ### Hooks & Instructions


### PR DESCRIPTION
## Summary

- Added `/fact-check` and `/elegance` as standalone skills, imported from srid/nixos-config's `AI/commands/`. These can now be invoked independently, not just as part of `/code-police`.
- Backported missing principles to code-police's embedded passes: fail-loud/fallbacks-justified/precision-over-coverage for fact-check, and iteration-continuity for elegance.
- Updated README with the two new skills.

## Test plan

- [ ] Verify `/fact-check` skill is available and runs correctly on a branch with changes
- [ ] Verify `/elegance` skill is available and runs its iterative loop
- [ ] Verify `/code-police` still works with the added principles

🤖 Generated with [Claude Code](https://claude.com/claude-code)