### PR TITLE
perf(do,talk): cut main-context reads in research phases

### DIFF
--- a/.apm/prompts/talk.prompt.md
+++ b/.apm/prompts/talk.prompt.md
@@ -23,7 +23,7 @@ Talk mode is a research-first workflow, not an off-the-cuff conversation. Before
 
 ### First-turn gate
 
-Your first substantive response must not contain recommendations, fixes, "suspects," or claims about third-party library behavior unless you have **already read the relevant source in this session**. If you haven't yet, your first response is the research itself (a plan + the reads), not an answer. Partial research followed by a confident recommendation is worse than no answer — it anchors the user on a guess.
+Your first substantive response must not contain recommendations, fixes, "suspects," or claims about third-party library behavior unless you have **already read the relevant source in this session**. If you haven't yet, your first response is the research itself — normally a single `Agent(subagent_type=Explore)` call. Direct `Read`s in the main turn are allowed only for narrow, single-file lookups you can name up front. Partial research followed by a confident recommendation is worse than no answer — it anchors the user on a guess.
 
 ### When to use the Explore subagent
 
@@ -38,7 +38,7 @@ For narrow, single-file lookups, `Grep`/`Read` directly is fine. The line is: if
 
 **When the source isn't on disk.** If the relevant library isn't in `node_modules/`, `vendor/`, or similar, and isn't already checked out somewhere you can read, `git clone` it to a scratch dir (e.g. `/tmp/<name>`) at the version the project actually uses, then read it there. Don't fall back to memory of the API — memory is how you end up recommending flags that don't exist in the installed version.
 
-**Subagent output is a lead, not ground truth.** Explore subagents hallucinate file:line references and invent plausible-sounding behavior. Before citing any specific claim a subagent made about a file:line, function signature, or control flow, open the file yourself and verify. If you haven't verified it, either verify now or mark the claim as "per subagent, unverified" so the user can weigh it — don't launder subagent guesses into confident statements.
+**Subagent output is a lead, not ground truth.** Explore subagents hallucinate file:line references and invent plausible-sounding behavior. If you haven't verified a claim yourself, mark it "per subagent, unverified" so the user can weigh it — don't launder subagent guesses into confident statements.
 
 ### Citation requirement
 

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -112,11 +112,18 @@ The script:
 Research the task thoroughly before writing code.
 
 - If given a GitHub issue URL **and** `forge == github`, fetch with `gh issue view`. On non-GitHub forges, treat any issue-like URL as opaque context — use the prompt text as-is and do not attempt to fetch. (Bitbucket issue/Jira fetching is tracked in #10.)
-- Use Explore subagents, Grep, Glob, Read — whatever it takes to understand the problem
 - **Never assume** how something works. Read the code. Check the config.
-- If the prompt involves external tools/libraries, use WebSearch/WebFetch
+- If the prompt involves external tools/libraries, use WebSearch/WebFetch.
 
-**Verify**: Can articulate what needs to change, where, and why.
+**Delegation rule — keep the main context lean.** Before your third `Read` in this step, stop and delegate the rest via `Agent(subagent_type=Explore)`. Main-context reads are reserved for:
+
+  (a) specific files the user named in the prompt,
+  (b) `.apm/instructions/**` and files referenced from them,
+  (c) verifying a specific file:line an Explore subagent cited — and only with `offset`/`limit`, never full-file.
+
+Anything that smells like "map the codebase", "find all callers", "understand how X works across the repo" — delegate. The Explore subagent returns a file:line map; keep that map and reference it in later steps instead of re-reading. Use `Grep`/`Glob` before `Read`: if the question can be answered by searching, don't open the file.
+
+**Verify**: Can articulate what needs to change, where, and why, with file:line citations drawn from the research map (not re-read in main context).
 
 ---
 


### PR DESCRIPTION
## Why

In a real `/do` session on Kolu, the **research** step alone pulled **~67k tokens via 25+ full-file `Read` calls in the main Opus context** — a third of a 1M-token window burned before `implement` even started. The loophole was the old bullet in `/do`'s research step:

> Use Explore subagents, Grep, Glob, Read — whatever it takes to understand the problem

"Whatever it takes" lets Opus choose the expensive path. The subagents were *not* the problem — they already run in isolated contexts and return only summaries. The problem was that the main agent never had a reason to delegate.

`/talk` has a similar leak, smaller in practice: the citation-verification clause says *"open the file yourself and verify"*, which in practice materialises as a full-file `Read` in the main turn. The "mark as unverified" fallback already covers the honesty requirement without that instruction.

## What changes

**`/do` research step** — adds a *delegation budget*:

- Before the third `Read` in research, stop and delegate the rest to `Agent(subagent_type=Explore)`.
- Main-context reads are reserved for (a) files the user named, (b) `.apm/instructions/**`, (c) `offset`/`limit` verification of a subagent-cited file:line — never full-file.
- "Map the codebase / find callers / understand how X works" — always delegate.
- Explore subagent returns a file:line map; later steps reference that map instead of re-reading.

**`/talk`**:

- First-turn gate now nudges toward a single `Agent(Explore)` call; main-turn `Read`s only for narrow, named single-file lookups.
- Drop the "open the file yourself and verify" clause from the subagent-lead warning. The companion "mark as unverified" fallback already preserves honesty, and the old phrasing was turning into an excuse for full-file re-reads in main.

## Expected impact

On the session that motivated this: if the delegation rule had been in force, ~50k tokens of raw client-source reads would have stayed inside the Explore subagent, with a ~2–5k summary returning to main. That closes most of the `/context` "file reads using 89k (9%)" gap — more than dedup alone could.

## Test plan

- [ ] Run `/do` on a non-trivial task and confirm research phase uses ≤2 direct `Read`s in main context before invoking Explore.
- [ ] Run `/talk` on a third-party-library question and confirm no full-file `Read` gets issued in the main turn; verification happens via offset/limit or subagent.
- [ ] Compare `/context` file-reads bucket before/after on a comparable workflow run.