### PR TITLE
Add CLAUDE.md reminding agents to keep README in sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Notes for coding agents
+
+## Keep `README.md` in sync
+
+When your changes affect anything user-facing — the list of commands, skills, hooks, instructions, install steps, or the `.apm/` layout shown as the example — update [`README.md`](./README.md) in the same change. Drift between what ships and what the README describes is a bug.
+
+Not every change needs a README edit. Internal refactors, skill prompt tweaks that don't alter the skill's user-facing purpose, and test/tooling updates don't. When in doubt, re-read the affected README section and ask: would a new user following this still get the right picture?


### PR DESCRIPTION
**Agents working in this repo should update `README.md` when their changes affect anything user-facing** — commands, skills, hooks, install steps, or the example `.apm/` layout. A top-level `CLAUDE.md` is the natural place to enforce this: it loads automatically into every session, costs almost nothing, and scopes itself to the one rule that actually matters.

The note also carves out the cases that *don't* need a README edit (internal refactors, skill-prompt tweaks that preserve user-facing purpose, tooling-only changes) so agents don't reflexively pad every PR with a docs paragraph.