### PR TITLE
agency-setup: use apm deps update; drop --update flag

### DIFF
--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -1,20 +1,15 @@
 ---
 name: agency-setup
 description: Bootstrap or update srid/agency in this project — run apm via uvx, configure apm.yml, install skills, draft workflow instructions. Use for first-time setup or to refresh an existing install.
-argument-hint: "[--update]"
 ---
 
 # Agency Setup
 
 Configure (or refresh) this repo to use [srid/agency](https://github.com/srid/agency). Each step below is **idempotent** — it inspects what's already on disk and acts only on what's missing or out of date. The skill works equally well as first-time bootstrap, full refresh, or **partial-install upgrade** (e.g. user already added `srid/agency` to `apm.yml` manually but never created `workflow.instructions.md` — the skill detects the gap and fills it without re-doing the parts that already exist).
 
+When the repo already has `srid/agency` in `apm.yml`, this skill also refreshes it to the latest ref (via `apm deps update srid/agency` in step 6) — there's no separate "update" mode.
+
 Don't commit anything — leave changes staged for the user to review.
-
-## The `--update` flag
-
-`--update` in `ARGUMENTS` is the only explicit mode hint, and it does exactly one thing: run `<apm-invocation> deps update srid/agency` at the start of step 6 to refresh the dependency to the latest ref before `apm install` and `apm compile` run. **Every other step runs unconditionally** — they each decide for themselves whether they have work to do.
-
-Strip the flag before treating the rest as additional context.
 
 ## Invariant: `apm install` and `apm compile` run *after* every file change
 
@@ -44,6 +39,8 @@ Multiple matches are fine — declare all of them. If nothing matches and the ho
 **Single vs. multiple targets:** `apm` has a bug where the plural `targets:` list breaks when only one entry is present. Use the singular `target: <name>` scalar for exactly one target, and the `targets:` list only when you have two or more.
 
 ## 3. Create or extend `apm.yml`
+
+Before editing, note whether `srid/agency` is already listed under `dependencies.apm:` — step 6 needs that fact to decide whether to refresh the dep.
 
 If `apm.yml` does not exist, write:
 
@@ -121,11 +118,11 @@ applyTo: "**"
 Keep `README.md` in sync with user-facing changes.
 ```
 
-## 6. Run `apm deps update` (if `--update`), then `apm install` (and `apm compile` for Codex / opencode)
+## 6. Refresh `srid/agency` (if already present), then run `apm install` (and `apm compile` for Codex / opencode)
 
-If `--update` was passed, first run `<apm-invocation> deps update srid/agency` from the directory containing `apm.yml`. `apm install` alone won't move an already-installed dependency to a newer ref — `deps update` is what pulls the latest commit on the pinned ref. Skip this sub-step entirely when `--update` was not passed.
+If `srid/agency` was already listed in `apm.yml` at the start of this run (you noted this in step 3), first run `<apm-invocation> deps update srid/agency` from the directory containing `apm.yml`. `apm install` alone won't move an already-installed dependency to a newer ref — `deps update` is what pulls the latest commit on the pinned ref. Skip this sub-step on first-time setup, where step 3 just added the entry; `apm install` will fetch it fresh.
 
-Then, regardless of `--update`, regenerate the host configs in a single pass. Run `<apm-invocation> install` from the directory containing `apm.yml`. `apm` reads `target:` / `targets:` from the yml and generates the runtime-specific folders (`.claude/` / `.opencode/` / `.codex/`), plus adds `apm_modules/` to `.gitignore`.
+Then, regenerate the host configs in a single pass. Run `<apm-invocation> install` from the directory containing `apm.yml`. `apm` reads `target:` / `targets:` from the yml and generates the runtime-specific folders (`.claude/` / `.opencode/` / `.codex/`), plus adds `apm_modules/` to `.gitignore`.
 
 **`install` does not generate the project-root `AGENTS.md` instruction file.** Codex and opencode read `AGENTS.md` at session start; without it they will not see the workflow instructions, code-police rules, or any other `.apm/instructions/` content. To produce it, also run:
 
@@ -160,5 +157,3 @@ Summarize for the user, in this order:
    - **opencode** → invoke `/skills` and pick `talk` or `do` from the list.
 
    If you installed for multiple targets, list the syntax for each.
-
-ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -12,7 +12,7 @@ Don't commit anything — leave changes staged for the user to review.
 
 ## The `--update` flag
 
-`--update` in `ARGUMENTS` is the only explicit mode hint, and it does exactly one thing: re-pin the `srid/agency` ref in `apm.yml` to `#master` (in case the user pinned it to an older tag/sha and wants to move forward). **Every other step runs unconditionally** — they each decide for themselves whether they have work to do.
+`--update` in `ARGUMENTS` is the only explicit mode hint, and it does exactly one thing: run `<apm-invocation> deps update srid/agency` at the start of step 6 to refresh the dependency to the latest ref before `apm install` and `apm compile` run. **Every other step runs unconditionally** — they each decide for themselves whether they have work to do.
 
 Strip the flag before treating the rest as additional context.
 
@@ -65,9 +65,8 @@ If `apm.yml` already exists, edit it idempotently:
 
 - If `dependencies.apm:` is missing the `srid/agency` entry, append `srid/agency#master`. Preserve every existing entry. If the `dependencies.apm:` block itself is missing, add it.
 - If neither `target:` nor `targets:` includes the detected host, add it. Don't remove existing targets. When adding a host pushes the count from one to two, convert `target: <name>` into a `targets:` list with both entries; when removing a host (not something this skill does, but worth knowing) drops the count back to one, convert the list back to the scalar form.
-- If `--update` was passed explicitly **and** `srid/agency` is already pinned to something other than `#master`, re-pin it to `#master`. Without the flag, leave the existing pin alone.
 
-Don't touch unrelated entries.
+Don't touch unrelated entries. Refreshing an existing `srid/agency` pin is handled by `apm deps update` in step 6 — don't hand-edit the ref here.
 
 ## 4. Ensure `.gitignore` covers agency runtime artifacts
 
@@ -122,9 +121,11 @@ applyTo: "**"
 Keep `README.md` in sync with user-facing changes.
 ```
 
-## 6. Run `apm install` (and `apm compile` for Codex / opencode)
+## 6. Run `apm deps update` (if `--update`), then `apm install` (and `apm compile` for Codex / opencode)
 
-Now that every file change is on disk, regenerate the host configs in a single pass. Run `<apm-invocation> install` from the directory containing `apm.yml`. `apm` reads `target:` / `targets:` from the yml and generates the runtime-specific folders (`.claude/` / `.opencode/` / `.codex/`), plus adds `apm_modules/` to `.gitignore`.
+If `--update` was passed, first run `<apm-invocation> deps update srid/agency` from the directory containing `apm.yml`. `apm install` alone won't move an already-installed dependency to a newer ref — `deps update` is what pulls the latest commit on the pinned ref. Skip this sub-step entirely when `--update` was not passed.
+
+Then, regardless of `--update`, regenerate the host configs in a single pass. Run `<apm-invocation> install` from the directory containing `apm.yml`. `apm` reads `target:` / `targets:` from the yml and generates the runtime-specific folders (`.claude/` / `.opencode/` / `.codex/`), plus adds `apm_modules/` to `.gitignore`.
 
 **`install` does not generate the project-root `AGENTS.md` instruction file.** Codex and opencode read `AGENTS.md` at session start; without it they will not see the workflow instructions, code-police rules, or any other `.apm/instructions/` content. To produce it, also run:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The agent will:
 
 Review the staged changes before committing.
 
-Pasting the same prompt again later acts as an **update** — it detects the existing install and refreshes generated files. Append `--update` to also re-pin `srid/agency` to `#master`.
+Pasting the same prompt again later acts as an **update** — it detects the existing install, refreshes `srid/agency` to the latest commit on its pinned ref (via `apm deps update srid/agency`), and regenerates the host folders.
 
 ## What's included
 
@@ -46,7 +46,7 @@ Pasting the same prompt again later acts as an **update** — it detects the exi
 - **`fact-check`** — Standalone correctness audit: finds silent error swallowing, unjustified fallbacks, wishful thinking, and logic errors. Prosecutor posture — no self-dismissals.
 - **`elegance`** — Iterative elegance pass: understand, research, apply, verify. Runs 3 iterations by default, each building on the last.
 - **`forge-pr`** — Writes PR titles and descriptions that devs actually want to read. Paragraphs over bullet lists, substance over boilerplate. GitHub today; Bitbucket support tracked in [#10](https://github.com/srid/agency/issues/10).
-- **`agency-setup`** — Bootstraps or updates srid/agency in a project. Powers the [Quickstart](#quickstart) prompt; re-paste later to refresh, or append `--update` to re-pin `srid/agency` to `#master`.
+- **`agency-setup`** — Bootstraps or updates srid/agency in a project. Powers the [Quickstart](#quickstart) prompt; re-paste later to refresh — when `srid/agency` is already in `apm.yml`, the skill runs `apm deps update srid/agency` to pull the latest commit on the pinned ref before regenerating host folders.
 
 ### Hooks & Instructions
 


### PR DESCRIPTION
## Summary

- The skill was telling the agent to re-pin `apm.yml` and run `apm install` for refreshes, but `apm install` won't move an already-installed dep to a newer ref. Switch to `apm deps update srid/agency`, which is the right tool for that job.
- Removes the `--update` argument entirely — re-running the skill is itself the "refresh" gesture. When `srid/agency` is already listed in `apm.yml` at the start of the run, the skill now runs `apm deps update srid/agency` before `apm install` / `apm compile`. First-time installs skip the deps-update sub-step; `apm install` fetches the freshly added entry.
- README updated to match the new behavior (no more `--update`, no more "re-pin to `#master`").

## Test plan

- [ ] Run `/agency-setup` in a repo that has no `apm.yml` — verify it creates one with `srid/agency#master`, runs `apm install` (and `apm compile` for codex/opencode), and does **not** run `apm deps update`.
- [ ] Run `/agency-setup` again in the same repo — verify it now runs `apm deps update srid/agency` first, followed by `apm install` (and `apm compile`).
- [ ] Spot-check the rendered SKILL.md frontmatter has no `argument-hint` and the body has no `--update` or `ARGUMENTS:` line left over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)