### PR TITLE
feat(lowy): add project-specific volatility axes hook

### DIFF
--- a/.apm/skills/lowy/SKILL.md
+++ b/.apm/skills/lowy/SKILL.md
@@ -43,6 +43,13 @@ For every module boundary, service split, or new abstraction in the code under r
 
 What is likely to change behind this boundary? Be specific — not "requirements might change" but "the payment provider, the auth protocol, the notification channel." If you can't name concrete axes of change, the boundary may be arbitrary.
 
+**Consider project-declared axes.** If a project instruction surfaces with axes the project already knows are volatile, treat each one as a candidate to check against the boundaries under review. These are declared by the project and delivered via a `paths:`-scoped rule (conventionally `lowy-axes`) that becomes a system-reminder when you read a matching file. The canonical schema is:
+
+| Axis | What changes | Why volatile | Expected encapsulation |
+|------|--------------|--------------|-----------------------|
+
+Rows in that table are not findings — they are the project's prior claims about where change lives. Your job is to check whether the boundaries under review actually encapsulate those axes, or leak them.
+
 **Speculative volatility is not volatility.** A change scenario counts only if it has happened before, is on a roadmap, or is a near-certain consequence of the domain (e.g. "payment providers change" in e-commerce). "What if we swap color spaces" in an app that has never swapped color spaces is speculation, not an axis of change. Lowy's framework is about *observed* or *plausible* volatility — designing for hypothetical change is over-engineering, not encapsulation.
 
 **Weak volatility may not deserve its own boundary.** Some volatilities are real but too minor to justify a separate component. Lowy's example: notification delivery might be volatile, but if the system already has a message bus utility, a dedicated NotificationManager adds complexity without containing meaningful additional change. Ask: does this volatility justify the cost of an additional boundary, or can it be folded into an existing one?

--- a/.apm/skills/lowy/SKILL.md
+++ b/.apm/skills/lowy/SKILL.md
@@ -43,12 +43,12 @@ For every module boundary, service split, or new abstraction in the code under r
 
 What is likely to change behind this boundary? Be specific — not "requirements might change" but "the payment provider, the auth protocol, the notification channel." If you can't name concrete axes of change, the boundary may be arbitrary.
 
-**Consider project-declared axes.** If a project instruction surfaces with axes the project already knows are volatile, treat each one as a candidate to check against the boundaries under review. These are declared by the project and delivered via a `paths:`-scoped rule (conventionally `lowy-axes`) that becomes a system-reminder when you read a matching file. The canonical schema is:
+**Consider project-declared areas of volatility.** If the project has enumerated its own areas of volatility — the term of art Lowy uses throughout *Righting Software* — those declarations surface as system-reminders when you read a matching file (Claude Code's `paths:`-scoped rule mechanism; it is wiring, not Lowy doctrine). The schema, loosely modeled on Lowy's TradeMe enumeration (*Righting Software*, Ch. 5), is:
 
-| Axis | What changes | Why volatile | Expected encapsulation |
-|------|--------------|--------------|-----------------------|
+| Area of volatility | What changes | Why volatile (likelihood × effect) | Expected encapsulation |
+|--------------------|--------------|------------------------------------|------------------------|
 
-Rows in that table are not findings — they are the project's prior claims about where change lives. Your job is to check whether the boundaries under review actually encapsulate those axes, or leak them.
+Rows in that table are **surviving candidates** after the project's own variable-vs-volatile screen (see §"Variable vs. Volatile" above). They are not findings, and they are not above review. Do two things with each row: (a) re-apply Lowy's bar — _"state what the volatility is, why it is volatile, and what risk the volatility poses in terms of likelihood and effect"_ — and challenge any row that fails it (Lowy: _"It is important to discuss the volatility candidates this way and even challenge them"_); (b) audit whether the boundaries under review actually encapsulate the surviving volatilities in a single component, rather than spraying or leaking them across modules.
 
 **Speculative volatility is not volatility.** A change scenario counts only if it has happened before, is on a roadmap, or is a near-certain consequence of the domain (e.g. "payment providers change" in e-commerce). "What if we swap color spaces" in an app that has never swapped color spaces is speculation, not an axis of change. Lowy's framework is about *observed* or *plausible* volatility — designing for hypothetical change is over-engineering, not encapsulation.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,44 @@ Data fetching must go through server functions, never direct API calls from comp
 
 These get checked alongside the built-in rules during the police pass.
 
+### 4. Add project-specific structural review vectors (optional)
+
+`hickey` and `lowy` ship with generic catalogs. Extend them with project-specific vectors by dropping an `.apm/instructions/*.instructions.md` file with an `applyTo:` glob. APM generates a `paths:`-scoped rule under `.claude/rules/`, and Claude Code auto-surfaces it as a system-reminder to the hickey/lowy subagent the moment it reads a matching file — no `/do` plumbing, no prompt wiring.
+
+**Hickey (complecting patterns).** Extends the Layer 4 catalog. File name is conventionally `hickey-catalog.instructions.md`. Schema:
+
+```markdown
+---
+description: Project-specific complecting patterns
+applyTo: "packages/client/src/**"
+---
+
+## Additional Complecting Patterns
+
+| Construct | What it complects | Simpler alternative |
+|-----------|-------------------|---------------------|
+| `createEffect` that writes to signals (effect-as-state-machine) | When + what + control flow | `createMemo` for derived values; `on()` for explicit dependency tracking |
+```
+
+**Lowy (volatility axes).** Consumed in the "Name the Volatility" step. File name is conventionally `lowy-axes.instructions.md`. Schema:
+
+```markdown
+---
+description: Project-specific volatility axes
+applyTo: "packages/client/src/**"
+---
+
+## Volatility Axes
+
+| Axis | What changes | Why volatile | Expected encapsulation |
+|------|--------------|--------------|-----------------------|
+| Reactive-owner lifecycle | Ownership/cleanup conventions across SolidJS versions | Framework-controlled; patterns shift between releases | Behind a `createSubscription`-like seam or a single root; never hand-rolled per component |
+```
+
+Rows are not findings — they declare where the project already knows change lives. The subagent checks whether the boundaries under review actually encapsulate those axes.
+
+See [Kolu's `agents/.apm/instructions/hickey-catalog.instructions.md`](https://github.com/juspay/kolu/blob/master/agents/.apm/instructions/hickey-catalog.instructions.md) for a worked example.
+
 ### Putting it together
 
 Your project's `.apm/` directory ends up looking something like:

--- a/README.md
+++ b/README.md
@@ -126,24 +126,24 @@ applyTo: "packages/client/src/**"
 | `createEffect` that writes to signals (effect-as-state-machine) | When + what + control flow | `createMemo` for derived values; `on()` for explicit dependency tracking |
 ```
 
-**Lowy (volatility axes).** Consumed in the "Name the Volatility" step. File name is conventionally `lowy-axes.instructions.md`. Schema:
+**Lowy (areas of volatility).** Consumed in the "Name the Volatility" step. File name is conventionally `lowy-volatilities.instructions.md`. Schema is loosely based on Lowy's TradeMe enumeration in *Righting Software* Ch. 5:
 
 ```markdown
 ---
-description: Project-specific volatility axes
+description: Project-declared areas of volatility
 applyTo: "packages/client/src/**"
 ---
 
-## Volatility Axes
+## Areas of Volatility
 
-| Axis | What changes | Why volatile | Expected encapsulation |
-|------|--------------|--------------|-----------------------|
-| Reactive-owner lifecycle | Ownership/cleanup conventions across SolidJS versions | Framework-controlled; patterns shift between releases | Behind a `createSubscription`-like seam or a single root; never hand-rolled per component |
+| Area of volatility | What changes | Why volatile (likelihood × effect) | Expected encapsulation |
+|--------------------|--------------|------------------------------------|------------------------|
+| Server-pushed state delivery | Transport for live server state (polling RPC → WebSocket → oRPC async iterables → future SSE/RSC) | Likelihood: already migrated twice in this codebase; Effect: every consumer of live state would need rewriting if the transport leaked into components | Behind the `createSubscription` seam — consumers see a SolidJS-signal-shaped API regardless of transport |
 ```
 
-Rows are not findings — they declare where the project already knows change lives. The subagent checks whether the boundaries under review actually encapsulate those axes.
+Each row must pass Lowy's variable-vs-volatile bar — *state what the volatility is, why it is volatile, and what risk it poses in likelihood and effect*. Rows are not findings; they are surviving candidates from the project's own screen. The subagent re-applies the bar, challenges rows that fail it, and audits whether boundaries under review actually encapsulate the surviving volatilities (adapting Lowy's Manager/Engine/Resource targeting to whatever encapsulation vocabulary fits the stack — `createSubscription` seams, hook modules, etc.).
 
-See [Kolu's `agents/.apm/instructions/hickey-catalog.instructions.md`](https://github.com/juspay/kolu/blob/master/agents/.apm/instructions/hickey-catalog.instructions.md) for a worked example.
+See [Kolu's `agents/.apm/instructions/hickey-catalog.instructions.md`](https://github.com/juspay/kolu/blob/master/agents/.apm/instructions/hickey-catalog.instructions.md) for a worked hickey-side example.
 
 ### Putting it together
 


### PR DESCRIPTION
Closes #84.

`/hickey` has long let projects extend its Layer 4 catalog — Kolu drops an `hickey-catalog.instructions.md` with an `applyTo:` glob, APM generates a `paths:`-scoped rule, and Claude Code auto-surfaces it as a system-reminder the moment the hickey subagent reads a matching file. No skill edit, no `/do` wiring, no per-PR reminders. It just works.

`/lowy` had no equivalent. This PR gives it one, in the least-intrusive form possible: a few sentences inside **Step 1: Name the Volatility** that tell the reviewer to treat project-declared axes as candidates, plus the canonical schema (*Axis | What changes | Why volatile | Expected encapsulation*) so rows can be machine-recognized. Rows aren't findings — they're the project's prior claims about where change lives, and the reviewer's job is to check whether the boundaries under review actually encapsulate them or leak them.

The README gets a new §4 under Usage that documents both conventions side-by-side — hickey catalog and lowy axes — with copy-pasteable frontmatter + schema and a link to Kolu's live `hickey-catalog.instructions.md` as the worked example. A project that already understands the hickey convention can extend to lowy by analogy in about a minute.

**Deliberately not changing:** `/do`. The delivery path is the `paths:`-scoped system-reminder mechanism Claude Code applies automatically when a subagent reads a matching file. Hickey proves it works end-to-end without any prompt plumbing; lowy rides the same rail.

## Test plan

- [ ] `apm install -t claude` regenerates `.claude/skills/lowy/SKILL.md` with the new Step 1 language
- [ ] Drop a `.apm/instructions/lowy-axes.instructions.md` in Kolu, regenerate, run `/do` on a change that touches `packages/client/src/**`, and confirm the `lowy-axes.md` rule surfaces as a system-reminder in the lowy subagent's transcript
- [ ] Review rendered README §4 on GitHub for copy/paste clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)