### PR TITLE
feat: make laconic the default talk mode, add --detailed flag

### DIFF
--- a/.apm/prompts/talk.prompt.md
+++ b/.apm/prompts/talk.prompt.md
@@ -70,6 +70,10 @@ If you're about to emit "probably", "almost certainly", "I suspect", "my #1 susp
 
 Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke the `hickey` and `lowy` skills on that proposal before presenting your final recommendation** — do not wait for the user to ask. Fold findings into the recommendation (e.g. flag complecting, note where simplicity could be preserved, flag boundaries that track functionality instead of volatility) rather than dumping raw skill output on top.
 
+<use_parallel_tool_calls>
+Invoke both Skill("hickey") and Skill("lowy") simultaneously in a single response. They are independent — do not wait for one before invoking the other.
+</use_parallel_tool_calls>
+
 Skip the Hickey/Lowy pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.
 
 ## Laconic mode

--- a/.apm/prompts/talk.prompt.md
+++ b/.apm/prompts/talk.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "Enter talk mode — conversation only, no file changes"
-argument-hint: "[-l|--laconic] <topic or question>"
+argument-hint: "[-d|--detailed] <topic or question>"
 ---
 
 # Probe (Talk Mode)
@@ -63,8 +63,14 @@ If you're about to emit "probably", "almost certainly", "I suspect", "my #1 susp
 
 ## Behavior
 
-- Be direct, opinionated, and concise.
+- Be direct, opinionated, and terse. One or two sentences when it will do. A single word when *that* will do.
+- No preamble, no recap of the question, no "great question", no closing offers to help further.
+- Drop bullet lists unless the answer is genuinely a list. No headings.
+- Keep file:line citations — brevity does not override the research/citation rules above. Research silently; show only the conclusion plus its citations.
+- Code blocks only when code is the answer.
 - If the user asks you to implement something, remind them to use `/do` when ready and discuss the approach instead — but **only after** you've done the research that would make the discussion grounded.
+
+Terse output trims the *output*, not the *investigation*. Do the same reading you would otherwise; just say less about it.
 
 ## Auto-Hickey + Auto-Lowy
 
@@ -76,16 +82,12 @@ Invoke both Skill("hickey") and Skill("lowy") simultaneously in a single respons
 
 Skip the Hickey/Lowy pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.
 
-## Laconic mode
+## Detailed mode
 
-If `ARGUMENTS` begins with `-l` or `--laconic` (strip the flag before treating the rest as the topic), answer as tersely as possible:
+If `ARGUMENTS` begins with `-d` or `--detailed` (strip the flag before treating the rest as the topic), switch to verbose output:
 
-- One or two sentences when it will do. A single word when *that* will do.
-- No preamble, no recap of the question, no "great question", no closing offers to help further.
-- Drop bullet lists unless the answer is genuinely a list. No headings.
-- Keep file:line citations — brevity does not override the research/citation rules above. Research silently; show only the conclusion plus its citations.
-- Code blocks only when code is the answer.
-
-Laconic mode trims the *output*, not the *investigation*. Do the same reading you would otherwise; just say less about it.
+- Use bullet lists, headings, and structured formatting freely.
+- Explain reasoning, trade-offs, and alternatives — not just conclusions.
+- Still keep file:line citations and the research-first requirement.
 
 ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -118,7 +118,11 @@ Research the task thoroughly before writing code.
 
 ### hickey + lowy
 
-Invoke `/hickey` and `/lowy` via the Skill tool. **Both calls MUST appear in a single message** so they execute in parallel — they are completely independent. Do NOT wait for one to finish before invoking the other. One message, two Skill tool calls. No exceptions.
+Invoke `/hickey` and `/lowy` via the Skill tool. They are completely independent — do NOT wait for one to finish before invoking the other.
+
+<use_parallel_tool_calls>
+For this step, invoke both Skill("hickey") and Skill("lowy") simultaneously in a single response. Do not include any other tool calls or text — just the two parallel Skill invocations.
+</use_parallel_tool_calls>
 
 After both complete, revise the approach to eliminate accidental complexity before proceeding.
 


### PR DESCRIPTION
## Summary

- Terse output (previously `--laconic`) is now the default `/talk` behavior — direct, opinionated, one-or-two-sentence answers
- Added `--detailed` (`-d`) flag for when verbose output with headings, bullet lists, and trade-off explanations is wanted
- Moved the laconic rules into the main Behavior section so they apply by default

## Test plan

- [ ] Run `/talk <question>` and verify output is terse by default
- [ ] Run `/talk --detailed <question>` and verify verbose formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)