### PR TITLE
Fix do-stop-guard output for Codex Stop hook schema

### DIFF
--- a/.apm/hooks/scripts/do-stop-guard.sh
+++ b/.apm/hooks/scripts/do-stop-guard.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# Prevents Claude from stopping while /do workflow is still running.
-# Reads .do-results.json and blocks the stop if active == true.
+# Prevents the agent from stopping while /do workflow is still running.
+# Reads .do-results.json and blocks the stop if active == "working".
+# Output shape is cross-compatible with Claude Code and Codex: only
+# `{"decision":"block","reason":"…"}` is emitted for the block case, and
+# empty stdout is used for the approve case (Codex rejects `decision:"approve"`).
 # Safe default: if the file exists but can't be parsed, block (not approve).
 results="$CLAUDE_PROJECT_DIR/.do-results.json"
 if [ ! -f "$results" ]; then
-  echo '{"decision":"approve"}'
   exit 0
 fi
 active=$(jq -r '.active // empty' "$results" 2>/dev/null) || active="parse_error"
@@ -12,13 +14,9 @@ case "$active" in
   working)
     echo '{"decision":"block","reason":"/do workflow still running — continue from where you left off. Check .do-results.json for current progress."}'
     ;;
-  waiting)
-    echo '{"decision":"approve","reason":"/do workflow is waiting for an external process (e.g. CI). Safe to stop — resume later with --from ci-only."}'
-    ;;
   parse_error)
     echo '{"decision":"block","reason":"Could not parse .do-results.json — file may be corrupted. Check and fix it before stopping."}'
     ;;
   *)
-    echo '{"decision":"approve"}'
     ;;
 esac

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -50,7 +50,7 @@ Each step is bookended by two calls to the `scripts/do-results` script (in this 
 - `noGit` is `true` if the user passed `--no-git`. When set, git-mutating steps (**branch**, **commit**, **create-pr**) record status `skipped` with reason `"--no-git"`.
 - Step `status` is one of `passed`, `failed`, or `skipped`. A `skipped` step must include a `reason` field explaining why (e.g., `"non-github forge: bitbucket"`, `"--no-git"`, `"no check command configured"`).
 
-- `active` is a state enum, not a boolean. Set it to `"working"` when the workflow starts (**sync**), `"waiting"` when the agent is idle waiting for an external process (e.g., background CI), back to `"working"` when the external process returns, and `false` when the workflow ends (**done**). The stop hook uses this field: `"working"` blocks exits, `"waiting"` allows them (with a resume hint), `false` allows them.
+- `active` is a state enum, not a boolean. Set it to `"working"` when the workflow starts (**sync**), `"waiting"` when the agent is idle waiting for an external process (e.g., background CI), back to `"working"` when the external process returns, and `false` when the workflow ends (**done**). The stop hook uses this field: `"working"` blocks exits; `"waiting"` and `false` allow them.
 - Set `status` to `"completed"` when **done** is reached, or `"failed"` if halted. This field is informational only.
 - **Always use the `scripts/do-results` script** (in this skill's directory, alongside `scripts/steps/`) — never write the JSON file directly. Invoke with the full path (e.g. `.../skills/do/scripts/do-results ...`). Commands:
   - **Initialize**: `scripts/do-results init <forge> <noGit>` — creates the skeleton with a timestamp


### PR DESCRIPTION
## Summary

- Codex's Stop hook parser only accepts `decision:"block"` (see `codex-rs/hooks/src/events/stop.rs`'s `BlockDecisionWire`); `decision:"approve"` fails with `hook returned invalid stop hook JSON output`. In `/talk` there is no `.do-results.json`, so every stop hit the approve branch and the hook failed on every Codex turn.
- Switch the allow-stop path to empty stdout (valid in both Claude Code and Codex). Keep `decision:"block"` for blocking — portable in both.
- Fold the `waiting` case into the default empty-output branch. Tradeoff: Claude Code users lose the informational "resume with `--from ci-only`" reason string on that path; the block/allow decision itself is unchanged in both harnesses.
- Sync the one line in `do/SKILL.md` that described the removed hint.

## Test plan

- [ ] Run `/talk` under Codex and confirm no more "invalid stop hook JSON output" errors.
- [ ] Under Claude Code: run `/do`, verify stop is still blocked while `active == "working"`.
- [ ] Under Claude Code: with `.do-results.json` absent (e.g. `/talk` or fresh repo), verify the stop proceeds cleanly.
- [ ] Under Claude Code: with a corrupted `.do-results.json`, verify the stop is still blocked with the parse-error reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)