### PR TITLE
feat(talk): add laconic flag and auto-Hickey pass

### DIFF
--- a/.apm/prompts/talk.prompt.md
+++ b/.apm/prompts/talk.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "Enter talk mode — conversation only, no file changes"
-argument-hint: "<topic or question>"
+argument-hint: "[-l|--laconic] <topic or question>"
 ---
 
 # Probe (Talk Mode)
@@ -65,5 +65,23 @@ If you're about to emit "probably", "almost certainly", "I suspect", "my #1 susp
 
 - Be direct, opinionated, and concise.
 - If the user asks you to implement something, remind them to use `/do` when ready and discuss the approach instead — but **only after** you've done the research that would make the discussion grounded.
+
+## Auto-Hickey
+
+Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke the `hickey` skill on that proposal before presenting your final recommendation** — do not wait for the user to ask. Fold the Hickey findings into the recommendation (e.g. flag complecting, note where simplicity could be preserved) rather than dumping raw skill output on top.
+
+Skip the Hickey pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.
+
+## Laconic mode
+
+If `ARGUMENTS` begins with `-l` or `--laconic` (strip the flag before treating the rest as the topic), answer as tersely as possible:
+
+- One or two sentences when it will do. A single word when *that* will do.
+- No preamble, no recap of the question, no "great question", no closing offers to help further.
+- Drop bullet lists unless the answer is genuinely a list. No headings.
+- Keep file:line citations — brevity does not override the research/citation rules above. Research silently; show only the conclusion plus its citations.
+- Code blocks only when code is the answer.
+
+Laconic mode trims the *output*, not the *investigation*. Do the same reading you would otherwise; just say less about it.
 
 ARGUMENTS: $ARGUMENTS


### PR DESCRIPTION
## Summary

- Add `-l` / `--laconic` prefix to `/talk` so terse answers no longer require typing "less words" each time. Trims output (one-or-two sentences, no preamble, no closing offers) while preserving research depth and citation requirements.
- Auto-invoke the `hickey` skill on any concrete code plan, diff proposal, or design sketch before presenting the final recommendation. Folds findings into the recommendation; skipped only for pure Q&A turns.

## Test plan

- [ ] `/talk -l <question>` produces a minimal response.
- [ ] `/talk <question>` with a proposed code change triggers the Hickey pass automatically and surfaces its findings.
- [ ] Pure Q&A turns (no proposed change) skip Hickey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)