### PR TITLE
do: add opt-in evidence step for PR artifacts

### DIFF
--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -99,7 +99,6 @@ Final file uses this template, including only the sections the user kept:
 ```markdown
 ---
 description: Workflow commands for the do pipeline
-applyTo: "**"
 ---
 
 ## Check command
@@ -148,6 +147,7 @@ Summarize for the user, in this order:
    - `code-police-rules.instructions.md` — project-specific quality rules checked alongside the built-in `code-police` rules.
    - `hickey-catalog.instructions.md` — project-specific complecting patterns extending the Hickey Layer 4 catalog.
    - `lowy-volatilities.instructions.md` — project-declared areas of volatility used by the Lowy review pass.
+   - `pr-evidence.instructions.md` — opts the project into `/do`'s `evidence` step, which posts an `## Evidence` PR comment with project-defined empirical artifacts (UI screenshots via chrome-devtools MCP, benchmark numbers, demo recordings, etc.).
 
    Point them at [Kolu's `.apm/instructions/`](https://github.com/juspay/kolu/tree/master/.apm/instructions) as a worked example. Skip files that already exist.
 6. **Restart the agent CLI** (Claude Code, Codex, opencode, etc.) so it picks up the newly generated skills — without a restart, the new skills won't be available in the running session.

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -62,10 +62,10 @@ Each step is bookended by two calls to the `scripts/do-results` script (in this 
 
 ## Progress tracking
 
-Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a live checklist of the workflow. At the start of **sync** (or the chosen `--from` entry point), seed a task list with all 14 step names in order:
+Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a live checklist of the workflow. At the start of **sync** (or the chosen `--from` entry point), seed a task list with all 15 step names in order:
 
 ```
-sync, research, branch, implement, check, docs, fmt, commit, hickey+lowy, police, test, create-pr, ci, done
+sync, research, branch, implement, check, docs, fmt, commit, hickey+lowy, police, test, create-pr, ci, evidence, done
 ```
 
 At each step boundary, update task state **alongside** the `scripts/do-results` script call — they are not redundant. The JSON file is machine state for the stop hook; the task list is the human-facing UI. Miss either and the workflow is inconsistent.
@@ -74,7 +74,7 @@ Rules:
 
 - **Flip to `in_progress` when a step starts, `completed` when it verifies.** One step `in_progress` at a time.
 - **Retries stay `in_progress`.** If `check`, `test`, or `ci` loop through their retry budget, do **not** bounce the task state back to `pending` or flicker it — leave it `in_progress` until the step finally verifies (or the retries exhaust and the workflow fails).
-- **`--from <step>` entry points**: still seed all 14 steps. Mark steps earlier than the entry point as `completed` immediately after seeding, so the checklist shows a consistent 14-item view regardless of entry point.
+- **`--from <step>` entry points**: still seed all 15 steps. Mark steps earlier than the entry point as `completed` immediately after seeding, so the checklist shows a consistent 15-item view regardless of entry point.
 - **Skipped steps** (e.g. `branch`/`commit`/`create-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. Record the skip with a back-to-back `scripts/do-results step-start <name>` / `scripts/do-results step-end skipped ... "<reason>"`; the task list just shows the step as done.
 - **Failure**: if retries exhaust and the workflow halts, leave the failing step `in_progress`, mark `done` `completed` after the failure summary is written, and run `scripts/do-results set status failed`.
 
@@ -370,14 +370,46 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 
 ---
 
+### evidence
+
+**Opt-in step.** Most projects skip this. The step exists so projects with empirical "did the feature actually work" needs — UI screenshots, performance benchmarks, demo recordings, output transcripts — can attach that evidence to the PR without baking the mechanism into agency.
+
+**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to attach evidence to.
+
+**If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. (Bitbucket comment wiring is tracked in #10.)
+
+**If `.apm/instructions/pr-evidence.instructions.md` does not exist**: Skip with status `skipped` and reason `"no .apm/instructions/pr-evidence.instructions.md"`. This is the default for projects that haven't opted in.
+
+**If the file exists**:
+
+Read it. The file is project-specific and describes how this project demonstrates a finished feature — what tools to use (e.g. `chrome-devtools` MCP for screenshots, `hyperfine` for benchmarks, `asciinema` for terminal demos), what to capture (which routes, which scenarios), and how to host any binary artifacts (screenshots typically need to be uploaded somewhere referenceable since `gh pr comment` does not attach files — the instruction file specifies the upload path). Agency does **not** prescribe any of this; follow whatever the file says.
+
+After gathering the evidence, post it as a single PR comment under a `## Evidence` heading using `gh pr comment`. Use the **single-quoted heredoc** pattern (see `forge-pr` → "Passing the body to `gh` safely") so backticks and `$` survive unescaped:
+
+```sh
+gh pr comment --body "$(cat <<'EOF'
+## Evidence
+
+<markdown produced per pr-evidence.instructions.md>
+EOF
+)"
+```
+
+Embed image/asset URLs inline in the markdown — `gh pr comment` itself cannot attach files.
+
+**Verify**: Either the step was skipped per the rules above, or a `## Evidence` PR comment exists (`gh pr view --comments` or equivalent) with the markdown produced from the instruction file.
+
+---
+
 ### done
 
 Present a summary of all steps with their verification status. If any step has a non-success status, retry it (max 3 attempts from done). If still failing after retries, set `status: "failed"`.
 
-`"completed"` requires **all steps `passed`**, with two exceptions that count toward completion:
+`"completed"` requires **all steps `passed`**, with three exceptions that count toward completion:
 
 1. A step `skipped` with `reason` beginning `"non-<forge> forge:"` (detected forge isn't GitHub).
 2. A step `skipped` with `reason` `"--no-git"` (user opted out of git operations).
+3. A step `skipped` with `reason` `"no .apm/instructions/pr-evidence.instructions.md"` (project hasn't opted into the evidence step — this is the default).
 
 A `failed` step always blocks `"completed"`. No redefining "passed," no footnote caveats. Update via `scripts/do-results set status completed` or `scripts/do-results set status failed` accordingly.
 
@@ -446,7 +478,7 @@ COMMENT
 
 ## Rules
 
-- **Never skip steps** (unless skipped by `--no-git` or forge detection). Run them in order from entry point to **done**.
+- **Never skip steps** (unless skipped by `--no-git`, forge detection, or — for **evidence** — the project hasn't opted in via `.apm/instructions/pr-evidence.instructions.md`). Run them in order from entry point to **done**.
 - **Every commit is NEW.** Never amend, rebase, or force-push.
 - **Feature branches only.** Never commit to master/main. (Under `--no-git`, no commits happen at all, so this rule is moot — the agent leaves the user on whatever branch they started on.)
 - **Background for CI.** Run CI with `run_in_background: true`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Pasting the same prompt again later acts as an **update** — it detects the exi
 
 #### Primary skills
 
-- **`do`** — Full pipeline: research → implement → structural review (hickey, lowy) → quality gate (code-police) → CI → ship. Structural review runs **post-implement on the concrete diff**, and each "Fix in this PR" finding lands as its own commit — so the PR history reads as a progression from primary implementation to each refinement. Fully autonomous; skip specific steps by mentioning them in the prompt.
+- **`do`** — Full pipeline: research → implement → structural review (hickey, lowy) → quality gate (code-police) → CI → evidence (opt-in) → ship. Structural review runs **post-implement on the concrete diff**, and each "Fix in this PR" finding lands as its own commit — so the PR history reads as a progression from primary implementation to each refinement. Fully autonomous; skip specific steps by mentioning them in the prompt.
 - **`talk`** — Conversation-and-research mode. Discuss ideas, explore approaches, read code, inspect upstream sources in temporary scratch space when needed — no repo changes allowed.
 - **`ralph`** — Iterative measurement-driven improvement loop. Measure, profile, mutate, re-measure, commit. Works for performance, bundle size, complexity — anything quantifiable.
 
@@ -85,6 +85,33 @@ Data fetching must go through server functions, never direct API calls from comp
 ```
 
 These get checked alongside the built-in rules during the police pass. See [Kolu's `code-police-rules.instructions.md`](https://github.com/juspay/kolu/blob/master/.apm/instructions/code-police-rules.instructions.md) for a worked example.
+
+## Project-specific PR evidence
+
+Mechanical gates (tests, CI, hickey/lowy) verify the diff is _correct_; they don't show the diff is _working_. `do`'s **`evidence` step** closes that gap by posting an `## Evidence` PR comment with project-defined empirical artifacts — UI screenshots, benchmark numbers, demo recordings — captured against the just-shipped change.
+
+The step is **opt-in**: it runs only when `.apm/instructions/pr-evidence.instructions.md` exists, and it skips silently otherwise. The instruction file is project-specific and tells the agent what to capture and how:
+
+```markdown
+---
+description: How to capture and post post-merge evidence on PRs
+---
+
+## PR Evidence
+
+For every PR that touches the UI:
+
+1. Use the `chrome-devtools` MCP to launch `npm run dev` and navigate to the
+   affected route.
+2. Capture a screenshot of the new state and upload it via `gh api` to the
+   repo's release-asset endpoint.
+3. Embed the resulting URL inline in the PR comment under `## Evidence`.
+
+For perf-sensitive changes, run `hyperfine` against `main` and the PR branch
+and paste the table into the comment instead.
+```
+
+Agency does not prescribe the capture mechanism — chrome-devtools MCP, `hyperfine`, `asciinema`, manual scripts all work. The convention is just _"`/do`'s `evidence` step reads this file and follows it"_.
 
 ## Examples
 


### PR DESCRIPTION
**Adds a 15th step `evidence` to the `/do` pipeline** — sandwiched between `ci` and `done` — that lets projects post empirical "did this feature actually work" artifacts (UI screenshots, benchmark numbers, demo recordings, output transcripts) as a structured PR comment. The step is **opt-in** and skips silently for any project that hasn't dropped `.apm/instructions/pr-evidence.instructions.md` into its repo.

This closes a real gap that mechanical gates (tests, CI, hickey/lowy) don't cover: those verify the diff is _correct_, but they never demonstrate the diff is _working_. The original ask was Kolu wanting `/do` to capture chrome-devtools MCP screenshots and attach them to the PR; rather than bake chrome-devtools (or any specific capture mechanism) into agency, the new step reads the project's instruction file and follows whatever capture/upload recipe lives there. Same generic-toolkit-with-project-specific-extension pattern that `code-police-rules`, `hickey-catalog`, and `lowy-volatilities` already use.

Also drops `applyTo: \"**\"` from the `workflow.instructions.md` template that `agency-setup` writes — `/do` already reads that file explicitly at the `check`/`fmt`/`test`/`ci`/`docs` steps, so preloading it on every file touch via `applyTo` was just context noise.

> _Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._