### PR TITLE
fix(do): bookend steps with step-start/step-end for real per-step timing

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -23,7 +23,7 @@ The workflow is **forge-aware**: it auto-detects whether the repo lives on GitHu
 
 ## Results Tracking
 
-After each step's verification, record results via the `scripts/do-results` script (in this skill's directory). The script manages a JSON file with this schema:
+Each step is bookended by two calls to the `scripts/do-results` script (in this skill's directory): `step-start <name>` before the work begins, and `step-end <status> <verification> [reason]` after verification. This is what keeps per-step timing accurate — collapsing both into a single end-of-step call produces zero-second durations and worthless timing tables. The script manages a JSON file with this schema:
 
 ```json
 {
@@ -53,10 +53,13 @@ After each step's verification, record results via the `scripts/do-results` scri
 - Set `status` to `"completed"` when **done** is reached, or `"failed"` if halted. This field is informational only.
 - **Always use the `scripts/do-results` script** (in this skill's directory, alongside `scripts/steps/`) — never write the JSON file directly. Invoke with the full path (e.g. `.../skills/do/scripts/do-results ...`). Commands:
   - **Initialize**: `scripts/do-results init <forge> <noGit>` — creates the skeleton with a timestamp
-  - **Record a step**: `scripts/do-results step <name> <status> "<verification>" <startedAt> <completedAt> ["<reason>"]` — pass `now` for either timestamp to auto-generate the current UTC time
+  - **Start a step**: `scripts/do-results step-start <name>` — stamps `pendingStep` with the current UTC time. Call this **before** doing the step's work.
+  - **End a step**: `scripts/do-results step-end <status> "<verification>" ["<reason>"]` — pops `pendingStep` and appends the completed step with `completedAt` set to the current UTC time.
+  - **Record a step in one call** (advanced): `scripts/do-results step <name> <status> "<verification>" <startedAt> <completedAt> ["<reason>"]` — used by `scripts/steps/sync` where `startedAt` is captured in shell. Agent code should prefer `step-start` / `step-end`.
   - **Update top-level field**: `scripts/do-results set <field> <value>` (e.g., `set active waiting`, `set status completed`)
   - **Patch last step**: `scripts/do-results patch-last <field> <value>` (e.g., `patch-last completedAt "2026-..."`)
-- Pass `now` as a timestamp argument to `scripts/do-results step` — the script resolves it to UTC internally. Do not run `date` yourself or guess timestamps.
+- **Bookend every step with `step-start` at the top and `step-end` at the bottom.** Calling `step-end` without a prior `step-start` is an error, and calling `step` with `now` for both timestamps collapses duration to 0 — neither pattern is allowed. The only exceptions: `sync` is recorded by `scripts/steps/sync` itself, and skipped steps (where duration is always 0 by definition) may use `step-start` followed immediately by `step-end` with status `skipped`.
+- Do not run `date` yourself or guess timestamps — `do-results` resolves the current UTC time internally.
 
 ## Progress tracking
 
@@ -73,7 +76,7 @@ Rules:
 - **Flip to `in_progress` when a step starts, `completed` when it verifies.** One step `in_progress` at a time.
 - **Retries stay `in_progress`.** If `check`, `test`, or `ci` loop through their retry budget, do **not** bounce the task state back to `pending` or flicker it — leave it `in_progress` until the step finally verifies (or the retries exhaust and the workflow fails).
 - **`--from <step>` entry points**: still seed all 14 steps. Mark steps earlier than the entry point as `completed` immediately after seeding, so the checklist shows a consistent 14-item view regardless of entry point.
-- **Skipped steps** (e.g. `branch`/`commit`/`create-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. The skip reason is recorded via `scripts/do-results step <name> skipped ... "<reason>"`; the task list just shows the step as done.
+- **Skipped steps** (e.g. `branch`/`commit`/`create-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. Record the skip with a back-to-back `scripts/do-results step-start <name>` / `scripts/do-results step-end skipped ... "<reason>"`; the task list just shows the step as done.
 - **Failure**: if retries exhaust and the workflow halts, leave the failing step `in_progress`, mark `done` `completed` after the failure summary is written, and run `scripts/do-results set status failed`.
 
 ## Steps

--- a/.apm/skills/do/scripts/do-results
+++ b/.apm/skills/do/scripts/do-results
@@ -4,8 +4,12 @@
 #
 # Usage:
 #   do-results init <forge> <noGit>           — create initial skeleton
+#   do-results step-start <name>              — stamp pendingStep with now; call at step start
+#   do-results step-end <status> <verif> [reason]
+#                                             — pop pendingStep, append with completedAt=now
 #   do-results step <name> <status> <verif> <startedAt> <completedAt> [reason]
-#                                             — append a completed step
+#                                             — append a completed step with explicit timestamps
+#                                               (use when startedAt comes from a single-shell caller)
 #                                               pass "now" for startedAt/completedAt to auto-generate UTC timestamp
 #   do-results set <field> <value>            — update a top-level field (active, status)
 #   do-results patch-last <field> <value>     — patch a field on the last step
@@ -21,7 +25,7 @@ fi
 
 FILE=".do-results.json"
 
-cmd="${1:?Usage: do-results <init|step|set|patch-last> ...}"
+cmd="${1:?Usage: do-results <init|step-start|step-end|step|set|patch-last> ...}"
 shift
 
 case "$cmd" in
@@ -40,6 +44,44 @@ case "$cmd" in
   "steps": []
 }
 ENDJSON
+    ;;
+
+  step-start)
+    name="${1:?name required}"
+    startedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    existing="$($JQ -r '.pendingStep.name // empty' "$FILE")"
+    if [ -n "$existing" ]; then
+      echo "do-results: overwriting stale pendingStep '$existing' — step-end was not called" >&2
+    fi
+    $JQ --arg n "$name" --arg sa "$startedAt" \
+       '.pendingStep = {"name":$n,"startedAt":$sa}' \
+       "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+    ;;
+
+  step-end)
+    status="${1:?status required (passed|failed|skipped)}"
+    verif="${2:?verification required}"
+    reason="${3:-}"
+    completedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    name="$($JQ -r '.pendingStep.name // empty' "$FILE")"
+    startedAt="$($JQ -r '.pendingStep.startedAt // empty' "$FILE")"
+    if [ -z "$name" ] || [ -z "$startedAt" ]; then
+      echo "do-results: no pendingStep — call step-start first" >&2
+      exit 1
+    fi
+
+    if [ -n "$reason" ]; then
+      $JQ --arg n "$name" --arg s "$status" --arg v "$verif" \
+         --arg sa "$startedAt" --arg ca "$completedAt" --arg r "$reason" \
+         '.steps += [{"name":$n,"status":$s,"verification":$v,"startedAt":$sa,"completedAt":$ca,"reason":$r}] | del(.pendingStep)' \
+         "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+    else
+      $JQ --arg n "$name" --arg s "$status" --arg v "$verif" \
+         --arg sa "$startedAt" --arg ca "$completedAt" \
+         '.steps += [{"name":$n,"status":$s,"verification":$v,"startedAt":$sa,"completedAt":$ca}] | del(.pendingStep)' \
+         "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+    fi
     ;;
 
   step)
@@ -86,7 +128,7 @@ ENDJSON
 
   *)
     echo "Unknown command: $cmd" >&2
-    echo "Usage: do-results <init|step|set|patch-last> ..." >&2
+    echo "Usage: do-results <init|step-start|step-end|step|set|patch-last> ..." >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

The `/do` timing table has been showing 0s per-step durations because the LLM loop called `do-results step ... now now` only at the end of each step, collapsing `startedAt` and `completedAt` to the same instant. The `sync` step didn't have this problem because `scripts/steps/sync` runs in a single shell and captures `startedAt` in a bash variable — but regular steps span many LLM turns and can't hold a timestamp that way.

This PR adds a stateful `step-start` / `step-end` pair to `scripts/do-results`:

- `step-start <name>` stamps `pendingStep` with the current UTC time in `.do-results.json`.
- `step-end <status> "<verification>" ["<reason>"]` pops `pendingStep` and appends the completed step with `completedAt` set to the current UTC time.

`SKILL.md` now tells the agent to bookend every step, and spells out why the old single-call pattern produced zero-second durations. The advanced `step <name> <status> <verif> <startedAt> <completedAt>` command stays in place — it's still the right fit for `scripts/steps/sync`, which captures its own `startedAt` in shell.

Reported in juspay/kolu#592 (comment [4264872988](https://github.com/juspay/kolu/pull/592#issuecomment-4264872988)).

## Test plan

- [x] `step-start` + sleep + `step-end` records distinct startedAt/completedAt
- [x] `step-end` without a preceding `step-start` exits 1 with a clear error
- [x] `step-start` over an existing `pendingStep` warns to stderr and overwrites
- [x] `scripts/steps/done` renders non-zero durations from the new state
- [x] Existing `step` command still works for `scripts/steps/sync`'s single-call path