### PR TITLE
Add agency-setup skill and README Quickstart

### DIFF
--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -26,7 +26,7 @@ Detect the mode from repo state — **don't require the user to pass a flag**. T
 1. `uvx --from apm-cli apm --version`
 2. `nix shell nixpkgs#uv -c uvx --from apm-cli apm --version`
 
-If neither works (no `uvx` and no `nix`), tell the user to install one of [`uv`](https://docs.astral.sh/uv/) or [`nix`](https://nixos.org/) and stop. Don't try to install package managers yourself.
+If neither works (no `uvx` and no `nix`), tell the user to install one of [`uv`](https://docs.astral.sh/uv/) or [`nix`](https://nixos.asia/en/install) and stop. Don't try to install package managers yourself.
 
 Use whichever prefix succeeded as the `apm` invocation for every subsequent `apm` call in this run (e.g., `uvx --from apm-cli apm install`).
 

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -6,18 +6,15 @@ argument-hint: "[--update]"
 
 # Agency Setup
 
-Configure (or refresh) this repo to use [srid/agency](https://github.com/srid/agency). Detect what state the project is in and do the right thing — first-time bootstrap vs. refreshing an existing install.
+Configure (or refresh) this repo to use [srid/agency](https://github.com/srid/agency). Each step below is **idempotent** — it inspects what's already on disk and acts only on what's missing or out of date. The skill works equally well as first-time bootstrap, full refresh, or **partial-install upgrade** (e.g. user already added `srid/agency` to `apm.yml` manually but never created `workflow.instructions.md` — the skill detects the gap and fills it without re-doing the parts that already exist).
 
-This skill is **idempotent** and safe to re-run. Don't commit anything — leave changes staged for the user to review.
+Don't commit anything — leave changes staged for the user to review.
 
-## Modes
+## The `--update` flag
 
-Detect the mode from repo state — **don't require the user to pass a flag**. The Quickstart prompt is the same for first-time setup and updates; users who paste it again after install expect it to refresh, not start over.
+`--update` in `ARGUMENTS` is the only explicit mode hint, and it does exactly one thing: re-pin the `srid/agency` ref in `apm.yml` to `#master` (in case the user pinned it to an older tag/sha and wants to move forward). **Every other step runs unconditionally** — they each decide for themselves whether they have work to do.
 
-- **First-time setup** — `apm.yml` is missing, or it exists but has no `srid/agency` entry under `dependencies.apm:`.
-- **Update** — `apm.yml` already pins `srid/agency`. Skip steps that would clobber the user's existing config; just refresh.
-
-`--update` in `ARGUMENTS` is an explicit hint that **also** requests bumping the `srid/agency` ref back to `#master` (in case the user pinned it to a tag/sha and wants to move forward). Without the flag, leave the existing pin alone in update mode. Strip the flag before treating the rest as additional context.
+Strip the flag before treating the rest as additional context.
 
 ## 1. Pick an `apm` invocation
 
@@ -57,10 +54,13 @@ dependencies:
     - srid/agency#master
 ```
 
-If `apm.yml` already exists:
+If `apm.yml` already exists, edit it idempotently:
 
-- In **first-time** mode: append `srid/agency#master` to `dependencies.apm:`, preserving every existing entry. If `dependencies.apm:` doesn't exist, add it. If `targets:` is missing or doesn't include the detected host, add the host to it (don't remove existing targets).
-- In **update** mode: leave `apm.yml` alone unless `--update` was passed explicitly — in that case, re-pin the `srid/agency` line to `#master`. Don't touch other entries.
+- If `dependencies.apm:` is missing the `srid/agency` entry, append `srid/agency#master`. Preserve every existing entry. If the `dependencies.apm:` block itself is missing, add it.
+- If `targets:` is missing or doesn't include the detected host, add the host. Don't remove existing targets.
+- If `--update` was passed explicitly **and** `srid/agency` is already pinned to something other than `#master`, re-pin it to `#master`. Without the flag, leave the existing pin alone.
+
+Don't touch unrelated entries.
 
 ## 4. Run `apm install`
 
@@ -77,7 +77,9 @@ If install fails, surface the error verbatim and stop — don't paper over it.
 
 ## 6. Draft `.apm/instructions/workflow.instructions.md`
 
-Skip this step in **update** mode if the file already exists.
+If this file already exists, **leave it alone** — the user has either already configured it or is intentionally hand-maintaining it. Skip to step 7.
+
+If it's missing (whether this is a first-time setup or an upgrade where the user added `srid/agency` to `apm.yml` themselves but never wrote workflow instructions), create it now.
 
 `do` runs autonomously but needs to know your project's check, format, test, and CI commands. Inspect the project to figure them out — look at:
 

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -87,7 +87,15 @@ Skip this step in **update** mode if the file already exists.
 - `Cargo.toml`, `flake.nix`, `pyproject.toml`
 - `.github/workflows/` for CI hints
 
-Write `.apm/instructions/workflow.instructions.md` based on **what you actually found**. Use this template, leaving any section you couldn't determine as a `# TODO` line — better to skip a step than guess wrong:
+For each of the four sections (Check, Format, Test, CI), there are three possible outcomes:
+
+- **Found a clear command** in the project → fill it in.
+- **Found a plausible command but you're not certain** → use `AskUserQuestion` to confirm. Offer the candidate as one option and "skip this section" as another, with a free-form fallback for the user to type a different command.
+- **Found nothing** → use `AskUserQuestion` to ask the user directly. Always include a "skip this section" option so they can explicitly discard it. Don't fabricate commands.
+
+Sections the user discards are **omitted from the generated file entirely** — no `# TODO` placeholders. `do` already handles missing sections by skipping the corresponding step with a note, which is the right behavior for a section the user has consciously declined.
+
+Final file uses this template, including only the sections the user kept:
 
 ```markdown
 ---
@@ -96,22 +104,20 @@ applyTo: "**"
 ---
 
 ## Check command
-<command, or: # TODO: configure check command>
+<command>
 
 ## Format command
-<command, or: # TODO>
+<command>
 
 ## Test command
-<command, or: # TODO>
+<command>
 
 ## CI command
-<command, or: # TODO>
+<command>
 
 ## Documentation
 Keep `README.md` in sync with user-facing changes.
 ```
-
-Don't fabricate commands. If `package.json` has no `typecheck` script and there's no `tsc` config, leave the section as `# TODO`. The user can fill it in.
 
 After writing this file, **re-run `apm install`** so the new instructions get picked up by the generated host config.
 
@@ -121,7 +127,7 @@ Summarize for the user, in this order:
 
 1. Which `apm` invocation you used (so the user knows the exact command for ad-hoc `apm` calls later).
 2. Which `targets:` ended up in `apm.yml`.
-3. What workflow commands you detected, and which were left as `# TODO`.
+3. Which workflow sections were filled in (and from where) versus skipped at the user's request.
 4. Files changed (staged, not committed). Tell them to review the diff before committing.
 5. **Restart the agent CLI** (Claude Code, Codex, opencode, etc.) so it picks up the newly generated skills — without a restart, `/talk` and `/do` won't be available in the running session.
 6. After restart, try `/talk <question>` or `/do <task>` to verify everything works.

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -131,7 +131,13 @@ Summarize for the user, in this order:
 2. Which `targets:` ended up in `apm.yml`.
 3. Which workflow sections were filled in (and from where) versus skipped at the user's request.
 4. Files changed (staged, not committed). Tell them to review the diff before committing.
-5. **Restart the agent CLI** (Claude Code, Codex, opencode, etc.) so it picks up the newly generated skills — without a restart, `/talk` and `/do` won't be available in the running session.
-6. After restart, try `/talk <question>` or `/do <task>` to verify everything works.
+5. **Optional instructions to consider adding** — list whichever of these files do **not** yet exist under `.apm/instructions/`, and explain briefly what each is for. They're project-specific and can't be auto-generated, but the user should know they exist so they can layer them on:
+   - `code-police-rules.instructions.md` — project-specific quality rules checked alongside the built-in `code-police` rules.
+   - `hickey-catalog.instructions.md` — project-specific complecting patterns extending the Hickey Layer 4 catalog.
+   - `lowy-volatilities.instructions.md` — project-declared areas of volatility used by the Lowy review pass.
+
+   Point them at [Kolu's `.apm/instructions/`](https://github.com/juspay/kolu/tree/master/.apm/instructions) as a worked example. Skip files that already exist.
+6. **Restart the agent CLI** (Claude Code, Codex, opencode, etc.) so it picks up the newly generated skills — without a restart, `/talk` and `/do` won't be available in the running session.
+7. After restart, try `/talk <question>` or `/do <task>` to verify everything works.
 
 ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -137,7 +137,12 @@ Summarize for the user, in this order:
    - `lowy-volatilities.instructions.md` — project-declared areas of volatility used by the Lowy review pass.
 
    Point them at [Kolu's `.apm/instructions/`](https://github.com/juspay/kolu/tree/master/.apm/instructions) as a worked example. Skip files that already exist.
-6. **Restart the agent CLI** (Claude Code, Codex, opencode, etc.) so it picks up the newly generated skills — without a restart, `/talk` and `/do` won't be available in the running session.
-7. After restart, try `/talk <question>` or `/do <task>` to verify everything works.
+6. **Restart the agent CLI** (Claude Code, Codex, opencode, etc.) so it picks up the newly generated skills — without a restart, the new skills won't be available in the running session.
+7. After restart, try `talk` or `do` to verify everything works. Tell the user the **exact** invocation syntax for the target(s) you installed for — don't make them guess:
+   - **Claude Code** → `/talk <question>` and `/do <task>` (slash commands).
+   - **Codex** → `$talk <question>` and `$do <task>` (dollar prefix).
+   - **opencode** → invoke `/skills` and pick `talk` or `do` from the list.
+
+   If you installed for multiple targets, list the syntax for each.
 
 ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -28,17 +28,17 @@ Detect the mode from repo state — **don't require the user to pass a flag**. T
 
 If neither works (no `uvx` and no `nix`), tell the user to install one of [`uv`](https://docs.astral.sh/uv/) or [`nix`](https://nixos.org/) and stop. Don't try to install package managers yourself.
 
-Use whichever prefix succeeded as the `apm` invocation for every subsequent `apm` call in this run (e.g., `uvx --from apm-cli apm install -t claude`).
+Use whichever prefix succeeded as the `apm` invocation for every subsequent `apm` call in this run (e.g., `uvx --from apm-cli apm install`).
 
-## 2. Detect the host target
+## 2. Detect the host targets
 
-Pass `-t <target>` to `apm install`. Detect the target from what's already on disk and the host you're running in:
+The host targets go into `apm.yml` as a `targets:` list (next step) — `apm install` reads them, no `-t` flag needed. Detect from what's already on disk and the host you're running in:
 
 - `.claude/` exists, or you're running in Claude Code → `claude`
 - `.opencode/` exists, or you're running in opencode → `opencode`
 - `.codex/` exists, or you're running in Codex → `codex`
 
-If still ambiguous, use `AskUserQuestion` to confirm. Do **not** guess silently — installing for the wrong target wastes a round trip.
+Multiple matches are fine — declare all of them. If nothing matches and the host you're in isn't one of the three, use `AskUserQuestion` to confirm. Do **not** guess silently — installing for the wrong target wastes a round trip.
 
 ## 3. Create or extend `apm.yml`
 
@@ -49,6 +49,9 @@ name: <repo-directory-name>
 version: 1.0.0
 type: hybrid
 
+targets:
+  - <detected-target>
+
 dependencies:
   apm:
     - srid/agency#master
@@ -56,12 +59,12 @@ dependencies:
 
 If `apm.yml` already exists:
 
-- In **first-time** mode: append `srid/agency#master` to `dependencies.apm:`, preserving every existing entry. If `dependencies.apm:` doesn't exist, add it.
+- In **first-time** mode: append `srid/agency#master` to `dependencies.apm:`, preserving every existing entry. If `dependencies.apm:` doesn't exist, add it. If `targets:` is missing or doesn't include the detected host, add the host to it (don't remove existing targets).
 - In **update** mode: leave `apm.yml` alone unless `--update` was passed explicitly — in that case, re-pin the `srid/agency` line to `#master`. Don't touch other entries.
 
 ## 4. Run `apm install`
 
-Run `<apm-invocation> install -t <target>` from the directory containing `apm.yml`. This generates `.claude/` (or `.opencode/` / `.codex/`) and adds `apm_modules/` to `.gitignore`.
+Run `<apm-invocation> install` from the directory containing `apm.yml`. `apm` reads `targets:` from the yml and generates `.claude/` / `.opencode/` / `.codex/` accordingly, plus adds `apm_modules/` to `.gitignore`.
 
 If install fails, surface the error verbatim and stop — don't paper over it.
 
@@ -110,7 +113,7 @@ After writing this file, **re-run `apm install`** so the new instructions get pi
 Summarize for the user, in this order:
 
 1. Which `apm` invocation you used (so the user knows the exact command for ad-hoc `apm` calls later).
-2. What target you installed for.
+2. Which `targets:` ended up in `apm.yml`.
 3. What workflow commands you detected, and which were left as `# TODO`.
 4. Files changed (staged, not committed). Tell them to review the diff before committing.
 5. Next step: try `/talk <question>` or `/do <task>` to verify everything works.

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: agency-setup
+description: Bootstrap or update srid/agency in this project — run apm via uvx, configure apm.yml, install skills, draft workflow instructions. Use for first-time setup or to refresh an existing install.
+argument-hint: "[--update]"
+---
+
+# Agency Setup
+
+Configure (or refresh) this repo to use [srid/agency](https://github.com/srid/agency). Detect what state the project is in and do the right thing — first-time bootstrap vs. refreshing an existing install.
+
+This skill is **idempotent** and safe to re-run. Don't commit anything — leave changes staged for the user to review.
+
+## Modes
+
+Detect the mode from repo state — **don't require the user to pass a flag**. The Quickstart prompt is the same for first-time setup and updates; users who paste it again after install expect it to refresh, not start over.
+
+- **First-time setup** — `apm.yml` is missing, or it exists but has no `srid/agency` entry under `dependencies.apm:`.
+- **Update** — `apm.yml` already pins `srid/agency`. Skip steps that would clobber the user's existing config; just refresh.
+
+`--update` in `ARGUMENTS` is an explicit hint that **also** requests bumping the `srid/agency` ref back to `#master` (in case the user pinned it to a tag/sha and wants to move forward). Without the flag, leave the existing pin alone in update mode. Strip the flag before treating the rest as additional context.
+
+## 1. Pick an `apm` invocation
+
+`apm` does not need to be installed — run it through `uvx`. Try in order, stopping at the first that works:
+
+1. `uvx --from apm-cli apm --version`
+2. `nix shell nixpkgs#uv -c uvx --from apm-cli apm --version`
+
+If neither works (no `uvx` and no `nix`), tell the user to install one of [`uv`](https://docs.astral.sh/uv/) or [`nix`](https://nixos.org/) and stop. Don't try to install package managers yourself.
+
+Use whichever prefix succeeded as the `apm` invocation for every subsequent `apm` call in this run (e.g., `uvx --from apm-cli apm install -t claude`).
+
+## 2. Detect the host target
+
+Pass `-t <target>` to `apm install`. Detect the target from what's already on disk and the host you're running in:
+
+- `.claude/` exists, or you're running in Claude Code → `claude`
+- `.opencode/` exists, or you're running in opencode → `opencode`
+- `.codex/` exists, or you're running in Codex → `codex`
+
+If still ambiguous, use `AskUserQuestion` to confirm. Do **not** guess silently — installing for the wrong target wastes a round trip.
+
+## 3. Create or extend `apm.yml`
+
+If `apm.yml` does not exist, write:
+
+```yaml
+name: <repo-directory-name>
+version: 1.0.0
+type: hybrid
+
+dependencies:
+  apm:
+    - srid/agency#master
+```
+
+If `apm.yml` already exists:
+
+- In **first-time** mode: append `srid/agency#master` to `dependencies.apm:`, preserving every existing entry. If `dependencies.apm:` doesn't exist, add it.
+- In **update** mode: leave `apm.yml` alone unless `--update` was passed explicitly — in that case, re-pin the `srid/agency` line to `#master`. Don't touch other entries.
+
+## 4. Run `apm install`
+
+Run `<apm-invocation> install -t <target>` from the directory containing `apm.yml`. This generates `.claude/` (or `.opencode/` / `.codex/`) and adds `apm_modules/` to `.gitignore`.
+
+If install fails, surface the error verbatim and stop — don't paper over it.
+
+## 5. Draft `.apm/instructions/workflow.instructions.md`
+
+Skip this step in **update** mode if the file already exists.
+
+`do` runs autonomously but needs to know your project's check, format, test, and CI commands. Inspect the project to figure them out — look at:
+
+- `package.json` `scripts:` (Node)
+- `justfile` (just)
+- `Makefile`
+- `Cargo.toml`, `flake.nix`, `pyproject.toml`
+- `.github/workflows/` for CI hints
+
+Write `.apm/instructions/workflow.instructions.md` based on **what you actually found**. Use this template, leaving any section you couldn't determine as a `# TODO` line — better to skip a step than guess wrong:
+
+```markdown
+---
+description: Workflow commands for the do pipeline
+applyTo: "**"
+---
+
+## Check command
+<command, or: # TODO: configure check command>
+
+## Format command
+<command, or: # TODO>
+
+## Test command
+<command, or: # TODO>
+
+## CI command
+<command, or: # TODO>
+
+## Documentation
+Keep `README.md` in sync with user-facing changes.
+```
+
+Don't fabricate commands. If `package.json` has no `typecheck` script and there's no `tsc` config, leave the section as `# TODO`. The user can fill it in.
+
+After writing this file, **re-run `apm install`** so the new instructions get picked up by the generated host config.
+
+## 6. Report back
+
+Summarize for the user, in this order:
+
+1. Which `apm` invocation you used (so the user knows the exact command for ad-hoc `apm` calls later).
+2. What target you installed for.
+3. What workflow commands you detected, and which were left as `# TODO`.
+4. Files changed (staged, not committed). Tell them to review the diff before committing.
+5. Next step: try `/talk <question>` or `/do <task>` to verify everything works.
+
+ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -68,7 +68,14 @@ Run `<apm-invocation> install` from the directory containing `apm.yml`. `apm` re
 
 If install fails, surface the error verbatim and stop — don't paper over it.
 
-## 5. Draft `.apm/instructions/workflow.instructions.md`
+## 5. Ensure `.gitignore` covers agency runtime artifacts
+
+`apm install` adds `apm_modules/` for you, but `do` writes `.do-results.json` at the repo root during a workflow run and that should not be committed. Make sure both lines exist in `.gitignore` (create the file if missing), idempotently — don't duplicate entries that are already there:
+
+- `/.do-results.json`
+- `/apm_modules/` (verify; `apm install` may already have added it as `apm_modules/` — either form is fine)
+
+## 6. Draft `.apm/instructions/workflow.instructions.md`
 
 Skip this step in **update** mode if the file already exists.
 
@@ -108,7 +115,7 @@ Don't fabricate commands. If `package.json` has no `typecheck` script and there'
 
 After writing this file, **re-run `apm install`** so the new instructions get picked up by the generated host config.
 
-## 6. Report back
+## 7. Report back
 
 Summarize for the user, in this order:
 

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -116,6 +116,7 @@ Summarize for the user, in this order:
 2. Which `targets:` ended up in `apm.yml`.
 3. What workflow commands you detected, and which were left as `# TODO`.
 4. Files changed (staged, not committed). Tell them to review the diff before committing.
-5. Next step: try `/talk <question>` or `/do <task>` to verify everything works.
+5. **Restart the agent CLI** (Claude Code, Codex, opencode, etc.) so it picks up the newly generated skills — without a restart, `/talk` and `/do` won't be available in the running session.
+6. After restart, try `/talk <question>` or `/do <task>` to verify everything works.
 
 ARGUMENTS: $ARGUMENTS

--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ Agency[^agency] is a near-autonomous workflow for coding agents, packaged as an 
 > [!IMPORTANT]
 > Agency has mainly been tested with Claude Code & Codex. YMMV with other agents.
 
+## Quickstart
+
+Paste this into your AI agent (Claude Code, Codex, opencode) at the root of the repo you want to set up:
+
+> Set up this repo to use srid/agency by following the instructions at <https://github.com/srid/agency/blob/master/.apm/skills/agency-setup/SKILL.md>.
+
+The agent will run `apm` via `uvx` (no install needed — falls back to `nix shell nixpkgs#uv -c uvx` if you have Nix but not `uvx`), create or extend `apm.yml`, run `apm install` for your host, and draft `.apm/instructions/workflow.instructions.md` from your project's existing scripts. Review the staged changes before committing.
+
+Pasting the same prompt again later acts as an **update** — it detects the existing install and refreshes generated files. Append `--update` to also re-pin `srid/agency` to `#master`.
+
+For the manual path or a deeper explanation, see [Usage](#usage) below.
+
 ## What's included
 
 ### Skills
@@ -25,6 +37,7 @@ Agency[^agency] is a near-autonomous workflow for coding agents, packaged as an 
 - **`fact-check`** — Standalone correctness audit: finds silent error swallowing, unjustified fallbacks, wishful thinking, and logic errors. Prosecutor posture — no self-dismissals.
 - **`elegance`** — Iterative elegance pass: understand, research, apply, verify. Runs 3 iterations by default, each building on the last.
 - **`forge-pr`** — Writes PR titles and descriptions that devs actually want to read. Paragraphs over bullet lists, substance over boilerplate. GitHub today; Bitbucket support tracked in [#10](https://github.com/srid/agency/issues/10).
+- **`agency-setup`** — Bootstraps or updates srid/agency in a project: runs `apm` via `uvx` (no install needed), configures `apm.yml`, runs `apm install`, and drafts `.apm/instructions/workflow.instructions.md` from the project's existing scripts. Powers the [Quickstart](#quickstart) prompt. Re-paste the prompt later to refresh; append `--update` to also re-pin `srid/agency`.
 
 ### Hooks & Instructions
 


### PR DESCRIPTION
**A new user can now bootstrap a repo by pasting one line into their AI agent.** The README opens with a Quickstart whose payload is a single prompt that points at the new `agency-setup` skill on GitHub — no apm.yml YAML to copy, no `uvx` flags to remember, no decision about which host target to pass.

The skill itself does the work: pick a working `apm` invocation (`uvx --from apm-cli apm`, falling back to `nix shell nixpkgs#uv -c uvx --from apm-cli apm` — _never asks the user to install apm permanently_), detect the host target from `.claude/`/`.opencode/`/`.codex/`, create or extend `apm.yml`, run `apm install`, and draft `.apm/instructions/workflow.instructions.md` from whatever the project already defines (`package.json` scripts, `justfile`, `Makefile`, `Cargo.toml`, `flake.nix`, `pyproject.toml`, `.github/workflows/`). Sections it can't confidently fill are left as `# TODO` — better to skip a step than fabricate a command.

_Pasting the same Quickstart prompt later auto-detects the existing install and refreshes generated files. Append `--update` to also re-pin `srid/agency` to `#master`._

Closes #108.

## Test plan

- [ ] Paste the Quickstart prompt into Claude Code on a fresh repo without `apm.yml` — confirm it picks `uvx`, creates `apm.yml`, installs `.claude/`, and drafts `workflow.instructions.md`
- [ ] Paste the same prompt on a repo that already has agency installed — confirm it refreshes generated files without clobbering the existing pin
- [ ] Paste with `--update` appended — confirm the `srid/agency` ref re-pins to `#master`
- [ ] Repeat on a Nix-only host (no `uvx` on PATH) — confirm it falls back to `nix shell nixpkgs#uv -c uvx`
- [ ] Verify in opencode and Codex that the host target detection picks the right `-t` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)