### PR TITLE
feat: add /lowy skill — volatility-based decomposition review

### DIFF
--- a/.apm/prompts/talk.prompt.md
+++ b/.apm/prompts/talk.prompt.md
@@ -66,11 +66,11 @@ If you're about to emit "probably", "almost certainly", "I suspect", "my #1 susp
 - Be direct, opinionated, and concise.
 - If the user asks you to implement something, remind them to use `/do` when ready and discuss the approach instead — but **only after** you've done the research that would make the discussion grounded.
 
-## Auto-Hickey
+## Auto-Hickey + Auto-Lowy
 
-Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke the `hickey` skill on that proposal before presenting your final recommendation** — do not wait for the user to ask. Fold the Hickey findings into the recommendation (e.g. flag complecting, note where simplicity could be preserved) rather than dumping raw skill output on top.
+Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke the `hickey` and `lowy` skills on that proposal before presenting your final recommendation** — do not wait for the user to ask. Fold findings into the recommendation (e.g. flag complecting, note where simplicity could be preserved, flag boundaries that track functionality instead of volatility) rather than dumping raw skill output on top.
 
-Skip the Hickey pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.
+Skip the Hickey/Lowy pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.
 
 ## Laconic mode
 

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -118,7 +118,7 @@ Research the task thoroughly before writing code.
 
 ### hickey
 
-Evaluate the planned approach for structural simplicity. Invoke the `hickey` skill via the Skill tool, then invoke the `lowy` skill.
+Evaluate the planned approach for structural simplicity. Invoke the `hickey` and `lowy` skills **in parallel** (two Skill tool calls in a single message) — the skills are independent and neither needs the other's output.
 
 - **hickey**: Identify concerns. Check for complecting. Suggest simplifications.
 - **lowy**: Check that module boundaries encapsulate axes of change, not just functionality.

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -118,9 +118,10 @@ Research the task thoroughly before writing code.
 
 ### hickey
 
-Evaluate the planned approach for structural simplicity. Invoke the `hickey` skill via the Skill tool.
+Evaluate the planned approach for structural simplicity. Invoke the `hickey` skill via the Skill tool, then invoke the `lowy` skill.
 
-- Identify concerns. Check for complecting. Suggest simplifications.
+- **hickey**: Identify concerns. Check for complecting. Suggest simplifications.
+- **lowy**: Check that module boundaries encapsulate axes of change, not just functionality.
 - Revise the approach to eliminate accidental complexity before proceeding.
 
 **If `--review`**: After hickey completes, use `EnterPlanMode` to present the revised approach for user approval:
@@ -192,11 +193,11 @@ Otherwise, invoke the `/code-police` skill via the Skill tool. It runs three pas
 
 When `/code-police` asks about scope: **changes in the current branch/PR only**.
 
-**Cross-reference hickey actions**: After code-police completes, check every hickey finding marked **"Fix in this PR"**. For each one, verify the diff addresses it. An unaddressed "Fix in this PR" action is a police failure — fix it before proceeding, same as any other police violation. This closes the loop between hickey (which finds structural issues before implementation) and police (which verifies the implementation after).
+**Cross-reference hickey/lowy actions**: After code-police completes, check every hickey and lowy finding marked **"Fix in this PR"**. For each one, verify the diff addresses it. An unaddressed "Fix in this PR" action is a police failure — fix it before proceeding, same as any other police violation. This closes the loop between hickey/lowy (which find structural issues before implementation) and police (which verifies the implementation after).
 
-**For followup entry points**: Run hickey on the full cumulative diff (`origin/HEAD...HEAD`) as part of police. Followups skip the normal hickey step (jumping straight to implement), so this is the only structural review the cumulative PR changes get. It catches complexity that accumulates silently across multiple small followups — e.g., a component gaining 12 new props across 5 followups without any structural review catching the prop-drilling pattern. Any findings with **"Fix in this PR"** actions are police violations — fix them before proceeding.
+**For followup entry points**: Run hickey and lowy on the full cumulative diff (`origin/HEAD...HEAD`) as part of police. Followups skip the normal hickey step (jumping straight to implement), so this is the only structural review the cumulative PR changes get. It catches complexity that accumulates silently across multiple small followups — e.g., a component gaining 12 new props across 5 followups without any structural review catching the prop-drilling pattern. Any findings with **"Fix in this PR"** actions are police violations — fix them before proceeding.
 
-**Verify**: All 3 passes clean ("All clear") AND all hickey "Fix in this PR" actions addressed in the diff.
+**Verify**: All 3 passes clean ("All clear") AND all hickey/lowy "Fix in this PR" actions addressed in the diff.
 **If violations found** (max 3 attempts): Fix the violations and re-invoke `/code-police`.
 
 ---

--- a/.apm/skills/hickey/SKILL.md
+++ b/.apm/skills/hickey/SKILL.md
@@ -178,3 +178,4 @@ Do NOT include a "What's simple" section. Praise biases toward positive framing 
 - **Simple ≠ familiar.** Hickey: _"If you want everything to be familiar, you will never learn anything new because it can't be significantly different from what you already know."_
 - **Tests are necessary but not sufficient.** Hickey: _"I'm glad I've got these guardrails... do the guardrails help you get to where you want to go? No."_
 - **This is not a replacement for functional review.** Simplicity analysis complements correctness review. A perfectly simple program that does the wrong thing is useless.
+- **For volatility-based decomposition** (do boundaries encapsulate axes of change?), see `/lowy`.

--- a/.apm/skills/lowy/SKILL.md
+++ b/.apm/skills/lowy/SKILL.md
@@ -27,6 +27,8 @@ For every module boundary, service split, or new abstraction in the code under r
 
 What is likely to change behind this boundary? Be specific — not "requirements might change" but "the payment provider, the auth protocol, the notification channel." If you can't name concrete axes of change, the boundary may be arbitrary.
 
+**Speculative volatility is not volatility.** A change scenario counts only if it has happened before, is on a roadmap, or is a near-certain consequence of the domain (e.g. "payment providers change" in e-commerce). "What if we swap color spaces" in an app that has never swapped color spaces is speculation, not an axis of change. Lowy's framework is about *observed* or *plausible* volatility — designing for hypothetical change is over-engineering, not encapsulation.
+
 ### 2. Functional vs. Volatility Boundary
 
 Does this boundary exist because the code *does something different* (functional), or because what's behind it *changes independently* (volatility)? Functional boundaries look clean on day one but fracture under change. A `UserService` that groups all user operations is functional decomposition — the volatility of auth, profile data, and notification preferences are unrelated axes of change jammed behind one boundary.
@@ -77,3 +79,9 @@ No findings → "No actions." Findings without actions = incomplete review.
 ## Relationship to /hickey
 
 This skill and `/hickey` are complementary lenses. Hickey asks "are independent concerns interleaved?" Lowy asks "do boundaries encapsulate axes of change?" Run both on architectural decisions for full coverage.
+
+### When Hickey and Lowy Disagree
+
+The two lenses can produce conflicting recommendations. Lowy may say "merge these — shared volatility is duplicated across both" while Hickey says "keep them separate — a mode flag would complect configuration with implementation." Neither lens is wrong; they're optimizing for different things.
+
+The resolution pattern: **unify the volatile axis without complecting the strategies.** Typically this means a wrapper or shared module that encapsulates the volatile part (satisfying Lowy) while the distinct strategies remain private and uncomplected (satisfying Hickey). If merging for blast-radius reduction requires a mode flag, conditional branching, or type-switching — that's complecting. Find the layer where unification is mechanical (a shared function, a common interface, a single config source) rather than conditional.

--- a/.apm/skills/lowy/SKILL.md
+++ b/.apm/skills/lowy/SKILL.md
@@ -9,7 +9,7 @@ agent: Explore
 
 Evaluate module boundaries and decomposition decisions using Juval Lowy's volatility-based decomposition framework. The core question: **do your boundaries encapsulate axes of change, or do they just group related functionality?**
 
-Source: Juval Lowy, *Righting Software* (2019), building on David Parnas, "On the Criteria to Be Used in Decomposing Systems into Modules" (1972).
+Source: Juval Lowy, [*Righting Software*](https://rightingsoftware.org/) (2019), building on David Parnas, ["On the Criteria to Be Used in Decomposing Systems into Modules"](https://www.win.tue.nl/~wstomv/edu/2ip30/references/criteria_for_modularization.pdf) (1972). See also: [Volatility-Based Decomposition](https://www.informit.com/articles/article.aspx?p=2995357&seqNum=2) (book excerpt).
 
 ## Key Idea
 

--- a/.apm/skills/lowy/SKILL.md
+++ b/.apm/skills/lowy/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: lowy
+description: Evaluate architecture and module boundaries for volatility-based decomposition using Juval Lowy's framework (from "Righting Software", building on Parnas 1972). Use when reviewing module splits, service boundaries, new abstractions, or any decomposition decision. Trigger on phrases like "where should this boundary be", "how to split this", "module boundaries", "encapsulate change", "volatility", or references to Lowy, Parnas, or "Righting Software". Complements /hickey (interleaved concerns) with a different lens (change encapsulation).
+context: fork
+agent: Explore
+---
+
+# Lowy: Volatility-Based Decomposition Review
+
+Evaluate module boundaries and decomposition decisions using Juval Lowy's volatility-based decomposition framework. The core question: **do your boundaries encapsulate axes of change, or do they just group related functionality?**
+
+Source: Juval Lowy, *Righting Software* (2019), building on David Parnas, "On the Criteria to Be Used in Decomposing Systems into Modules" (1972).
+
+## Key Idea
+
+**Functional decomposition** groups code by what it does (UserService, PaymentController, AuthModule). **Volatility-based decomposition** groups code by what is likely to *change* — and encapsulates each axis of change behind a stable interface.
+
+Lowy's electricity analogy: a house's power supply has enormous volatility (AC/DC, 110v/220v, 50/60Hz, solar/grid/generator, wire gauges). All of it is encapsulated behind a receptacle. Without that encapsulation, you'd need an oscilloscope every time you plugged something in. The receptacle is the stable interface; the volatility behind it can change without affecting consumers.
+
+**Functional decomposition maximizes the blast radius of change.** When boundaries track functionality rather than volatility, a single change cuts across multiple modules. Volatility-based decomposition contains the grenade in the vault.
+
+## The Evaluation
+
+For every module boundary, service split, or new abstraction in the code under review:
+
+### 1. Name the Volatility
+
+What is likely to change behind this boundary? Be specific — not "requirements might change" but "the payment provider, the auth protocol, the notification channel." If you can't name concrete axes of change, the boundary may be arbitrary.
+
+### 2. Functional vs. Volatility Boundary
+
+Does this boundary exist because the code *does something different* (functional), or because what's behind it *changes independently* (volatility)? Functional boundaries look clean on day one but fracture under change. A `UserService` that groups all user operations is functional decomposition — the volatility of auth, profile data, and notification preferences are unrelated axes of change jammed behind one boundary.
+
+### 3. Change Blast Radius
+
+For a plausible change scenario (new provider, new format, new rule), trace how many modules would need to be modified. If the change leaks across boundaries, the decomposition is functional, not volatility-based.
+
+### 4. Interface Stability
+
+Is the interface between modules stable under the changes the module encapsulates? The receptacle doesn't change when you switch from grid to solar. If the interface must change when the encapsulated volatility changes, the abstraction is leaking.
+
+### 5. Reuse Signal
+
+Lowy: volatility-based building blocks are reusable because they encapsulate one axis of change. If a module can only be used in one context, it may be encapsulating functionality rather than volatility.
+
+## Output Format
+
+1. **Boundaries examined** — List each module boundary or decomposition decision reviewed.
+2. **Volatility map** — For each boundary: what volatility it encapsulates (or fails to).
+3. **Findings** — Boundaries that track functionality rather than volatility, with blast-radius analysis.
+4. **Simplifications** — Concrete restructuring to align boundaries with axes of change.
+5. **Actions** — One entry per finding: **Fix in this PR** or **Defer `#<issue>`**.
+
+No findings → "No actions." Findings without actions = incomplete review.
+
+## Relationship to /hickey
+
+This skill and `/hickey` are complementary lenses. Hickey asks "are independent concerns interleaved?" Lowy asks "do boundaries encapsulate axes of change?" Run both on architectural decisions for full coverage.

--- a/.apm/skills/lowy/SKILL.md
+++ b/.apm/skills/lowy/SKILL.md
@@ -43,13 +43,34 @@ Is the interface between modules stable under the changes the module encapsulate
 
 Lowy: volatility-based building blocks are reusable because they encapsulate one axis of change. If a module can only be used in one context, it may be encapsulating functionality rather than volatility.
 
+## Fact-Check Your Own Evaluation
+
+After completing all steps, **invoke `/fact-check` on your own output**. The fact-check catches:
+
+- Findings you talked yourself out of ("However, this is a reasonable grouping..." / "acceptable for now")
+- Functional boundaries rationalized as volatility boundaries without naming the concrete axis of change
+- "Low blast radius" used as a synonym for "ignore"
+- Change scenarios you didn't actually trace through the code
+
+**Flag these phrase shapes** — they mean you stopped one step early:
+
+- _"This boundary groups related functionality but could also be seen as encapsulating volatility"_ — name the volatility or it's functional decomposition. "Could be seen as" is not an axis of change.
+- _"The interface would only need minor changes"_ — minor interface changes are still leaking. The receptacle doesn't change at all.
+- _"This module is only used in one place, but that's fine for now"_ — single-use is the reuse signal firing. Investigate.
+- _"The boundary follows the framework's conventions"_ — framework conventions are functional decomposition by default. Convention is not volatility analysis.
+- _"This could theoretically change independently"_ — theoretical independence without a concrete change scenario is wishful thinking.
+- _"Out of scope for this PR" / "pre-existing"_ — process judgment, not a volatility judgment. Defer with an issue link or fix it.
+
+If fact-check finds issues, revise before presenting to the user.
+
 ## Output Format
 
 1. **Boundaries examined** — List each module boundary or decomposition decision reviewed.
 2. **Volatility map** — For each boundary: what volatility it encapsulates (or fails to).
 3. **Findings** — Boundaries that track functionality rather than volatility, with blast-radius analysis.
 4. **Simplifications** — Concrete restructuring to align boundaries with axes of change.
-5. **Actions** — One entry per finding: **Fix in this PR** or **Defer `#<issue>`**.
+5. **Fact-check result** — Output of `/fact-check` on this evaluation, including the phrase-shape check.
+6. **Actions** — One entry per finding: **Fix in this PR** or **Defer `#<issue>`**. Every finding must appear here — including those labeled "pre-existing" or "orthogonal". A finding that never reaches this section has been dismissed, not deferred.
 
 No findings → "No actions." Findings without actions = incomplete review.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Near-autonomous workflow for coding agents, packaged as an [APM](https://github.
 ### Skills
 
 - **`hickey`** — Structural simplicity evaluation using [Rich Hickey's "Simple Made Easy"](https://www.infoq.com/presentations/Simple-Made-Easy/) framework. Catches accidental complexity that tests can't.
+- **`lowy`** — Volatility-based decomposition review using Juval Lowy's framework (from *Righting Software*, building on Parnas 1972). Checks that module boundaries encapsulate axes of change, not just functionality.
 - **`code-police`** — Three-pass quality gate: rule checklist, fact-check for logic errors, and elegance review with iterative refinement.
 - **`fact-check`** — Standalone correctness audit: finds silent error swallowing, unjustified fallbacks, wishful thinking, and logic errors. Prosecutor posture — no self-dismissals.
 - **`elegance`** — Iterative elegance pass: understand, research, apply, verify. Runs 3 iterations by default, each building on the last.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Near-autonomous workflow for coding agents, packaged as an [APM](https://github.
 ### Skills
 
 - **`hickey`** — Structural simplicity evaluation using [Rich Hickey's "Simple Made Easy"](https://www.infoq.com/presentations/Simple-Made-Easy/) framework. Catches accidental complexity that tests can't.
-- **`lowy`** — Volatility-based decomposition review using Juval Lowy's framework (from *Righting Software*, building on Parnas 1972). Checks that module boundaries encapsulate axes of change, not just functionality.
+- **`lowy`** — Volatility-based decomposition review using [Juval Lowy's framework](https://www.informit.com/articles/article.aspx?p=2995357&seqNum=2) (from [*Righting Software*](https://rightingsoftware.org/), building on [Parnas 1972](https://www.win.tue.nl/~wstomv/edu/2ip30/references/criteria_for_modularization.pdf)). Checks that module boundaries encapsulate axes of change, not just functionality.
 - **`code-police`** — Three-pass quality gate: rule checklist, fact-check for logic errors, and elegance review with iterative refinement.
 - **`fact-check`** — Standalone correctness audit: finds silent error swallowing, unjustified fallbacks, wishful thinking, and logic errors. Prosecutor posture — no self-dismissals.
 - **`elegance`** — Iterative elegance pass: understand, research, apply, verify. Runs 3 iterations by default, each building on the last.


### PR DESCRIPTION
## Summary

- Adds `/lowy` skill based on [Juval Lowy's *Righting Software*](https://rightingsoftware.org/) framework (building on [Parnas 1972](https://www.win.tue.nl/~wstomv/edu/2ip30/references/criteria_for_modularization.pdf)). Evaluates whether module boundaries encapsulate axes of change (volatility) rather than just grouping related functionality. Includes the [electricity analogy](https://www.informit.com/articles/article.aspx?p=2995357&seqNum=2) as the core mental model.
- Integrates lowy alongside hickey in `/do` (hickey step), `/talk` (auto-Lowy), and police (cross-reference of findings).
- Adds cross-reference between hickey and lowy so reviewers know the complementary lens exists.

## Test plan

- [ ] Run `/lowy` on a codebase with functional decomposition to verify it flags boundaries that track functionality instead of volatility
- [ ] Run `/do` and verify the hickey step invokes both hickey and lowy
- [ ] Run `/talk` with a design proposal and verify auto-Lowy fires alongside auto-Hickey

🤖 Generated with [Claude Code](https://claude.com/claude-code)