### PR TITLE
fix: restore --laconic as default-on, add --no-laconic opt-out

### DIFF
--- a/.apm/prompts/talk.prompt.md
+++ b/.apm/prompts/talk.prompt.md
@@ -1,6 +1,6 @@
 ---
 description: "Enter talk mode — conversation only, no file changes"
-argument-hint: "[-d|--detailed] <topic or question>"
+argument-hint: "[--no-laconic] <topic or question>"
 ---
 
 # Probe (Talk Mode)
@@ -63,14 +63,8 @@ If you're about to emit "probably", "almost certainly", "I suspect", "my #1 susp
 
 ## Behavior
 
-- Be direct, opinionated, and terse. One or two sentences when it will do. A single word when *that* will do.
-- No preamble, no recap of the question, no "great question", no closing offers to help further.
-- Drop bullet lists unless the answer is genuinely a list. No headings.
-- Keep file:line citations — brevity does not override the research/citation rules above. Research silently; show only the conclusion plus its citations.
-- Code blocks only when code is the answer.
+- Be direct, opinionated, and concise.
 - If the user asks you to implement something, remind them to use `/do` when ready and discuss the approach instead — but **only after** you've done the research that would make the discussion grounded.
-
-Terse output trims the *output*, not the *investigation*. Do the same reading you would otherwise; just say less about it.
 
 ## Auto-Hickey + Auto-Lowy
 
@@ -82,12 +76,18 @@ Invoke both Skill("hickey") and Skill("lowy") simultaneously in a single respons
 
 Skip the Hickey/Lowy pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.
 
-## Detailed mode
+## Laconic mode (default)
 
-If `ARGUMENTS` begins with `-d` or `--detailed` (strip the flag before treating the rest as the topic), switch to verbose output:
+Laconic mode is **on by default**. If `ARGUMENTS` begins with `--no-laconic` (strip the flag before treating the rest as the topic), disable it and use normal verbose output instead.
 
-- Use bullet lists, headings, and structured formatting freely.
-- Explain reasoning, trade-offs, and alternatives — not just conclusions.
-- Still keep file:line citations and the research-first requirement.
+When laconic mode is active:
+
+- One or two sentences when it will do. A single word when *that* will do.
+- No preamble, no recap of the question, no "great question", no closing offers to help further.
+- Drop bullet lists unless the answer is genuinely a list. No headings.
+- Keep file:line citations — brevity does not override the research/citation rules above. Research silently; show only the conclusion plus its citations.
+- Code blocks only when code is the answer.
+
+Laconic mode trims the *output*, not the *investigation*. Do the same reading you would otherwise; just say less about it.
 
 ARGUMENTS: $ARGUMENTS


### PR DESCRIPTION
## Summary

- Reverts the `--detailed` approach from #73 (c7cc86a)
- Restores `--laconic` as a named mode, now **on by default** — terse output without any flag
- Adds `--no-laconic` to opt out and get normal verbose output
- Moves terse-output rules back under a dedicated "Laconic mode" section (out of general Behavior)

## Test plan

- [ ] Run `/talk <question>` and verify output is terse (laconic by default)
- [ ] Run `/talk --no-laconic <question>` and verify verbose formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)