### PR TITLE
Remove do-results patch-last

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -58,7 +58,6 @@ Each step is bookended by two calls to the `scripts/do-results` script (in this 
   - **End a step**: `scripts/do-results step-end <status> "<verification>" ["<reason>"]` — pops `pendingStep` and appends the completed step with `completedAt` set to the current UTC time.
   - **Record a step in one call** (advanced): `scripts/do-results step <name> <status> "<verification>" <startedAt> <completedAt> ["<reason>"]` — used by `scripts/steps/sync` where `startedAt` is captured in shell. Agent code should prefer `step-start` / `step-end`.
   - **Update top-level field**: `scripts/do-results set <field> <value>` (e.g., `set active waiting`, `set status completed`)
-  - **Patch last step**: `scripts/do-results patch-last <field> <value>` (e.g., `patch-last completedAt "2026-..."`)
 - **Bookend every step with `step-start` at the top and `step-end` at the bottom.** Calling `step-end` without a prior `step-start` is an error, and calling `step` with `now` for both timestamps collapses duration to 0 — neither pattern is allowed. The only exceptions: `sync` is recorded by `scripts/steps/sync` itself, and skipped steps (where duration is always 0 by definition) may use `step-start` followed immediately by `step-end` with status `skipped`.
 - Do not run `date` yourself or guess timestamps — `do-results` resolves the current UTC time internally.
 

--- a/.apm/skills/do/scripts/do-results
+++ b/.apm/skills/do/scripts/do-results
@@ -12,7 +12,6 @@
 #                                               (use when startedAt comes from a single-shell caller)
 #                                               pass "now" for startedAt/completedAt to auto-generate UTC timestamp
 #   do-results set <field> <value>            — update a top-level field (active, status)
-#   do-results patch-last <field> <value>     — patch a field on the last step
 
 set -euo pipefail
 
@@ -25,7 +24,7 @@ fi
 
 FILE=".do-results.json"
 
-cmd="${1:?Usage: do-results <init|step-start|step-end|step|set|patch-last> ...}"
+cmd="${1:?Usage: do-results <init|step-start|step-end|step|set> ...}"
 shift
 
 case "$cmd" in
@@ -120,15 +119,9 @@ ENDJSON
     fi
     ;;
 
-  patch-last)
-    field="${1:?field required}"
-    value="${2:?value required}"
-    $JQ --arg f "$field" --arg v "$value" '.steps[-1][$f] = $v' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
-    ;;
-
   *)
     echo "Unknown command: $cmd" >&2
-    echo "Usage: do-results <init|step-start|step-end|step|set|patch-last> ..." >&2
+    echo "Usage: do-results <init|step-start|step-end|step|set> ..." >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
#95 

## Summary

- Remove the do-results patch-last command that could mutate the most recent completed step after the fact
- Update /do workflow docs so the command list matches the script

## Verification

- Confirmed no patch-last references remain in /do docs or script
- Ran do-results with an unknown command and confirmed usage now omits patch-last