### PR TITLE
feat: add --setup flag for interactive step selection in /do

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -1,23 +1,24 @@
 ---
 name: do
 description: Do a task end-to-end — implement, PR, CI loop, ship
-argument-hint: "<issue-url | prompt> [--review] [--no-git] [--from <step>]"
+argument-hint: "<issue-url | prompt> [--review] [--no-git] [--setup] [--from <step>]"
 ---
 
 # Do Workflow
 
 Take a task and do it top-to-bottom: research, branch, implement, pass CI, open a PR, and ship. (Under `--no-git`, extend the working tree in place — no branch, commit, or PR.)
 
-**Fully autonomous.** Do NOT use `AskUserQuestion` at any point (unless `--review` is active during the planning pause). Make sensible default choices and keep moving.
+**Fully autonomous.** Do NOT use `AskUserQuestion` at any point (unless `--review` is active during the planning pause, or `--setup` is active during the setup step gate). Make sensible default choices and keep moving.
 
 ## Arguments
 
-Parse the arguments string: `[--review] [--no-git] [--from <step-id>] <task description or issue-url>`
+Parse the arguments string: `[--review] [--no-git] [--setup] [--from <step-id>] <task description or issue-url>`
 
 The workflow is **forge-aware**: it auto-detects whether the repo lives on GitHub or elsewhere during the **sync** step (see Forge Detection). Only GitHub has an active code path today — Bitbucket/other forges gracefully skip PR-related steps. Tracking: [srid/agency#10](https://github.com/srid/agency/issues/10).
 
 - `--review`: Pause after **hickey**/**lowy** for user plan approval via `EnterPlanMode`/`ExitPlanMode`, then continue autonomously
 - `--no-git`: Extend the working tree **in place** — do not create a branch, commit, push, or touch any PR. Research, implement, check, docs, police, fmt, and test all run; git-mutating steps (**branch**, **commit**, **create-pr**) are skipped. Use this when you have uncommitted local work and want the agent to build on it without taking over git state. Feedback from a Bitbucket user in [#26](https://github.com/srid/agency/issues/26).
+- `--setup` (`-s`): After **research**, pause to present a recommended step plan to the user via `AskUserQuestion`. The AI assesses which steps are relevant based on the task (e.g., a docs-only change doesn't need **check** or **test**; a trivial one-liner doesn't need **hickey+lowy** or **police**) and presents a multi-select checklist of skippable steps with pre-selected recommendations. The user confirms or adjusts, then the workflow continues autonomously. Steps the user deselects are recorded as `skipped` with reason `"--setup: user skipped"`. **sync** and **done** are never skippable. See the **Setup step gate** section below for details.
 - `--from <step-id>`: Start from a specific step (see entry points below)
 
 ## Results Tracking
@@ -113,6 +114,33 @@ Research the task thoroughly before writing code.
 - If the prompt involves external tools/libraries, use WebSearch/WebFetch
 
 **Verify**: Can articulate what needs to change, where, and why.
+
+---
+
+### Setup step gate
+
+**Only runs if `--setup` is active.** Otherwise skip entirely — all steps run as normal.
+
+After **research** completes (and before **hickey+lowy**), assess which of the remaining steps are relevant to this task. Consider:
+
+- **Nature of the change**: docs-only, config change, trivial fix, refactor, feature, bug fix
+- **Scope**: number of files, lines changed, complexity
+- **Project config**: whether check/test/fmt/docs commands are even configured
+
+Present a single `AskUserQuestion` with `multiSelect: true` listing the skippable steps (all except **sync**, **research**, and **done** — those always run). For each step, set a recommended default:
+
+- **Pre-select** (recommend running) steps that are relevant to the task
+- **Deselect** (recommend skipping) steps the AI judges as not useful for this particular change
+
+The question should explain the rationale briefly, e.g.:
+
+> "This looks like a docs-only change. Which steps should run? (Pre-selected = recommended)"
+
+Steps the user leaves deselected are skipped throughout the workflow with status `skipped` and reason `"--setup: user skipped"`. Steps the user selects proceed normally. The `--setup` flag is recorded in the results JSON via `do-results set setup true`.
+
+**Interaction with other flags**: `--setup` composes with `--no-git` and `--from`. Steps already skipped by `--no-git` or `--from` are not shown in the checklist (they're already handled). Only steps that *would* normally run are presented for user selection.
+
+After the user confirms, continue autonomously from **hickey+lowy** (or the next non-skipped step).
 
 ---
 
@@ -293,10 +321,11 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 
 Present a summary of all steps with their verification status. If any step has a non-success status, retry it (max 3 attempts from done). If still failing after retries, set `status: "failed"`.
 
-`"completed"` requires **all steps `passed`**, with two exceptions that count toward completion:
+`"completed"` requires **all steps `passed`**, with three exceptions that count toward completion:
 
 1. A step `skipped` with `reason` beginning `"non-<forge> forge:"` (detected forge isn't GitHub).
 2. A step `skipped` with `reason` `"--no-git"` (user opted out of git operations).
+3. A step `skipped` with `reason` `"--setup: user skipped"` (user chose to skip during setup).
 
 A `failed` step always blocks `"completed"`. No redefining "passed," no footnote caveats. Update via `do-results set status completed` or `do-results set status failed` accordingly.
 
@@ -358,11 +387,11 @@ COMMENT
 
 ## Rules
 
-- **Never skip steps.** Run them in order from entry point to **done**.
+- **Never skip steps** (unless skipped by `--no-git`, `--setup`, or forge detection). Run them in order from entry point to **done**.
 - **Every commit is NEW.** Never amend, rebase, or force-push.
 - **Feature branches only.** Never commit to master/main. (Under `--no-git`, no commits happen at all, so this rule is moot — the agent leaves the user on whatever branch they started on.)
 - **Background for CI.** Run CI with `run_in_background: true`.
-- **No questions.** Don't use `AskUserQuestion` unless `--review` is active during the hickey/lowy pause.
+- **No questions.** Don't use `AskUserQuestion` unless `--review` is active during the hickey/lowy pause, or `--setup` is active during the setup step gate.
 - **Never stop between steps.** After completing a step, immediately proceed to the next one.
 - **Complete the full workflow.** Implementing code is one step of many. The task is not done until a PR URL (GitHub), a pushed branch name (non-GitHub forges), or a working-tree summary (`--no-git`) is reported.
 - **Exhausted retries = halt.** If `ci` or `test` retries are exhausted, set status to `"failed"` and skip to **done**. On `ci` failure the draft PR (opened in the preceding **create-pr** step) stays open as the record of the failed attempt — do not close, undraft, or otherwise mutate it.


### PR DESCRIPTION
## Summary

- Adds `--setup` (`-s`) flag to `/do` that pauses after **research** to present an AI-assessed step checklist via `AskUserQuestion`
- The AI recommends which steps to run/skip based on task nature (docs-only, trivial fix, feature, etc.) and the user confirms or adjusts
- Skipped steps record `"--setup: user skipped"` and count toward workflow completion
- Composes with `--no-git` and `--from` — already-skipped steps don't appear in the checklist

## Test plan

- [ ] Run `/do --setup <task>` and verify the checklist appears after research
- [ ] Confirm deselected steps are skipped with correct reason
- [ ] Verify `--setup` composes with `--no-git` (git steps excluded from checklist)
- [ ] Verify workflow completes successfully with skipped steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)