### PR TITLE
Open PR before running CI in /do workflow

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -17,7 +17,7 @@ Parse the arguments string: `[--review] [--no-git] [--from <step-id>] <task desc
 The workflow is **forge-aware**: it auto-detects whether the repo lives on GitHub or elsewhere during the **sync** step (see Forge Detection). Only GitHub has an active code path today — Bitbucket/other forges gracefully skip PR-related steps. Tracking: [srid/agency#10](https://github.com/srid/agency/issues/10).
 
 - `--review`: Pause after **hickey** for user plan approval via `EnterPlanMode`/`ExitPlanMode`, then continue autonomously
-- `--no-git`: Extend the working tree **in place** — do not create a branch, commit, push, or touch any PR. Research, implement, check, docs, police, fmt, and test all run; git-mutating steps (**branch**, **commit**, **update-pr**) are skipped. Use this when you have uncommitted local work and want the agent to build on it without taking over git state. Feedback from a Bitbucket user in [#26](https://github.com/srid/agency/issues/26).
+- `--no-git`: Extend the working tree **in place** — do not create a branch, commit, push, or touch any PR. Research, implement, check, docs, police, fmt, and test all run; git-mutating steps (**branch**, **commit**, **create-pr**) are skipped. Use this when you have uncommitted local work and want the agent to build on it without taking over git state. Feedback from a Bitbucket user in [#26](https://github.com/srid/agency/issues/26).
 - `--from <step-id>`: Start from a specific step (see entry points below)
 
 ## Results Tracking
@@ -45,7 +45,7 @@ After each step's verification, record results via the `do-results` script. The 
 ```
 
 - `forge` is set during **sync** (see Forge Detection below). One of `github`, `bitbucket`, `unknown`.
-- `noGit` is `true` if the user passed `--no-git`. When set, git-mutating steps (**branch**, **commit**, **update-pr**) record status `skipped` with reason `"--no-git"`.
+- `noGit` is `true` if the user passed `--no-git`. When set, git-mutating steps (**branch**, **commit**, **create-pr**) record status `skipped` with reason `"--no-git"`.
 - Step `status` is one of `passed`, `failed`, or `skipped`. A `skipped` step must include a `reason` field explaining why (e.g., `"non-github forge: bitbucket"`, `"--no-git"`, `"no check command configured"`).
 
 - `active` is a state enum, not a boolean. Set it to `"working"` when the workflow starts (**sync**), `"waiting"` when the agent is idle waiting for an external process (e.g., background CI), back to `"working"` when the external process returns, and `false` when the workflow ends (**done**). The stop hook uses this field: `"working"` blocks exits, `"waiting"` allows them (with a resume hint), `false` allows them.
@@ -62,7 +62,7 @@ After each step's verification, record results via the `do-results` script. The 
 Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a live checklist of the workflow. At the start of **sync** (or the chosen `--from` entry point), seed a task list with all 14 step names in order:
 
 ```
-sync, research, hickey, branch, implement, check, docs, police, fmt, commit, test, update-pr, ci, done
+sync, research, hickey, branch, implement, check, docs, police, fmt, commit, test, create-pr, ci, done
 ```
 
 At each step boundary, update task state **alongside** the `do-results` script call — they are not redundant. The JSON file is machine state for the stop hook; the task list is the human-facing UI. Miss either and the workflow is inconsistent.
@@ -72,7 +72,7 @@ Rules:
 - **Flip to `in_progress` when a step starts, `completed` when it verifies.** One step `in_progress` at a time.
 - **Retries stay `in_progress`.** If `check`, `test`, or `ci` loop through their retry budget, do **not** bounce the task state back to `pending` or flicker it — leave it `in_progress` until the step finally verifies (or the retries exhaust and the workflow fails).
 - **`--from <step>` entry points**: still seed all 14 steps. Mark steps earlier than the entry point as `completed` immediately after seeding, so the checklist shows a consistent 14-item view regardless of entry point.
-- **Skipped steps** (e.g. `branch`/`commit`/`update-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. The skip reason is recorded via `do-results step <name> skipped ... "<reason>"`; the task list just shows the step as done.
+- **Skipped steps** (e.g. `branch`/`commit`/`create-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. The skip reason is recorded via `do-results step <name> skipped ... "<reason>"`; the task list just shows the step as done.
 - **Failure**: if retries exhaust and the workflow halts, leave the failing step `in_progress`, mark `done` `completed` after the failure summary is written, and run `do-results set status failed`.
 
 ## Steps
@@ -144,7 +144,7 @@ Detect the default branch: `git symbolic-ref refs/remotes/origin/HEAD`
 
 1. Create a descriptive feature branch from `origin/<default>`
 
-That's it — just the local branch. No commit, no push, no PR. The branch is pushed later in **commit**, and the PR is created in **update-pr** after all changes are done.
+That's it — just the local branch. No commit, no push, no PR. The branch is pushed later in **commit**, and the PR is created in **create-pr** after all changes are done.
 
 **Verify**: On a feature branch (not master/main).
 
@@ -234,9 +234,9 @@ If changes are purely internal with no user-facing impact, unit tests may suffic
 
 ---
 
-### update-pr
+### create-pr
 
-**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to update. Proceed to **ci**.
+**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to create. Proceed to **ci**.
 
 **If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. (Bitbucket `bkt pr edit` wiring is tracked in #10.) Proceed to **ci**.
 
@@ -281,7 +281,7 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 **Flaky vs real**: A test is flaky only if it **passes on a subsequent retry**. Consistent failure = real bug. Before retrying, read the failing test code to judge if the failure pattern is inherently flaky (race conditions, timing, async waits).
 
 **If flaky** (max 3 retries): Retry just the failing step.
-**If real bug** (max 5 fixes): Fix → **fmt** → **commit** → retry CI. Under `--no-git`, drop **commit** from the loop (Fix → **fmt** → retry CI). The draft PR already exists — subsequent pushes update it automatically, no re-run of **update-pr** needed.
+**If real bug** (max 5 fixes): Fix → **fmt** → **commit** → retry CI. Under `--no-git`, drop **commit** from the loop (Fix → **fmt** → retry CI). The draft PR already exists — subsequent pushes update it automatically, no re-run of **create-pr** needed.
 **If retries exhausted**: Set workflow status to `"failed"`, skip to **done**. The draft PR stays open as the record of the failed attempt.
 
 ---
@@ -362,6 +362,6 @@ COMMENT
 - **No questions.** Don't use `AskUserQuestion` unless `--review` is active during the hickey pause.
 - **Never stop between steps.** After completing a step, immediately proceed to the next one.
 - **Complete the full workflow.** Implementing code is one step of many. The task is not done until a PR URL (GitHub), a pushed branch name (non-GitHub forges), or a working-tree summary (`--no-git`) is reported.
-- **Exhausted retries = halt.** If `ci` or `test` retries are exhausted, set status to `"failed"` and skip to **done**. On `ci` failure the draft PR (opened in the preceding **update-pr** step) stays open as the record of the failed attempt — do not close, undraft, or otherwise mutate it.
+- **Exhausted retries = halt.** If `ci` or `test` retries are exhausted, set status to `"failed"` and skip to **done**. On `ci` failure the draft PR (opened in the preceding **create-pr** step) stays open as the record of the failed attempt — do not close, undraft, or otherwise mutate it.
 
 ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -62,7 +62,7 @@ After each step's verification, record results via the `do-results` script. The 
 Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a live checklist of the workflow. At the start of **sync** (or the chosen `--from` entry point), seed a task list with all 14 step names in order:
 
 ```
-sync, research, hickey, branch, implement, check, docs, police, fmt, commit, test, ci, update-pr, done
+sync, research, hickey, branch, implement, check, docs, police, fmt, commit, test, update-pr, ci, done
 ```
 
 At each step boundary, update task state **alongside** the `do-results` script call — they are not redundant. The JSON file is machine state for the stop hook; the task list is the human-facing UI. Miss either and the workflow is inconsistent.
@@ -234,33 +234,11 @@ If changes are purely internal with no user-facing impact, unit tests may suffic
 
 ---
 
-### ci
-
-Read the project's instructions to find the CI command and verification method. Run CI with `run_in_background: true` if the command takes more than a few seconds.
-
-**Never pipe CI to `tail`/`head`**, and **never append `2>&1`** — background mode captures both streams.
-
-**Active state**: Before waiting for background CI, run `do-results set active waiting`. When CI returns (success or failure), run `do-results set active working` before proceeding. This lets the stop hook allow graceful exits while the agent is idle.
-
-CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are forge-independent — **run them regardless of forge**. Only the *verification method* may be forge-specific: if the project's instructions describe verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output for verification on non-GitHub forges, and note this in the step record. (Bitbucket `bkt pr checks` wiring is tracked in #10.)
-
-**Verify**: Use the verification method described in the project's instructions (e.g., checking commit statuses on GitHub, reading CI output elsewhere). If no CI command is documented, skip with a note. **The CI result must cover `HEAD`.** Before recording the step as passed, compare the commit SHA that CI ran against with `git rev-parse HEAD`. If they differ (e.g., a commit was pushed after CI started — whether from a fix retry, user-requested changes, or any other source), re-run CI against the current HEAD. CI passing on a stale commit does not satisfy verification.
-
-**On failure** — read logs or output to diagnose.
-
-**Flaky vs real**: A test is flaky only if it **passes on a subsequent retry**. Consistent failure = real bug. Before retrying, read the failing test code to judge if the failure pattern is inherently flaky (race conditions, timing, async waits).
-
-**If flaky** (max 3 retries): Retry just the failing step.
-**If real bug** (max 5 fixes): Fix → **fmt** → **commit** → retry CI. Under `--no-git`, drop **commit** from the loop (Fix → **fmt** → retry CI).
-**If retries exhausted**: Set workflow status to `"failed"`, skip to **done**.
-
----
-
 ### update-pr
 
-**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to update. Proceed to **done**.
+**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to update. Proceed to **ci**.
 
-**If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. (Bitbucket `bkt pr edit` wiring is tracked in #10.) Proceed to **done**.
+**If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. (Bitbucket `bkt pr edit` wiring is tracked in #10.) Proceed to **ci**.
 
 **If `forge == github`**:
 
@@ -280,7 +258,31 @@ Re-check the PR title/body against current scope. If scope changed, update via `
 
 **Surface deferred hickey findings**: If the hickey step produced any **"Defer `#issue`"** actions, append a `> **Deferred:** #123, #124` line to the PR body (via `gh pr edit`) so reviewers see the outstanding structural debt. These are easy to miss in a PR comment — the description is what reviewers actually read.
 
+**Why this runs before `ci`**: The draft PR is the canonical home for CI status. Opening it before CI runs means CI checks land directly on the PR, reviewers see the run history as it happens, and a failing run doesn't leave an orphaned branch with red statuses and no PR to explain them. If retries exhaust in **ci**, the draft PR remains as the artifact of the failed attempt — visible, reviewable, and ready to resume via `--from ci-only`.
+
 **Verify**: Draft PR exists (`gh pr view` succeeds), PR title/body matches the delivered scope, hickey findings posted if any, and any deferred hickey issues are linked in the body.
+
+---
+
+### ci
+
+Read the project's instructions to find the CI command and verification method. Run CI with `run_in_background: true` if the command takes more than a few seconds.
+
+**Never pipe CI to `tail`/`head`**, and **never append `2>&1`** — background mode captures both streams.
+
+**Active state**: Before waiting for background CI, run `do-results set active waiting`. When CI returns (success or failure), run `do-results set active working` before proceeding. This lets the stop hook allow graceful exits while the agent is idle.
+
+CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are forge-independent — **run them regardless of forge**. Only the *verification method* may be forge-specific: if the project's instructions describe verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output for verification on non-GitHub forges, and note this in the step record. (Bitbucket `bkt pr checks` wiring is tracked in #10.)
+
+**Verify**: Use the verification method described in the project's instructions (e.g., checking commit statuses on GitHub, reading CI output elsewhere). If no CI command is documented, skip with a note. **The CI result must cover `HEAD`.** Before recording the step as passed, compare the commit SHA that CI ran against with `git rev-parse HEAD`. If they differ (e.g., a commit was pushed after CI started — whether from a fix retry, user-requested changes, or any other source), re-run CI against the current HEAD. CI passing on a stale commit does not satisfy verification.
+
+**On failure** — read logs or output to diagnose.
+
+**Flaky vs real**: A test is flaky only if it **passes on a subsequent retry**. Consistent failure = real bug. Before retrying, read the failing test code to judge if the failure pattern is inherently flaky (race conditions, timing, async waits).
+
+**If flaky** (max 3 retries): Retry just the failing step.
+**If real bug** (max 5 fixes): Fix → **fmt** → **commit** → retry CI. Under `--no-git`, drop **commit** from the loop (Fix → **fmt** → retry CI). The draft PR already exists — subsequent pushes update it automatically, no re-run of **update-pr** needed.
+**If retries exhausted**: Set workflow status to `"failed"`, skip to **done**. The draft PR stays open as the record of the failed attempt.
 
 ---
 
@@ -360,6 +362,6 @@ COMMENT
 - **No questions.** Don't use `AskUserQuestion` unless `--review` is active during the hickey pause.
 - **Never stop between steps.** After completing a step, immediately proceed to the next one.
 - **Complete the full workflow.** Implementing code is one step of many. The task is not done until a PR URL (GitHub), a pushed branch name (non-GitHub forges), or a working-tree summary (`--no-git`) is reported.
-- **Exhausted retries = halt.** If `ci` or `test` retries are exhausted, set status to `"failed"` and skip to **done**. Do not proceed to `update-pr` as if nothing happened.
+- **Exhausted retries = halt.** If `ci` or `test` retries are exhausted, set status to `"failed"` and skip to **done**. On `ci` failure the draft PR (opened in the preceding **update-pr** step) stays open as the record of the failed attempt — do not close, undraft, or otherwise mutate it.
 
 ARGUMENTS: $ARGUMENTS


### PR DESCRIPTION
**CI now lands on the PR from the first run.** The `/do` workflow previously pushed the branch, ran CI against it, and *then* created the PR — so the first CI run happened on an orphaned branch with no PR to host the status checks. A failed first attempt left the user with a red branch and nothing to review. This reorders the sequence so `update-pr` runs immediately after `commit`, opening a draft PR before `ci` kicks off.

New step order: `commit → test → update-pr → ci → done`.

The CI retry loop doesn't change — pushes during fix iterations update the already-existing draft PR automatically, so no re-run of `update-pr` is needed. If retries exhaust, the draft PR stays open as the reviewable artifact of the failed attempt rather than disappearing. *The `--from ci-only` entry point keeps its current semantics* (resume against an existing PR), which now composes cleanly with the new ordering.

> Meta: this PR itself was hand-opened, not produced by `/do`, since the workflow being patched is the one that opens PRs.