### PR TITLE
fix: enforce parallel hickey+lowy and ban test runs from hickey

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -59,10 +59,10 @@ After each step's verification, record results via the `do-results` script. The 
 
 ## Progress tracking
 
-Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a live checklist of the workflow. At the start of **sync** (or the chosen `--from` entry point), seed a task list with all 15 step names in order:
+Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a live checklist of the workflow. At the start of **sync** (or the chosen `--from` entry point), seed a task list with all 14 step names in order:
 
 ```
-sync, research, hickey, lowy, branch, implement, check, docs, police, fmt, commit, test, create-pr, ci, done
+sync, research, hickey+lowy, branch, implement, check, docs, police, fmt, commit, test, create-pr, ci, done
 ```
 
 At each step boundary, update task state **alongside** the `do-results` script call — they are not redundant. The JSON file is machine state for the stop hook; the task list is the human-facing UI. Miss either and the workflow is inconsistent.
@@ -71,7 +71,7 @@ Rules:
 
 - **Flip to `in_progress` when a step starts, `completed` when it verifies.** One step `in_progress` at a time.
 - **Retries stay `in_progress`.** If `check`, `test`, or `ci` loop through their retry budget, do **not** bounce the task state back to `pending` or flicker it — leave it `in_progress` until the step finally verifies (or the retries exhaust and the workflow fails).
-- **`--from <step>` entry points**: still seed all 15 steps. Mark steps earlier than the entry point as `completed` immediately after seeding, so the checklist shows a consistent 15-item view regardless of entry point.
+- **`--from <step>` entry points**: still seed all 14 steps. Mark steps earlier than the entry point as `completed` immediately after seeding, so the checklist shows a consistent 14-item view regardless of entry point.
 - **Skipped steps** (e.g. `branch`/`commit`/`create-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. The skip reason is recorded via `do-results step <name> skipped ... "<reason>"`; the task list just shows the step as done.
 - **Failure**: if retries exhaust and the workflow halts, leave the failing step `in_progress`, mark `done` `completed` after the failure summary is written, and run `do-results set status failed`.
 
@@ -116,19 +116,11 @@ Research the task thoroughly before writing code.
 
 ---
 
-### hickey
+### hickey + lowy
 
-Invoke the `/hickey` skill via the Skill tool. Identify concerns, check for complecting, suggest simplifications.
+Invoke `/hickey` and `/lowy` via the Skill tool. **Both calls MUST appear in a single message** so they execute in parallel — they are completely independent. Do NOT wait for one to finish before invoking the other. One message, two Skill tool calls. No exceptions.
 
-**Important**: hickey and lowy are independent — invoke them **in parallel** by issuing both Skill tool calls in a single message. Neither needs the other's output.
-
----
-
-### lowy
-
-Invoke the `/lowy` skill via the Skill tool. Check that module boundaries encapsulate axes of change, not just functionality.
-
-After both hickey and lowy complete, revise the approach to eliminate accidental complexity before proceeding.
+After both complete, revise the approach to eliminate accidental complexity before proceeding.
 
 **If `--review`**: Use `EnterPlanMode` to present the revised approach for user approval:
 

--- a/.apm/skills/hickey/SKILL.md
+++ b/.apm/skills/hickey/SKILL.md
@@ -178,4 +178,5 @@ Do NOT include a "What's simple" section. Praise biases toward positive framing 
 - **Simple ≠ familiar.** Hickey: _"If you want everything to be familiar, you will never learn anything new because it can't be significantly different from what you already know."_
 - **Tests are necessary but not sufficient.** Hickey: _"I'm glad I've got these guardrails... do the guardrails help you get to where you want to go? No."_
 - **This is not a replacement for functional review.** Simplicity analysis complements correctness review. A perfectly simple program that does the wrong thing is useless.
+- **Do NOT run tests, builds, or any shell commands.** This skill is purely analytical — read code, reason about structure, report findings. Running tests is the job of other workflow steps, not this one.
 - **For volatility-based decomposition** (do boundaries encapsulate axes of change?), see `/lowy`.


### PR DESCRIPTION
## Summary
- **hickey running tests**: The hickey agent (Explore type with Bash access) was running `test-quick` during structural analysis. Added explicit "Do NOT run tests, builds, or any shell commands" caveat to the hickey skill.
- **Sequential hickey/lowy**: Despite instructions saying "invoke in parallel", having them as separate `###` steps caused the agent to run them sequentially. Merged into a single `### hickey + lowy` step so both Skill calls must appear in one message.

## Test plan
- [ ] Run `/do` on a task and verify hickey does not invoke any Bash commands
- [ ] Verify hickey and lowy Skill calls appear in the same agent message (true parallel execution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)