### PR TITLE
refactor(do): extract sync and done steps into scripts

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -80,27 +80,27 @@ Rules:
 
 ### sync
 
-Run: `git fetch origin && git remote set-head origin --auto`
+Run the `scripts/steps/sync` script in this skill's directory, passing `true` or `false` for `--no-git`:
 
-**If `--no-git` is NOT set**: if current branch is behind origin, fast-forward with `git pull --ff-only`.
+```
+.../skills/do/scripts/steps/sync <noGit>
+```
 
-**If `--no-git` is set**: do **not** pull. Fetching the remote is harmless and useful context, but modifying the working tree could conflict with the user's uncommitted work. Leave the branch where it is.
+The script:
 
-**Dirty-tree hint**: run `git status --porcelain`. If it is non-empty and `--no-git` was NOT passed, print a one-line hint to the terminal:
+- Fetches `origin` and pins `origin/HEAD`
+- If `--no-git` is **not** set and the branch is behind origin (ahead-count 0), fast-forwards with `git pull --ff-only`. Under `--no-git`, fetching happens but the working tree is not touched — uncommitted work is preserved.
+- Prints the dirty-tree hint to stderr (no pause) when the tree is dirty and `--no-git` is not set:
 
-> _Dirty tree detected. Continuing will create a fresh branch on top of these changes. If you wanted the agent to extend your WIP in place without touching git, re-run with `--no-git`._
+  > _Dirty tree detected. Continuing will create a fresh branch on top of these changes. If you wanted the agent to extend your WIP in place without touching git, re-run with `--no-git`._
 
-Do **not** pause or ask — just print and continue. The user's default-mode invocation is respected.
+- Classifies the forge from `git remote get-url origin` — `github.com` → `github`, `bitbucket.` (covers `bitbucket.org` and self-hosted servers like `bitbucket.juspay.net`) → `bitbucket`, otherwise `unknown`.
+- Calls `do-results init <forge> <noGit>` then `do-results step sync passed ...`.
+- Prints `forge=<value>`, `branch=<value>`, `defaultBranch=<value>` on stdout for downstream steps.
 
-**Forge detection**: Inspect `git remote get-url origin` and classify:
+**Only `github` has an active code path today.** Both `bitbucket` and `unknown` cause forge-dependent steps (PR creation, PR comments, PR edits, CI status) to skip gracefully. Bitbucket support is planned — see [srid/agency#10](https://github.com/srid/agency/issues/10).
 
-- URL contains `github.com` → `github`
-- URL contains `bitbucket.` (covers `bitbucket.org` and self-hosted Bitbucket Server, e.g. `bitbucket.juspay.net`) → `bitbucket`
-- Otherwise → `unknown`
-
-Record the result via `do-results set forge <value>`. Subsequent steps branch on this value. **Only `github` has an active code path today.** Both `bitbucket` and `unknown` cause forge-dependent steps (PR creation, PR comments, PR edits, CI status) to skip gracefully. Bitbucket support is planned — see [srid/agency#10](https://github.com/srid/agency/issues/10).
-
-**Verify**: git fetch ran without error, `forge` is recorded, and `noGit` is recorded.
+**Verify**: Script exited 0 and printed a `forge=` line. `.do-results.json` exists and its `forge`/`noGit` fields match.
 
 ---
 
@@ -338,11 +338,18 @@ A `failed` step always blocks `"completed"`. No redefining "passed," no footnote
 
 #### Timing summary
 
-Compute duration for each step from its `startedAt`/`completedAt` timestamps. Print a table to the user showing each step's duration and the total wall-clock time (`startedAt` of first step → `completedAt` of last step). Highlight the **slowest step** and any step that took >30% of total time.
+Run `scripts/steps/done` in this skill's directory. The script reads `.do-results.json` and emits:
+
+1. A markdown timing table (step, status, duration, verification), with any step that took ≥30% of total time shown in **bold**.
+2. A total wall-clock line (`startedAt` of first step → `completedAt` of last step).
+3. A `**Slowest step**:` line.
+4. A `<<<FACTS ... FACTS` block with machine-readable summary data (`totalSeconds`, `slowestStep`, `slowestSeconds`, `dominantSteps`, `skippedSteps`, `failedSteps`) — use this to compose optimization suggestions below.
+
+Do not compute durations yourself — the script handles all timestamp arithmetic.
 
 #### Optimization suggestions
 
-After the timing table, print 2–4 concrete suggestions for reducing time-to-completion in future runs. Base these on the actual timing data — for example:
+Read the `FACTS` block the `done` script emitted and generate 2–4 concrete suggestions for reducing time-to-completion in future runs. Base these on the actual timing data — for example:
 
 - If **ci** dominates: suggest `--from ci-only` for re-runs, or note which CI sub-step was slowest
 - If **research** was slow: suggest pre-reading relevant code before invoking `/do`
@@ -358,7 +365,7 @@ Be specific to this run's data, not generic advice.
 
 **If `forge != github`**: Report the branch name (and remote URL, if available via `git remote get-url origin`) instead of a PR URL. Print the timing table and optimization suggestions to the terminal only — do **not** attempt to post a PR comment. (Bitbucket `bkt pr comment` wiring is tracked in #10.)
 
-**If `forge == github`**: Report the PR URL. Then post the final step status table as a **PR comment** using `gh pr comment` with a markdown table including durations. Format:
+**If `forge == github`**: Report the PR URL. Then post the final step status table as a **PR comment** using `gh pr comment`. Use the markdown table and slowest-step line emitted by `scripts/steps/done` verbatim (strip the trailing `<<<FACTS ... FACTS` block — that's internal). Format:
 
 ```
 gh pr comment --body "$(cat <<'COMMENT'

--- a/.apm/skills/do/scripts/steps/done
+++ b/.apm/skills/do/scripts/steps/done
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# /do workflow's done step — extracted to a script so the LLM doesn't do
+# timestamp arithmetic over every step. Reads .do-results.json and emits a
+# ready-to-paste markdown timing table plus a FACTS block the agent uses to
+# compose optimization suggestions.
+#
+# Usage:
+#   done
+#
+# Stdout layout:
+#   <markdown timing table>
+#
+#   <slowest-step line>
+#
+#   <<<FACTS
+#   totalSeconds=<int>
+#   slowestStep=<name>
+#   slowestSeconds=<int>
+#   dominantSteps=<comma-separated step names that took >=30% of total>
+#   skippedSteps=<comma-separated name:reason pairs>
+#   failedSteps=<comma-separated step names>
+#   FACTS
+
+set -euo pipefail
+
+FILE=".do-results.json"
+[ -f "$FILE" ] || { echo "done: $FILE not found — cannot produce summary" >&2; exit 1; }
+
+if command -v jq &>/dev/null; then
+  JQ=jq
+else
+  JQ="nix run nixpkgs#jq --"
+fi
+
+# Portable ISO-8601 -> unix seconds. Supports GNU and BSD date.
+iso_to_epoch() {
+  local iso="$1"
+  if date -u -d "$iso" +%s 2>/dev/null; then
+    return
+  fi
+  date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s
+}
+
+fmt_dur() {
+  local s=$1
+  if [ "$s" -lt 60 ]; then
+    echo "${s}s"
+  else
+    printf "%dm %ds" $(( s / 60 )) $(( s % 60 ))
+  fi
+}
+
+total_start="$($JQ -r '[.steps[].startedAt] | first // .startedAt' "$FILE")"
+total_start_epoch="$(iso_to_epoch "$total_start")"
+
+last_end="$($JQ -r '[.steps[].completedAt] | last // .startedAt' "$FILE")"
+last_end_epoch="$(iso_to_epoch "$last_end")"
+
+total_dur=$(( last_end_epoch - total_start_epoch ))
+[ "$total_dur" -lt 0 ] && total_dur=0
+
+# Walk steps once; compute durations, icons, dominance, and aggregates.
+slowest_name=""
+slowest_dur=0
+dominant=()
+skipped=()
+failed=()
+rows=()
+
+while IFS=$'\t' read -r name status start end verif reason; do
+  start_e="$(iso_to_epoch "$start")"
+  end_e="$(iso_to_epoch "$end")"
+  d=$(( end_e - start_e ))
+  [ "$d" -lt 0 ] && d=0
+
+  case "$status" in
+    passed)  icon="✓" ;;
+    failed)  icon="✗"; failed+=("$name") ;;
+    skipped) icon="—"; skipped+=("$name:${reason:-unspecified}") ;;
+    *)       icon="?" ;;
+  esac
+
+  # Only count non-skipped steps toward slowest / dominance — a skipped
+  # step has 0 duration and would drown out real timing noise.
+  if [ "$status" != "skipped" ]; then
+    if [ "$d" -gt "$slowest_dur" ]; then
+      slowest_dur=$d
+      slowest_name=$name
+    fi
+    if [ "$total_dur" -gt 0 ] && [ $(( d * 100 / total_dur )) -ge 30 ]; then
+      dominant+=("$name")
+    fi
+  fi
+
+  dur_str="$(fmt_dur "$d")"
+  if [ "$status" != "skipped" ] && [ "$total_dur" -gt 0 ] && [ $(( d * 100 / total_dur )) -ge 30 ]; then
+    dur_str="**$dur_str**"
+  fi
+
+  verif_clean="$(echo "${verif:-}" | tr '\n' ' ' | sed 's/|/\\|/g')"
+  rows+=("| $name | $icon | $dur_str | $verif_clean |")
+done < <(
+  $JQ -r '.steps[] | [.name, .status, .startedAt, .completedAt, (.verification // ""), (.reason // "")] | @tsv' "$FILE"
+)
+
+# Emit markdown table
+echo "| Step | Status | Duration | Verification |"
+echo "|------|--------|----------|--------------|"
+for row in "${rows[@]}"; do
+  echo "$row"
+done
+echo "| **Total** | | **$(fmt_dur "$total_dur")** | |"
+echo
+
+if [ -n "$slowest_name" ]; then
+  echo "**Slowest step**: \`$slowest_name\` ($(fmt_dur "$slowest_dur"))"
+fi
+
+# FACTS block — parsed by the agent to compose optimization suggestions.
+join_csv() { local IFS=,; echo "$*"; }
+echo
+echo "<<<FACTS"
+echo "totalSeconds=$total_dur"
+echo "slowestStep=$slowest_name"
+echo "slowestSeconds=$slowest_dur"
+echo "dominantSteps=$(join_csv "${dominant[@]+${dominant[@]}}")"
+echo "skippedSteps=$(join_csv "${skipped[@]+${skipped[@]}}")"
+echo "failedSteps=$(join_csv "${failed[@]+${failed[@]}}")"
+echo "FACTS"

--- a/.apm/skills/do/scripts/steps/sync
+++ b/.apm/skills/do/scripts/steps/sync
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# /do workflow's sync step — extracted to a script to collapse several Bash
+# round-trips into one. Handles fetch, fast-forward, forge detection, dirty-
+# tree hint, and initial results bookkeeping.
+#
+# Usage:
+#   sync <noGit>
+#     <noGit>  "true" or "false" — whether --no-git was passed
+#
+# Stdout (for the agent to parse):
+#   forge=<github|bitbucket|unknown>
+#   branch=<current branch name>
+#   defaultBranch=<origin HEAD ref name>
+
+set -euo pipefail
+
+noGit="${1:?Usage: sync <noGit>  (true|false)}"
+case "$noGit" in
+  true|false) ;;
+  *) echo "sync: noGit must be 'true' or 'false', got '$noGit'" >&2; exit 2 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DO_RESULTS="$SKILL_DIR/do-results"
+
+startedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Fetch and pin origin/HEAD
+git fetch origin
+git remote set-head origin --auto >/dev/null
+
+# Fast-forward if behind upstream, unless --no-git
+if [ "$noGit" = "false" ]; then
+  if upstream="$(git rev-parse --abbrev-ref '@{u}' 2>/dev/null)"; then
+    behind="$(git rev-list --count "HEAD..$upstream" 2>/dev/null || echo 0)"
+    ahead="$(git rev-list --count "$upstream..HEAD" 2>/dev/null || echo 0)"
+    if [ "$behind" -gt 0 ] && [ "$ahead" -eq 0 ]; then
+      git pull --ff-only
+    fi
+  fi
+fi
+
+# Dirty-tree hint (no pause, just print)
+if [ "$noGit" = "false" ] && [ -n "$(git status --porcelain)" ]; then
+  echo "Dirty tree detected. Continuing will create a fresh branch on top of these changes. If you wanted the agent to extend your WIP in place without touching git, re-run with --no-git." >&2
+fi
+
+# Forge detection from origin URL
+origin_url="$(git remote get-url origin)"
+case "$origin_url" in
+  *github.com*)  forge="github" ;;
+  *bitbucket.*)  forge="bitbucket" ;;
+  *)             forge="unknown" ;;
+esac
+
+# Initialize results skeleton and record the sync step
+"$DO_RESULTS" init "$forge" "$noGit"
+"$DO_RESULTS" step sync passed \
+  "git fetch ok; forge=$forge; noGit=$noGit" \
+  "$startedAt" now
+
+# Emit structured facts the agent uses for downstream steps
+branch="$(git rev-parse --abbrev-ref HEAD)"
+default_ref="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || echo master)"
+
+echo "forge=$forge"
+echo "branch=$branch"
+echo "defaultBranch=$default_ref"


### PR DESCRIPTION
## Summary

Sync and done are the two `/do` steps that are pure plumbing — no model decisions, just git calls and timestamp math. The model was driving each through 3–5 sequential Bash round-trips, paying tool-loop latency for deterministic work.

Two new scripts under `.apm/skills/do/scripts/steps/`:

- **`sync <noGit>`** — fetch, fast-forward (unless `--no-git`), dirty-tree hint, forge classification, `do-results init` + `step sync`. Prints `forge=`, `branch=`, `defaultBranch=` on stdout for downstream steps.
- **`done`** — reads `.do-results.json`, emits the markdown timing table with >30% steps bolded, a slowest-step line, and a `<<<FACTS ... FACTS` block (`totalSeconds`, `slowestStep`, `dominantSteps`, `skippedSteps`, `failedSteps`) the model uses to compose optimization suggestions without re-parsing JSON.

`SKILL.md` is updated accordingly; the spec is unchanged, just delegated to the scripts.

Not scripted (discussed, intentionally left alone):

- `check` / `fmt` / `test` / `ci` — command varies per project, wrapping adds indirection without removing model work (still has to read CLAUDE.md instructions).
- `branch` / `commit` — mechanical parts are one-liners; naming/messaging needs the model.
- `research` / `hickey+lowy` / `implement` / `docs` — inherently model work.

## Test plan

- [x] Smoke tested `sync false` against a fresh clone — forge detected, results file initialized, sync step recorded with timestamps.
- [x] Smoke tested `sync false` against this worktree with a dirty tree — dirty-tree hint printed to stderr, branch/forge/defaultBranch emitted on stdout.
- [x] Fabricated a multi-step `.do-results.json` and ran `done` — table renders correctly, dominant steps (≥30%) bolded, slowest step highlighted, FACTS block lists skipped/dominant steps accurately.
- [ ] First real `/do` run on a follow-up task (next time one comes up) — confirm end-to-end flow with the new scripts.