### PR TITLE
fix: use <use_parallel_tool_calls> tag for hickey+lowy parallelism

### DIFF
--- a/.apm/prompts/talk.prompt.md
+++ b/.apm/prompts/talk.prompt.md
@@ -70,6 +70,10 @@ If you're about to emit "probably", "almost certainly", "I suspect", "my #1 susp
 
 Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke the `hickey` and `lowy` skills on that proposal before presenting your final recommendation** — do not wait for the user to ask. Fold findings into the recommendation (e.g. flag complecting, note where simplicity could be preserved, flag boundaries that track functionality instead of volatility) rather than dumping raw skill output on top.
 
+<use_parallel_tool_calls>
+Invoke both Skill("hickey") and Skill("lowy") simultaneously in a single response. They are independent — do not wait for one before invoking the other.
+</use_parallel_tool_calls>
+
 Skip the Hickey/Lowy pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.
 
 ## Laconic mode

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -118,7 +118,11 @@ Research the task thoroughly before writing code.
 
 ### hickey + lowy
 
-Invoke `/hickey` and `/lowy` via the Skill tool. **Both calls MUST appear in a single message** so they execute in parallel — they are completely independent. Do NOT wait for one to finish before invoking the other. One message, two Skill tool calls. No exceptions.
+Invoke `/hickey` and `/lowy` via the Skill tool. They are completely independent — do NOT wait for one to finish before invoking the other.
+
+<use_parallel_tool_calls>
+For this step, invoke both Skill("hickey") and Skill("lowy") simultaneously in a single response. Do not include any other tool calls or text — just the two parallel Skill invocations.
+</use_parallel_tool_calls>
 
 After both complete, revise the approach to eliminate accidental complexity before proceeding.
 


### PR DESCRIPTION
## Summary

- Replace natural-language emphasis ("MUST appear in a single message", "No exceptions") with the officially documented `<use_parallel_tool_calls>` XML tag from [Claude's prompting best practices](https://platform.claude.com/docs/en/docs/build-with-claude/prompt-engineering/claude-prompting-best-practices#optimize-parallel-tool-calling), which boosts parallel tool calling to ~100% success rate
- Apply the same fix to `talk.prompt.md`'s Auto-Hickey + Auto-Lowy section

## Test plan

- [ ] Run `/do` on a task and verify hickey and lowy Skill calls appear in the same agent message (true parallel execution)
- [ ] Run `/talk` with a code plan and verify hickey+lowy fire in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)