### PR TITLE
Run apm compile for Codex/opencode targets

### DIFF
--- a/.apm/instructions/apm-sources.instructions.md
+++ b/.apm/instructions/apm-sources.instructions.md
@@ -10,3 +10,5 @@ applyTo: ".claude/**,.opencode/**"
 Everything under `.claude/` and `.opencode/` is **generated** from `.apm/` sources by APM. Direct edits will be overwritten on the next `apm install` run.
 
 To modify agent configuration, find the `.apm/` directory (it may be at the project root or nested under a subdirectory such as `agents/.apm/`), edit the source files there, then run `apm install` to regenerate.
+
+**For Codex / opencode targets, also run `apm compile --target codex,opencode`** (or whichever subset applies) — `install` regenerates the runtime folders but does not produce the project-root `AGENTS.md` that those hosts read. Claude reads `.claude/` natively, so no compile step is needed when `claude` is the only target.

--- a/.apm/instructions/apm-sources.instructions.md
+++ b/.apm/instructions/apm-sources.instructions.md
@@ -11,4 +11,4 @@ Everything under `.claude/` and `.opencode/` is **generated** from `.apm/` sourc
 
 To modify agent configuration, find the `.apm/` directory (it may be at the project root or nested under a subdirectory such as `agents/.apm/`), edit the source files there, then run `apm install` to regenerate.
 
-**For Codex / opencode targets, also run `apm compile --target codex,opencode`** (or whichever subset applies) — `install` regenerates the runtime folders but does not produce the project-root `AGENTS.md` that those hosts read. Claude reads `.claude/` natively, so no compile step is needed when `claude` is the only target.
+**For Codex / opencode targets, also run `apm compile -t codex,opencode`** (or whichever subset applies) — `install` regenerates the runtime folders but does not produce the project-root `AGENTS.md` that those hosts read. Claude reads `.claude/` natively, so no compile step is needed when `claude` is the only target.

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -62,11 +62,19 @@ If `apm.yml` already exists, edit it idempotently:
 
 Don't touch unrelated entries.
 
-## 4. Run `apm install`
+## 4. Run `apm install` (and `apm compile` for Codex / opencode)
 
-Run `<apm-invocation> install` from the directory containing `apm.yml`. `apm` reads `targets:` from the yml and generates `.claude/` / `.opencode/` / `.codex/` accordingly, plus adds `apm_modules/` to `.gitignore`.
+Run `<apm-invocation> install` from the directory containing `apm.yml`. `apm` reads `targets:` from the yml and generates the runtime-specific folders (`.claude/` / `.opencode/` / `.codex/`), plus adds `apm_modules/` to `.gitignore`.
 
-If install fails, surface the error verbatim and stop — don't paper over it.
+**`install` does not generate the project-root `AGENTS.md` instruction file.** Codex and opencode read `AGENTS.md` at session start; without it they will not see the workflow instructions, code-police rules, or any other `.apm/instructions/` content. To produce it, also run:
+
+```sh
+<apm-invocation> compile --target <subset>
+```
+
+…where `<subset>` is the comma-separated list of `codex` and/or `opencode` from your `targets:` (e.g., `--target codex,opencode` if both are declared, `--target codex` if only Codex). **Skip the compile step entirely if `claude` is the only target** — Claude Code reads `.claude/` natively and doesn't need `AGENTS.md` (compiling `CLAUDE.md` is intentionally avoided).
+
+If `install` or `compile` fails, surface the error verbatim and stop — don't paper over it.
 
 ## 5. Ensure `.gitignore` covers agency runtime artifacts
 
@@ -121,7 +129,7 @@ applyTo: "**"
 Keep `README.md` in sync with user-facing changes.
 ```
 
-After writing this file, **re-run `apm install`** so the new instructions get picked up by the generated host config.
+After writing this file, **re-run `apm install`** (and `apm compile --target <subset>` if `codex` or `opencode` is in `targets:`) so the new instructions get picked up by the generated host config and the project-root `AGENTS.md`.
 
 ## 7. Report back
 

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -69,10 +69,10 @@ Run `<apm-invocation> install` from the directory containing `apm.yml`. `apm` re
 **`install` does not generate the project-root `AGENTS.md` instruction file.** Codex and opencode read `AGENTS.md` at session start; without it they will not see the workflow instructions, code-police rules, or any other `.apm/instructions/` content. To produce it, also run:
 
 ```sh
-<apm-invocation> compile --target <subset>
+<apm-invocation> compile -t <subset>
 ```
 
-…where `<subset>` is the comma-separated list of `codex` and/or `opencode` from your `targets:` (e.g., `--target codex,opencode` if both are declared, `--target codex` if only Codex). **Skip the compile step entirely if `claude` is the only target** — Claude Code reads `.claude/` natively and doesn't need `AGENTS.md` (compiling `CLAUDE.md` is intentionally avoided).
+…where `<subset>` is the comma-separated list of `codex` and/or `opencode` from your `targets:` (e.g., `-t codex,opencode` if both are declared, `-t codex` if only Codex). **Skip the compile step entirely if `claude` is the only target** — Claude Code reads `.claude/` natively and doesn't need `AGENTS.md` (compiling `CLAUDE.md` is intentionally avoided).
 
 If `install` or `compile` fails, surface the error verbatim and stop — don't paper over it.
 
@@ -129,7 +129,7 @@ applyTo: "**"
 Keep `README.md` in sync with user-facing changes.
 ```
 
-After writing this file, **re-run `apm install`** (and `apm compile --target <subset>` if `codex` or `opencode` is in `targets:`) so the new instructions get picked up by the generated host config and the project-root `AGENTS.md`.
+After writing this file, **re-run `apm install`** (and `apm compile -t <subset>` if `codex` or `opencode` is in `targets:`) so the new instructions get picked up by the generated host config and the project-root `AGENTS.md`.
 
 ## 7. Report back
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Paste this into your AI agent (Claude Code, Codex, opencode) at the root of the 
 
 > Set up this repo to use srid/agency by following the instructions at <https://github.com/srid/agency/blob/master/.apm/skills/agency-setup/SKILL.md>.
 
-The agent will run `apm` via `uvx` (no install needed — falls back to `nix shell nixpkgs#uv -c uvx` if you have Nix but not `uvx`), create or extend `apm.yml`, run `apm install` for your host, and draft `.apm/instructions/workflow.instructions.md` from your project's existing scripts. Review the staged changes before committing.
+The agent will run `apm` via `uvx` (no install needed — falls back to `nix shell nixpkgs#uv -c uvx` if you have Nix but not `uvx`), create or extend `apm.yml`, run `apm install` (plus `apm compile --target codex,opencode` when those hosts are declared, since they need a project-root `AGENTS.md`), and draft `.apm/instructions/workflow.instructions.md` from your project's existing scripts. Review the staged changes before committing.
 
 Pasting the same prompt again later acts as an **update** — it detects the existing install and refreshes generated files. Append `--update` to also re-pin `srid/agency` to `#master`.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Paste this into your AI agent (Claude Code, Codex, opencode) at the root of the 
 
 > Set up this repo to use srid/agency by following the instructions at <https://github.com/srid/agency/blob/master/.apm/skills/agency-setup/SKILL.md>.
 
-The agent will run `apm` via `uvx` (no install needed — falls back to `nix shell nixpkgs#uv -c uvx` if you have Nix but not `uvx`), create or extend `apm.yml`, run `apm install` (plus `apm compile --target codex,opencode` when those hosts are declared, since they need a project-root `AGENTS.md`), and draft `.apm/instructions/workflow.instructions.md` from your project's existing scripts. Review the staged changes before committing.
+The agent will run `apm` via `uvx` (no install needed — falls back to `nix shell nixpkgs#uv -c uvx` if you have Nix but not `uvx`), create or extend `apm.yml`, run `apm install` (plus `apm compile -t codex,opencode` when those hosts are declared, since they need a project-root `AGENTS.md`), and draft `.apm/instructions/workflow.instructions.md` from your project's existing scripts. Review the staged changes before committing.
 
 Pasting the same prompt again later acts as an **update** — it detects the existing install and refreshes generated files. Append `--update` to also re-pin `srid/agency` to `#master`.
 


### PR DESCRIPTION
**Codex and opencode silently miss every `.apm/instructions/` rule** unless `apm compile` runs after `apm install`. Both hosts read the project-root `AGENTS.md` at session start, and `install` only regenerates the runtime-specific folders (`.claude/`, `.codex/`, `.opencode/`) — `AGENTS.md` is produced exclusively by `compile`. The failure mode is invisible: hosts start cleanly, agency's skills are visible, but workflow instructions, code-police rules, and the like never enter context.

The `agency-setup` skill now runs `apm compile --target <subset>` after `install` whenever `codex` or `opencode` is declared in `targets:`. _Skipped when `claude` is the only target_ — Claude Code reads `.claude/` natively, so compiling `CLAUDE.md` is intentionally avoided. Step 6's "re-run after writing workflow.instructions.md" guidance and the `apm-sources` instruction (which auto-attaches when an agent edits `.claude/` or `.opencode/`) both pick up the same compile guidance, as does the README Quickstart blurb.

Pattern lifted from [kolu's `agents/ai.just`](https://github.com/juspay/kolu/blob/2c0f6eacb4910c1c5b23b0bbc2e1ab33108690ba/agents/ai.just#L22-L27).

## Test plan

- [ ] Paste the Quickstart prompt into Codex on a fresh repo — confirm `AGENTS.md` appears at the repo root and contains the workflow instructions
- [ ] Same for opencode — confirm `AGENTS.md` is generated and the host reads it
- [ ] Paste on a Claude-only project (`targets: [claude]`) — confirm the compile step is skipped
- [ ] Re-run on a project that already has `targets: [codex, opencode]` — confirm `apm compile --target codex,opencode` runs idempotently
- [ ] Edit `.apm/instructions/workflow.instructions.md` in an existing project, re-run setup — confirm both `install` and `compile` re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)