### PR TITLE
fix: always post hickey/lowy PR comment, even when out of scope

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -281,7 +281,7 @@ Check whether a PR already exists for this branch (`gh pr view`).
 
    **MANDATORY**: Load the `forge-pr` skill (via Skill tool) BEFORE writing the PR title/body.
 
-2. **Post hickey/lowy results**: If the hickey or lowy steps produced findings with suggestions, post the analysis as a PR comment using `gh pr comment`. Use a `## Hickey/Lowy Analysis` header. Skip this if neither found issues.
+2. **Post hickey/lowy results**: Post the hickey and lowy analysis as a PR comment using `gh pr comment` with a `## Hickey/Lowy Analysis` header. Always post when the steps ran, even if all findings are deferred or out of scope — reviewers should see the structural analysis.
 
 **If PR already exists** (followup runs, `--from` entry points):
 


### PR DESCRIPTION
## Summary
- Remove the conditional "skip this if neither found issues" from the create-pr step's hickey/lowy comment posting
- Hickey/lowy analysis is now always posted as a PR comment when the steps ran, even if all findings are deferred or out of scope
- Gives reviewers visibility into structural analysis they would otherwise never see

Closes #77

## Test plan
- [ ] Run `/do` on a PR where hickey finds only out-of-scope issues — verify the PR comment is still posted
- [ ] Run `/do` on a PR where hickey finds in-scope issues — verify behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)