### PR TITLE
feat(do): lead hickey/lowy PR comment with a findings ledger

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -300,6 +300,25 @@ Check whether a PR already exists for this branch (`gh pr view`).
 
 2. **Post hickey/lowy results**: Post the hickey and lowy analysis as a PR comment using `gh pr comment` with a `## Hickey/Lowy Analysis` header. Always post when the steps ran, even if all findings are deferred or out of scope — reviewers should see the structural analysis.
 
+   **Format the comment with a leading findings ledger.** Compose a single table from both sub-agents' Actions sections — one row per finding — so a reviewer can see disposition at a glance without parsing paragraphs. Put each lens's prose underneath as rationale:
+
+   ```md
+   ## Hickey/Lowy Analysis
+
+   | # | Lens   | Finding                                  | Disposition       |
+   |---|--------|------------------------------------------|-------------------|
+   | 1 | Hickey | viewportDimensions complects two roles   | Fixed in this PR  |
+   | 2 | Lowy   | useViewport encapsulates ghost concern   | Deferred [#123]   |
+
+   ### Hickey rationale
+   <prose from the hickey sub-agent>
+
+   ### Lowy rationale
+   <prose from the lowy sub-agent>
+   ```
+
+   The Disposition cell mirrors the sub-agent's Actions disposition verbatim — **Fixed in this PR**, **Deferred [#N]** (linked), or **No-op** (deletion-only / subsumed by another finding). The Finding cell is the short bolded label the sub-agent emits at the start of each Actions entry. If both lenses produced zero findings, write a one-line "No findings — analysis below" instead of an empty table.
+
 **If PR already exists** (followup runs, `--from` entry points):
 
 Re-check the PR title/body against current scope. If scope changed, update via `gh pr edit` per the `forge-pr` skill.

--- a/.apm/skills/hickey/SKILL.md
+++ b/.apm/skills/hickey/SKILL.md
@@ -164,9 +164,13 @@ If fact-check finds issues with your evaluation, revise before presenting to the
 5. **Severity** — For each finding: blast radius, change friction, reasoning load.
 6. **Simplifications** — Concrete alternative for every finding.
 7. **Fact-check result** — Output of `/fact-check` on this evaluation, including the phrase-shape check.
-8. **Actions** — One entry per finding. **Every finding from every layer must appear here** — including findings labeled "pre-existing", "orthogonal", or "not introduced by this PR". A finding that never reaches this section has been dismissed, not deferred. Each must be dispositioned as exactly one of:
+8. **Actions** — One entry per finding, formatted so a downstream step (e.g. `/do`'s PR comment composer) can lift each entry into a table row. **Every finding from every layer must appear here** — including findings labeled "pre-existing", "orthogonal", or "not introduced by this PR". A finding that never reaches this section has been dismissed, not deferred.
+
+   Each entry **starts with a short bolded finding label (≤8 words)** that names *what* is wrong, then dispositions it as exactly one of:
    - **Fix in this PR**: one-line description of what the implementation step must do. This is the default — prefer it.
    - **Defer `#<issue-number>`**: create a GitHub/forge issue for the finding first, then reference it here. "Out of scope" without an issue link is a dismissal, not a deferral. If you can't be bothered to create the issue, the finding belongs in this PR. **When running autonomously (via `/do`)**, you MUST actually create the issue (`gh issue create` or equivalent) before writing the Defer entry — do not leave it for the user. When running interactively, you may prompt the user to create the issue.
+
+   Example: `**viewportDimensions complects current+default roles** — Fix in this PR: delete the signal, replace with per-tile FitAddon measurement.`
 
    "No findings" → "No actions." But if findings exist and the actions list is empty, the evaluation is incomplete.
 

--- a/.apm/skills/lowy/SKILL.md
+++ b/.apm/skills/lowy/SKILL.md
@@ -122,7 +122,9 @@ If fact-check finds issues, revise before presenting to the user.
 3. **Findings** — Boundaries that track functionality rather than volatility, with blast-radius analysis. Include symmetry violations and layering inversions.
 4. **Simplifications** — Concrete restructuring to align boundaries with axes of change.
 5. **Fact-check result** — Output of `/fact-check` on this evaluation, including the phrase-shape check.
-6. **Actions** — One entry per finding: **Fix in this PR** or **Defer `#<issue>`**. Every finding must appear here — including those labeled "pre-existing" or "orthogonal". A finding that never reaches this section has been dismissed, not deferred.
+6. **Actions** — One entry per finding, formatted so a downstream step (e.g. `/do`'s PR comment composer) can lift each entry into a table row. Each entry **starts with a short bolded finding label (≤8 words)** naming *what* is wrong, then dispositions it as **Fix in this PR** or **Defer `#<issue>`**. Every finding must appear here — including those labeled "pre-existing" or "orthogonal". A finding that never reaches this section has been dismissed, not deferred.
+
+Example: `**useViewport encapsulates ghost concern** — Fix in this PR: delete the hook, let FitAddon measure per-tile.`
 
 No findings → "No actions." Findings without actions = incomplete review.
 


### PR DESCRIPTION
**The hickey/lowy PR comment is rich prose but skips the per-finding disposition** that both skills already mandate in their Output Format. A reviewer can't tell at a glance which findings the agent fixed vs deferred without parsing paragraphs — see [juspay/kolu#631](https://github.com/juspay/kolu/pull/631#issuecomment-4275954849), where the only structural cue is one trailing blockquote.

Lead the comment with a **Findings ledger table** composed from each sub-agent's Actions section, then put each lens's prose underneath as rationale. To make the table mechanical to compose, the hickey/lowy Output Format now requires each Action entry to start with a short bolded finding label (≤8 words) — a one-line contract change, no schema migration.

> The Disposition cell mirrors the sub-agent's Actions disposition verbatim — **Fixed in this PR**, **Deferred [#N]** (linked), or **No-op**. _Lens columns surface scope without prose-parsing; the prose stays for reviewers who want the structural argument._

🤖 Generated with [Claude Code](https://claude.com/claude-code)