### PR TITLE
feat: add /ralph skill — iterative measurement-driven improvement loop

### DIFF
--- a/.apm/skills/ralph/SKILL.md
+++ b/.apm/skills/ralph/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: ralph
+description: Iterative measurement-driven improvement loop. Measure, profile, mutate, re-measure, commit. Works for performance, bundle size, complexity, test coverage — anything quantifiable. Use when the user wants to systematically improve a metric through repeated cycles of profiling and targeted changes.
+---
+
+# Ralph
+
+Iterative measurement-driven improvement loop. Each cycle: measure, profile the breakdown, find the biggest contributor, mutate, re-measure, commit only if the improvement exceeds noise.
+
+Named after the pattern: **R**esearch **A**nd **L**oop **P**rofiling **H**euristics.
+
+## 0. Gather inputs
+
+Use `AskUserQuestion` to collect:
+
+1. **What to improve** — the target metric and direction (e.g., "make `nix develop` faster", "reduce bundle size below 500KB", "improve lighthouse score to 95+")
+2. **How to measure** — the command or method. If the user doesn't know, research and propose one.
+3. **How many cycles** — default 20
+4. **Constraints** — what must NOT change (e.g., "no behavioural changes", "don't remove features")
+
+## 1. Setup
+
+### Branch & PR
+
+Create a feature branch and open a **draft PR** early. The PR is the home for measurements and the report file — open it before doing any work.
+
+Load the `forge-pr` skill before writing the PR title/body. The PR description should include a measurements table (populated with baseline, updated as cycles complete).
+
+### Baseline measurement
+
+Measure the target metric **scientifically**:
+
+- Run the measurement command **at least 5 times**
+- Report the **median** (not mean — outliers skew means)
+- For time measurements: distinguish **cold** (no cache) from **hot** (cached) where applicable
+- Document the methodology (what command, what machine state, how cold/hot is defined)
+
+### Report file
+
+Create `docs/<target>-ralph-report.md` (e.g., `docs/nix-eval-perf-ralph-report.md`) with:
+
+- Baseline measurements
+- Methodology section
+- Optimization log table (populated as cycles complete)
+- Findings section (populated as investigations conclude)
+
+### Task tracking
+
+Seed a `TaskCreate` list with N cycle tasks. Update each to `in_progress` when starting, `completed` when done.
+
+## 2. The loop
+
+For each cycle:
+
+### 2a. Profile
+
+Break down the metric into components. Find where the time/size/cost comes from. Use whatever tools are appropriate:
+
+- **Time**: measure individual phases, components, imports, function calls
+- **Size**: analyze dependency tree, find largest contributors
+- **Complexity**: count per-module, per-function
+- **Coverage**: identify untested paths
+
+**Be scientific.** Measure each component independently with multiple runs. Don't guess — measure.
+
+### 2b. Classify
+
+Categorize the biggest contributor:
+
+- Unnecessary dependency (pulled in but not needed)
+- Eager evaluation (computed but not used)
+- Redundant work (done twice, or done when cached result exists)
+- Wrong abstraction (heavyweight tool for simple job)
+- Missing cache (recomputed on every invocation)
+- Structural overhead (inherent cost of the architecture)
+
+### 2c. Mutate
+
+Apply a **single, targeted change** that addresses the biggest contributor. Keep changes minimal and reversible.
+
+### 2d. Re-measure
+
+Run the same benchmark as baseline with the same methodology. Compare median values.
+
+**Noise threshold**: if the improvement is within measurement noise (typically <3% for time measurements), the change is **not worth committing** for its performance value. Document the finding in the report but do not commit. If the change is a worthwhile architectural cleanup, commit it separately without performance claims.
+
+### 2e. Commit & push
+
+Only if the improvement exceeds noise:
+
+- `git add` changed files + report file
+- Commit with metrics in the message: `perf: <what changed>\n\nMeasurements (median of N runs):\n  <metric>: <before> -> <after> (<delta>)`
+- `git push`
+
+### 2f. Update report
+
+Append a row to the optimization log table in the report file. Include:
+
+- Cycle number
+- Short commit hash
+- What changed
+- Before/after metric values
+- Delta
+
+For cycles with no improvement, add to the "Investigated but no improvement" section instead.
+
+## 3. Wrap-up
+
+After all cycles (or when diminishing returns are reached):
+
+### Final measurement
+
+Run the full benchmark one last time with the same methodology as baseline. This is the **final number** that goes in the PR.
+
+### Update PR description
+
+Update the PR description with:
+
+- Final before/after measurements table
+- Summary of each change and its impact
+- Key findings (what was expensive, what didn't help, irreducible floor)
+
+### Update report
+
+Ensure the report file has:
+
+- Complete optimization log
+- "Investigated but no improvement" section with all dead ends
+- "Key findings" section with insights
+- Cost breakdown (where the metric comes from after optimization)
+
+### Run CI
+
+Read the project's instructions to find the CI command. Run it to verify nothing is broken.
+
+## Rules
+
+- **Facts over opinions.** Measure everything. Don't commit changes based on theory alone.
+- **One change per cycle.** Isolate variables so you know what helped.
+- **Only commit improvements.** Noise-level changes clutter the history.
+- **Preserve behaviour.** Unless the user explicitly allows it, all changes must be behaviour-preserving. Run tests after each mutation.
+- **Document dead ends.** A finding of "X doesn't help" is valuable — record it so nobody wastes time re-investigating.
+- **Stop at diminishing returns.** If 3 consecutive cycles show no improvement, the remaining overhead is likely irreducible. Tell the user and stop early rather than churning.
+- **Keep the report.** The `.md` file is a deliverable — it's useful for blog posts, documentation, and future reference.

--- a/.apm/skills/ralph/SKILL.md
+++ b/.apm/skills/ralph/SKILL.md
@@ -5,140 +5,47 @@ description: Iterative measurement-driven improvement loop. Measure, profile, mu
 
 # Ralph
 
-Iterative measurement-driven improvement loop. Each cycle: measure, profile the breakdown, find the biggest contributor, mutate, re-measure, commit only if the improvement exceeds noise.
-
-Named after the pattern: **R**esearch **A**nd **L**oop **P**rofiling **H**euristics.
+Iterative measurement-driven improvement loop. Each cycle: measure → profile → find biggest contributor → mutate → re-measure → commit only if improvement exceeds noise.
 
 ## 0. Gather inputs
 
 Use `AskUserQuestion` to collect:
 
-1. **What to improve** — the target metric and direction (e.g., "make `nix develop` faster", "reduce bundle size below 500KB", "improve lighthouse score to 95+")
-2. **How to measure** — the command or method. If the user doesn't know, research and propose one.
+1. **What to improve** — target metric and direction
+2. **How to measure** — command or method (research and propose one if user doesn't know)
 3. **How many cycles** — default 20
-4. **Constraints** — what must NOT change (e.g., "no behavioural changes", "don't remove features")
+4. **Constraints** — what must NOT change
 
 ## 1. Setup
 
-### Branch & PR
-
-Create a feature branch and open a **draft PR** early. The PR is the home for measurements and the report file — open it before doing any work.
-
-Load the `forge-pr` skill before writing the PR title/body. The PR description should include a measurements table (populated with baseline, updated as cycles complete).
-
-### Baseline measurement
-
-Measure the target metric **scientifically**:
-
-- Run the measurement command **at least 5 times**
-- Report the **median** (not mean — outliers skew means)
-- For time measurements: distinguish **cold** (no cache) from **hot** (cached) where applicable
-- Document the methodology (what command, what machine state, how cold/hot is defined)
-
-### Report file
-
-Create `docs/<target>-ralph-report.md` (e.g., `docs/nix-eval-perf-ralph-report.md`) with:
-
-- Baseline measurements
-- Methodology section
-- Optimization log table (populated as cycles complete)
-- Findings section (populated as investigations conclude)
-
-### Task tracking
-
-Seed a `TaskCreate` list with N cycle tasks. Update each to `in_progress` when starting, `completed` when done.
+- Create a feature branch and **draft PR** early (load `forge-pr` skill for title/body). PR description includes a measurements table updated as cycles complete.
+- **Baseline**: measure at least 5 runs, report **median**. For time: distinguish cold (no cache) from hot (cached). Document methodology.
+- Create `docs/<target>-ralph-report.md` with baseline, methodology, optimization log table, and findings.
+- Seed `TaskCreate` list with N cycle tasks.
 
 ## 2. The loop
 
-For each cycle:
+Each cycle:
 
-### 2a. Profile
-
-Break down the metric into components. Find where the time/size/cost comes from. Use whatever tools are appropriate:
-
-- **Time**: measure individual phases, components, imports, function calls
-- **Size**: analyze dependency tree, find largest contributors
-- **Complexity**: count per-module, per-function
-- **Coverage**: identify untested paths
-
-**Be scientific.** Measure each component independently with multiple runs. Don't guess — measure.
-
-### 2b. Classify
-
-Categorize the biggest contributor:
-
-- Unnecessary dependency (pulled in but not needed)
-- Eager evaluation (computed but not used)
-- Redundant work (done twice, or done when cached result exists)
-- Wrong abstraction (heavyweight tool for simple job)
-- Missing cache (recomputed on every invocation)
-- Structural overhead (inherent cost of the architecture)
-
-### 2c. Mutate
-
-Apply a **single, targeted change** that addresses the biggest contributor. Keep changes minimal and reversible.
-
-### 2d. Re-measure
-
-Run the same benchmark as baseline with the same methodology. Compare median values.
-
-**Noise threshold**: if the improvement is within measurement noise (typically <3% for time measurements), the change is **not worth committing** for its performance value. Document the finding in the report but do not commit. If the change is a worthwhile architectural cleanup, commit it separately without performance claims.
-
-### 2e. Commit & push
-
-Only if the improvement exceeds noise:
-
-- `git add` changed files + report file
-- Commit with metrics in the message: `perf: <what changed>\n\nMeasurements (median of N runs):\n  <metric>: <before> -> <after> (<delta>)`
-- `git push`
-
-### 2f. Update report
-
-Append a row to the optimization log table in the report file. Include:
-
-- Cycle number
-- Short commit hash
-- What changed
-- Before/after metric values
-- Delta
-
-For cycles with no improvement, add to the "Investigated but no improvement" section instead.
+1. **Profile** — break down the metric into components. Measure each independently. Don't guess.
+2. **Classify** — categorize the biggest contributor (unnecessary dep, eager eval, redundant work, wrong abstraction, missing cache, structural overhead).
+3. **Mutate** — single, targeted change addressing the biggest contributor.
+4. **Re-measure** — same benchmark, same methodology. If improvement is within noise (<3% for time), don't commit — document in report only.
+5. **Commit + push** — only if improvement exceeds noise. Include metrics in commit message. Push report file with each commit.
 
 ## 3. Wrap-up
 
-After all cycles (or when diminishing returns are reached):
-
-### Final measurement
-
-Run the full benchmark one last time with the same methodology as baseline. This is the **final number** that goes in the PR.
-
-### Update PR description
-
-Update the PR description with:
-
-- Final before/after measurements table
-- Summary of each change and its impact
-- Key findings (what was expensive, what didn't help, irreducible floor)
-
-### Update report
-
-Ensure the report file has:
-
-- Complete optimization log
-- "Investigated but no improvement" section with all dead ends
-- "Key findings" section with insights
-- Cost breakdown (where the metric comes from after optimization)
-
-### Run CI
-
-Read the project's instructions to find the CI command. Run it to verify nothing is broken.
+- **Final measurement** with same methodology as baseline — this is the number for the PR.
+- **Update PR description** with final before/after table, summary of changes, key findings.
+- **Complete report** with optimization log, dead ends ("Investigated but no improvement"), key findings, and cost breakdown.
+- **Run CI** to verify nothing is broken.
 
 ## Rules
 
-- **Facts over opinions.** Measure everything. Don't commit changes based on theory alone.
-- **One change per cycle.** Isolate variables so you know what helped.
-- **Only commit improvements.** Noise-level changes clutter the history.
-- **Preserve behaviour.** Unless the user explicitly allows it, all changes must be behaviour-preserving. Run tests after each mutation.
-- **Document dead ends.** A finding of "X doesn't help" is valuable — record it so nobody wastes time re-investigating.
-- **Stop at diminishing returns.** If 3 consecutive cycles show no improvement, the remaining overhead is likely irreducible. Tell the user and stop early rather than churning.
-- **Keep the report.** The `.md` file is a deliverable — it's useful for blog posts, documentation, and future reference.
+- **Facts over opinions.** Measure everything. Don't commit based on theory.
+- **One change per cycle.** Isolate variables.
+- **Only commit improvements.** Noise-level changes clutter history.
+- **Preserve behaviour.** All changes behaviour-preserving unless user explicitly allows otherwise.
+- **Document dead ends.** "X doesn't help" is valuable knowledge.
+- **Stop at diminishing returns.** 3 consecutive no-improvement cycles → tell user and stop.
+- **Keep the report.** The `.md` is a deliverable — useful for blog posts and future reference.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Near-autonomous workflow for coding agents, packaged as an [APM](https://github.
 ### Commands
 
 - **`/do`** — Full autonomous pipeline: research → hickey → branch → implement → CI → ship. Hands-off from start to PR.
+- **`/ralph`** — Iterative measurement-driven improvement loop. Measure, profile, mutate, re-measure, commit. Works for performance, bundle size, complexity — anything quantifiable.
 - **`/talk`** — Conversation-only mode. Discuss ideas, explore approaches, read code — no file changes allowed.
 
 ### Skills
@@ -15,6 +16,7 @@ Near-autonomous workflow for coding agents, packaged as an [APM](https://github.
 - **`code-police`** — Three-pass quality gate: rule checklist, fact-check for logic errors, and elegance review with iterative refinement.
 - **`fact-check`** — Standalone correctness audit: finds silent error swallowing, unjustified fallbacks, wishful thinking, and logic errors. Prosecutor posture — no self-dismissals.
 - **`elegance`** — Iterative elegance pass: understand, research, apply, verify. Runs 3 iterations by default, each building on the last.
+- **`ralph`** — The measurement loop engine behind `/ralph`. Profiles a quantifiable metric, finds the biggest contributor, applies a targeted mutation, and re-measures. Only commits changes that demonstrably move the needle.
 - **`forge-pr`** — Writes PR titles and descriptions that devs actually want to read. Paragraphs over bullet lists, substance over boilerplate. GitHub today; Bitbucket support tracked in [#10](https://github.com/srid/agency/issues/10).
 
 ### Hooks & Instructions


### PR DESCRIPTION
## Summary

New `/ralph` skill for iterative, measurement-driven improvement loops. Measure a metric, profile the breakdown, find the biggest contributor, apply a targeted mutation, re-measure, commit only if the improvement exceeds noise. Repeat.

Works for any quantifiable target: performance, bundle size, complexity, test coverage, lighthouse scores.

## Usage

```
/ralph
```

The skill asks interactively (via AskUserQuestion) what to improve, how to measure, how many cycles, and any constraints.

## The loop

Each cycle: **profile** → **classify** (unnecessary dep, eager eval, wrong abstraction, etc.) → **mutate** → **re-measure** → **commit if improved** → **update report**

## Design decisions

- **Interactive input** over argument parsing — lets the agent ask clarifying questions
- **Scientific methodology** — median of 5+ runs, cold/hot distinction, documented methodology
- **Noise threshold** — only commits changes that demonstrably move the needle
- **Report file** — `.md` deliverable for blog posts / documentation
- **Dead end documentation** — "X doesn't help" is valuable knowledge
- **Diminishing returns stop** — halts after 3 consecutive no-improvement cycles

## Reference

Manual ralph loop on `nix develop` eval time (juspay/kolu#534):
- Cold: 2500ms → 892ms (**-64%**)
- Hot: 333ms → 121ms (**-64%**)
- `just dev` hot: 4221ms → 121ms (**-97%, 35x faster**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)