### PR TITLE
fix: use "in parallel" + MUST trigger in use_parallel_tool_calls blocks

### DIFF
--- a/.apm/prompts/talk.prompt.md
+++ b/.apm/prompts/talk.prompt.md
@@ -71,7 +71,7 @@ If you're about to emit "probably", "almost certainly", "I suspect", "my #1 susp
 Any time the conversation produces a concrete code plan, diff proposal, or design sketch that could be implemented, **invoke the `hickey` and `lowy` sub-agents on that proposal before presenting your final recommendation** — do not wait for the user to ask. Fold findings into the recommendation (e.g. flag complecting, note where simplicity could be preserved, flag boundaries that track functionality instead of volatility) rather than dumping raw sub-agent output on top.
 
 <use_parallel_tool_calls>
-Invoke both `Agent(subagent_type="hickey")` and `Agent(subagent_type="lowy")` simultaneously in a single response. They are independent — do not wait for one before invoking the other. Do NOT use the `Skill` tool here: `Skill` calls serialize on the main loop, so two Skill invocations in one response still run sequentially. Dedicated sub-agents run concurrently and keep their (large) analysis contexts out of this conversation.
+For maximum efficiency, invoke `Agent(subagent_type="hickey")` and `Agent(subagent_type="lowy")` **in parallel** rather than sequentially. You MUST use parallel tool calls: emit both Agent tool_use blocks in a single response. Do NOT use the `Skill` tool here — `Skill` calls serialize on the main loop, so two Skill invocations in one response still run sequentially.
 </use_parallel_tool_calls>
 
 Skip the Hickey/Lowy pass only when the turn is pure Q&A with no proposed change (e.g. "how does X work?"). When in doubt, run it.

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -149,7 +149,7 @@ After the user confirms, continue autonomously from **hickey+lowy** (or the next
 Invoke `hickey` and `lowy` as two **parallel Claude Code sub-agents** via the `Agent` tool (`subagent_type: "hickey"` and `subagent_type: "lowy"`). Do NOT use the `Skill` tool for this step — `Skill` invocations serialize on the main conversation loop, so two back-to-back `Skill` calls run one after the other even when issued in the same response. Dedicated sub-agents run in isolated contexts and genuinely execute concurrently, cutting this step's wall-clock time roughly in half. Offloading their analysis into forked contexts also keeps the main context lean for the downstream implement/police/ci steps.
 
 <use_parallel_tool_calls>
-In a single response, make exactly two `Agent` tool calls — one with `subagent_type: "hickey"`, one with `subagent_type: "lowy"`. Do not include any other tool calls or text in that response.
+For maximum efficiency, invoke the `hickey` and `lowy` Agent tools **in parallel** rather than sequentially. You MUST use parallel tool calls: emit both `Agent` tool_use blocks (one with `subagent_type: "hickey"`, one with `subagent_type: "lowy"`) in a single response, with no other tool calls or text in that response.
 </use_parallel_tool_calls>
 
 Each `Agent` prompt must be self-contained (sub-agents do not inherit this conversation's context). Brief each one with:


### PR DESCRIPTION
## Summary

#80 shipped `hickey`/`lowy` as sub-agents and wrapped their invocation in `<use_parallel_tool_calls>`, but empirically they still run **serially** — Claude emits one `Agent` tool_use block, waits for it, then emits the second.

Root cause: the block body used "simultaneously" / "in a single response", but Claude Code's own Agent-tool description (the system prompt the model receives at runtime) conditionals on the literal phrase **"in parallel"**:

> When you launch multiple agents for independent work, send them in a single message with multiple tool uses so they run concurrently.
> **If the user specifies that they want you to run agents "in parallel", you MUST send a single message with multiple Agent tool use content blocks.**

Without those exact tokens, the model falls back to serial Task emission — a documented behavior bug tracked in [anthropics/claude-code#7406](https://github.com/anthropics/claude-code/issues/7406) ("Claude thinks it spawns agents in parallel, but it doesn't"). There is no flag, env var, or tool-level config to force it — only the prompt trigger.

## Fix

Rewrite both `<use_parallel_tool_calls>` blocks (`/do`'s hickey+lowy step and `/talk`'s Auto-Hickey+Auto-Lowy pass) to mirror the exact wording Anthropic ships in its reference multi-agent research prompt — [`anthropics/claude-cookbooks/patterns/agents/prompts/research_lead_agent.md`](https://github.com/anthropics/claude-cookbooks/blob/main/patterns/agents/prompts/research_lead_agent.md):

> For maximum efficiency, whenever you need to perform multiple independent operations, invoke all relevant tools simultaneously rather than sequentially. Call tools in parallel to run subagents at the same time. **You MUST use parallel tool calls** for creating multiple subagents…

Both trigger tokens (`in parallel`, `MUST`) now appear in each block.

## Test plan

- [ ] Next `/do` run through the hickey+lowy step: transcript shows two `Agent` tool_use blocks in **one** assistant message (same start timestamp), not two sequential messages.
- [ ] Same verification for `/talk`'s Auto-Hickey+Auto-Lowy pass on a concrete code plan.
- [ ] Wall-clock for the step ≈ max(hickey, lowy) rather than sum.
- [ ] `/hickey` and `/lowy` slash commands still work unchanged (skills untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)