### PR TITLE
simplify: per-skill .agency/<name>.md project config

### DIFF
--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -86,7 +86,7 @@ If it's missing (whether this is a first-time setup or an upgrade where the user
 - `Cargo.toml`, `flake.nix`, `pyproject.toml`
 - `.github/workflows/` for CI hints
 
-For each of the four sections (Check, Format, Test, CI), there are three possible outcomes:
+For each of the four command sections (Check, Format, Test, CI), there are three possible outcomes:
 
 - **Found a clear command** in the project → fill it in.
 - **Found a plausible command but you're not certain** → use `AskUserQuestion` to confirm. Offer the candidate as one option and "skip this section" as another, with a free-form fallback for the user to type a different command.
@@ -94,7 +94,9 @@ For each of the four sections (Check, Format, Test, CI), there are three possibl
 
 Sections the user discards are **omitted from the generated file entirely** — no `# TODO` placeholders. `do` already handles missing sections by skipping the corresponding step with a note, which is the right behavior for a section the user has consciously declined.
 
-Final file uses this template, including only the sections the user kept:
+The file also hosts **four optional sections** that other agency skills (`code-police`, `hickey`, `lowy`, `/do` evidence) read at runtime. Don't fill these in autonomously — they're project-specific and can't be inferred. Mention them at report-back time (step 7) so the user can layer them on later. Each section is free-form: inline prose, a pointer to another file (`See ./code-police-rules.md`), or a script reference all work.
+
+Final file uses this template, including only the command sections the user kept and leaving the optional sections out (the user adds them manually if and when they want them):
 
 ```markdown
 ---
@@ -115,6 +117,13 @@ description: Workflow commands for the do pipeline
 
 ## Documentation
 Keep `README.md` in sync with user-facing changes.
+
+<!-- Optional sections (add manually if needed):
+## Code-police rules
+## Hickey catalog
+## Lowy volatilities
+## PR evidence
+-->
 ```
 
 ## 6. Refresh `srid/agency` (if already present), then run `apm install` (and `apm compile` for Codex / opencode)
@@ -143,13 +152,13 @@ Summarize for the user, in this order:
 2. Which target(s) ended up in `apm.yml` (and which form — `target:` scalar or `targets:` list).
 3. Which workflow sections were filled in (and from where) versus skipped at the user's request.
 4. Files changed (staged, not committed). Tell them to review the diff before committing.
-5. **Optional instructions to consider adding** — list whichever of these files do **not** yet exist under `.apm/instructions/`, and explain briefly what each is for. They're project-specific and can't be auto-generated, but the user should know they exist so they can layer them on:
-   - `code-police-rules.instructions.md` — project-specific quality rules checked alongside the built-in `code-police` rules.
-   - `hickey-catalog.instructions.md` — project-specific complecting patterns extending the Hickey Layer 4 catalog.
-   - `lowy-volatilities.instructions.md` — project-declared areas of volatility used by the Lowy review pass.
-   - `pr-evidence.instructions.md` — opts the project into `/do`'s `evidence` step, which posts an `## Evidence` PR comment with project-defined empirical artifacts (UI screenshots via chrome-devtools MCP, benchmark numbers, demo recordings, etc.).
+5. **Optional sections to consider adding to `workflow.instructions.md`** — list whichever of these are **not** already present in the file, and explain briefly what each is for. They're project-specific and can't be auto-generated, but the user should know they exist so they can layer them on. Each is free-form: inline prose, a file pointer (`See ./<path>`), or a script reference all work.
+   - `## Code-police rules` — project-specific quality rules checked alongside the built-in `code-police` rules.
+   - `## Hickey catalog` — project-specific complecting/fragmentation patterns extending the Hickey Layer 4 catalog.
+   - `## Lowy volatilities` — project-declared areas of volatility used by the Lowy review pass.
+   - `## PR evidence` — opts the project into `/do`'s `evidence` step, which posts an `## Evidence` PR comment with project-defined empirical artifacts (UI screenshots via chrome-devtools MCP, benchmark numbers, demo recordings, etc.).
 
-   Point them at [Kolu's `.apm/instructions/`](https://github.com/juspay/kolu/tree/master/.apm/instructions) as a worked example. Skip files that already exist.
+   Point them at [Kolu's `workflow.instructions.md`](https://github.com/juspay/kolu/blob/master/.apm/instructions/workflow.instructions.md) as a worked example. Skip sections that already exist.
 6. **Restart the agent CLI** (Claude Code, Codex, opencode, etc.) so it picks up the newly generated skills — without a restart, the new skills won't be available in the running session.
 7. After restart, try `talk` or `do` to verify everything works. Tell the user the **exact** invocation syntax for the target(s) you installed for — don't make them guess:
    - **Claude Code** → `/talk <question>` and `/do <task>` (slash commands).

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -7,13 +7,13 @@ description: Bootstrap or update srid/agency in this project — run apm via uvx
 
 Configure (or refresh) this repo to use [srid/agency](https://github.com/srid/agency). Each step below is **idempotent** — it inspects what's already on disk and acts only on what's missing or out of date. The skill works equally well as first-time bootstrap, full refresh, or **partial-install upgrade** (e.g. user already added `srid/agency` to `apm.yml` manually but never created `.agency/do.md` — the skill detects the gap and fills it without re-doing the parts that already exist).
 
-When the repo already has `srid/agency` in `apm.yml`, this skill also refreshes it to the latest ref (via `apm deps update srid/agency` in step 6) — there's no separate "update" mode.
+When the repo already has `srid/agency` in `apm.yml`, this skill also refreshes it to the latest ref (via `apm deps update srid/agency` in step 7) — there's no separate "update" mode.
 
 Don't commit anything — leave changes staged for the user to review.
 
 ## Invariant: `apm install` and `apm compile` run *after* every file change
 
-`apm install` regenerates the host folders (`.claude/`, `.opencode/`, `.codex/`) from `apm.yml` plus the contents of `.apm/`, and `apm compile -t <subset>` produces the project-root `AGENTS.md` for Codex / opencode from the same inputs. **Any** change to `apm.yml` or anything under `.apm/` invalidates both outputs. So this skill makes all file changes first (steps 1–5) and runs `apm install` (and `apm compile` where needed) exactly once at the end (step 6). Don't run install or compile partway through — later steps may add or modify files that must land in the same regeneration. If you ever edit `apm.yml` or `.apm/*` outside the prescribed order, you must re-run both before reporting back.
+`apm install` regenerates the host folders (`.claude/`, `.opencode/`, `.codex/`) from `apm.yml` plus the contents of `.apm/`, and `apm compile -t <subset>` produces the project-root `AGENTS.md` for Codex / opencode from the same inputs. **Any** change to `apm.yml` or anything under `.apm/` invalidates both outputs. So this skill makes all file changes first (steps 1–6) and runs `apm install` (and `apm compile` where needed) exactly once at the end (step 7). Don't run install or compile partway through — later steps may add or modify files that must land in the same regeneration. If you ever edit `apm.yml` or `.apm/*` outside the prescribed order, you must re-run both before reporting back.
 
 ## 1. Pick an `apm` invocation
 
@@ -40,7 +40,7 @@ Multiple matches are fine — declare all of them. If nothing matches and the ho
 
 ## 3. Create or extend `apm.yml`
 
-Before editing, note whether `srid/agency` is already listed under `dependencies.apm:` — step 6 needs that fact to decide whether to refresh the dep.
+Before editing, note whether `srid/agency` is already listed under `dependencies.apm:` — steps 5 and 7 both need that fact (step 5 skips on first-time setup; step 7 decides whether to refresh the dep).
 
 If `apm.yml` does not exist, write:
 
@@ -63,18 +63,49 @@ If `apm.yml` already exists, edit it idempotently:
 - If `dependencies.apm:` is missing the `srid/agency` entry, append `srid/agency#master`. Preserve every existing entry. If the `dependencies.apm:` block itself is missing, add it.
 - If neither `target:` nor `targets:` includes the detected host, add it. Don't remove existing targets. When adding a host pushes the count from one to two, convert `target: <name>` into a `targets:` list with both entries; when removing a host (not something this skill does, but worth knowing) drops the count back to one, convert the list back to the scalar form.
 
-Don't touch unrelated entries. Refreshing an existing `srid/agency` pin is handled by `apm deps update` in step 6 — don't hand-edit the ref here.
+Don't touch unrelated entries. Refreshing an existing `srid/agency` pin is handled by `apm deps update` in step 7 — don't hand-edit the ref here.
 
 ## 4. Ensure `.gitignore` covers agency runtime artifacts
 
-`apm install` (which runs in step 6) will add `apm_modules/` for you, but `do` writes `.do-results.json` at the repo root during a workflow run and that should not be committed. Make sure both lines exist in `.gitignore` (create the file if missing), idempotently — don't duplicate entries that are already there:
+`apm install` (which runs in step 7) will add `apm_modules/` for you, but `do` writes `.do-results.json` at the repo root during a workflow run and that should not be committed. Make sure both lines exist in `.gitignore` (create the file if missing), idempotently — don't duplicate entries that are already there:
 
 - `/.do-results.json`
 - `/apm_modules/` (verify; `apm install` may already have added it as `apm_modules/` — either form is fine)
 
-## 5. Draft `.agency/do.md`
+## 5. Apply pending migrations
 
-If this file already exists, **leave it alone** — the user has either already configured it or is intentionally hand-maintaining it. Skip to step 6.
+**Skip if this is a first-time setup** — `srid/agency` was not in `apm.yml` at the start of step 3, so there's nothing to migrate from.
+
+Otherwise, work through the registry below in order. **Each entry is idempotent** — re-running on an already-migrated repo is a no-op (the detection condition will simply fail). Apply only the entries whose detection condition is currently true.
+
+For each entry: announce to the user which migration is being applied and which files it touches, then perform the listed steps. Do **not** ask permission per entry — the user invoked this skill to refresh their install; that's authorization. Migrations only restructure files; they don't drop content.
+
+### #123 (simplify) — project config to `.agency/<skill>.md`
+
+**Detect**: any of these legacy paths exist:
+- `.apm/instructions/code-police-rules.instructions.md`
+- `.apm/instructions/hickey-catalog.instructions.md`
+- `.apm/instructions/lowy-volatilities.instructions.md`
+- `.apm/instructions/pr-evidence.instructions.md`
+- a `.apm/instructions/workflow.instructions.md` containing any of `## Check command`, `## Format command`, `## Test command`, `## CI command`, `## Documentation`
+
+**Migrate**:
+
+1. Create `.agency/` at the repo root.
+2. For each `.apm/instructions/<name>.instructions.md` extension file present, `git mv` it to its new location and **strip the YAML frontmatter** (delete everything from the first `---` to the second `---`, inclusive) from the moved file:
+   - `code-police-rules.instructions.md` → `.agency/code-police.md`
+   - `hickey-catalog.instructions.md` → `.agency/hickey.md`
+   - `lowy-volatilities.instructions.md` → `.agency/lowy.md`
+3. If `pr-evidence.instructions.md` was present, append its body (post-frontmatter) as a `## PR evidence` section to `.agency/do.md` (create the file if it doesn't exist yet — header `# /do config`, then the section). Delete the original file once content is moved.
+4. If `workflow.instructions.md` contains the `/do` command sections (`## Check command` etc., `## Documentation`), extract them into `.agency/do.md` (creating it if needed) and delete those sections from `workflow.instructions.md`.
+5. If `workflow.instructions.md` still has substantive content after the extraction (project-wide preamble, Git conventions, library notes, etc.), leave it alone — but its name no longer reflects its role. Suggest renaming to `conventions.instructions.md` at report-back time. If the file is empty or only has frontmatter after the extraction, `git rm` it.
+6. The stale `.claude/rules/` mirrors of the moved files will be cleaned up automatically by `apm install` in step 7.
+
+(Future migrations get appended below as new `### #<PR>` subsections.)
+
+## 6. Draft `.agency/do.md`
+
+If this file already exists, **leave it alone** — the user has either already configured it or is intentionally hand-maintaining it. Skip to step 7.
 
 If it's missing (whether this is a first-time setup or an upgrade where the user added `srid/agency` to `apm.yml` themselves but never wrote a do config), create it now. Make sure the `.agency/` directory exists at the project root before writing.
 
@@ -94,7 +125,7 @@ For each of the four command sections (Check, Format, Test, CI), there are three
 
 Sections the user discards are **omitted from the generated file entirely** — no `# TODO` placeholders. `do` already handles missing sections by skipping the corresponding step with a note, which is the right behavior for a section the user has consciously declined.
 
-The same file also hosts an optional `## PR evidence` section that `/do`'s evidence step reads at runtime. Don't fill it in autonomously — it's project-specific and can't be inferred. Mention it at report-back time (step 7) so the user can add it later if they want PR-comment screenshots/benchmarks/etc. The section is free-form (inline prose, file pointer, script reference — all work).
+The same file also hosts an optional `## PR evidence` section that `/do`'s evidence step reads at runtime. Don't fill it in autonomously — it's project-specific and can't be inferred. Mention it at report-back time (step 8) so the user can add it later if they want PR-comment screenshots/benchmarks/etc. The section is free-form (inline prose, file pointer, script reference — all work).
 
 Final file uses this template, including only the command sections the user kept and leaving the optional `## PR evidence` section out (the user adds it manually if and when they want it):
 
@@ -121,7 +152,7 @@ Keep `README.md` in sync with user-facing changes.
 -->
 ```
 
-## 6. Refresh `srid/agency` (if already present), then run `apm install` (and `apm compile` for Codex / opencode)
+## 7. Refresh `srid/agency` (if already present), then run `apm install` (and `apm compile` for Codex / opencode)
 
 If `srid/agency` was already listed in `apm.yml` at the start of this run (you noted this in step 3), first run `<apm-invocation> deps update srid/agency` from the directory containing `apm.yml`. `apm install` alone won't move an already-installed dependency to a newer ref — `deps update` is what pulls the latest commit on the pinned ref. Skip this sub-step on first-time setup, where step 3 just added the entry; `apm install` will fetch it fresh.
 
@@ -139,23 +170,24 @@ If `install` or `compile` fails, surface the error verbatim and stop — don't p
 
 If you discover after this step that you still need to touch `apm.yml` or anything under `.apm/`, run `install` (and `compile` if applicable) again before moving on. The invariant at the top is non-negotiable.
 
-## 7. Report back
+## 8. Report back
 
 Summarize for the user, in this order:
 
 1. Which `apm` invocation you used (so the user knows the exact command for ad-hoc `apm` calls later).
 2. Which target(s) ended up in `apm.yml` (and which form — `target:` scalar or `targets:` list).
 3. Which workflow sections were filled in (and from where) versus skipped at the user's request.
-4. Files changed (staged, not committed). Tell them to review the diff before committing.
-5. **Optional `.agency/<name>.md` files to consider adding** — list whichever of these don't yet exist under `.agency/`, and explain briefly what each is for. They're project-specific and can't be auto-generated, but the user should know they exist so they can layer them on. Each file is plain Markdown — no frontmatter — and free-form (inline content or `See ./<path>` pointers all work).
+4. **Migrations applied** (if step 5 ran) — list each migration entry that fired and what it touched, so the user knows what restructuring happened in their tree. If a migration suggested a follow-up rename (e.g. `workflow.instructions.md` → `conventions.instructions.md`), surface that suggestion here.
+5. Files changed (staged, not committed). Tell them to review the diff before committing.
+6. **Optional `.agency/<name>.md` files to consider adding** — list whichever of these don't yet exist under `.agency/`, and explain briefly what each is for. They're project-specific and can't be auto-generated, but the user should know they exist so they can layer them on. Each file is plain Markdown — no frontmatter — and free-form (inline content or `See ./<path>` pointers all work).
    - `.agency/code-police.md` — project-specific quality rules checked alongside the built-in `code-police` rules.
    - `.agency/hickey.md` — project-specific complecting/fragmentation patterns extending the Hickey Layer 4 catalog.
    - `.agency/lowy.md` — project-declared areas of volatility used by the Lowy review pass.
-   - `.agency/do.md` `## PR evidence` section (in the file you may have just written in step 5) — opts the project into `/do`'s `evidence` step, which posts an `## Evidence` PR comment with project-defined empirical artifacts (UI screenshots via chrome-devtools MCP, benchmark numbers, demo recordings, etc.).
+   - `.agency/do.md` `## PR evidence` section (in the file you may have just written in step 6) — opts the project into `/do`'s `evidence` step, which posts an `## Evidence` PR comment with project-defined empirical artifacts (UI screenshots via chrome-devtools MCP, benchmark numbers, demo recordings, etc.).
 
    Point them at [Kolu's `.agency/`](https://github.com/juspay/kolu/tree/master/.agency) as a worked example. Skip files/sections that already exist.
-6. **Restart the agent CLI** (Claude Code, Codex, opencode, etc.) so it picks up the newly generated skills — without a restart, the new skills won't be available in the running session.
-7. After restart, try `talk` or `do` to verify everything works. Tell the user the **exact** invocation syntax for the target(s) you installed for — don't make them guess:
+7. **Restart the agent CLI** (Claude Code, Codex, opencode, etc.) so it picks up the newly generated skills — without a restart, the new skills won't be available in the running session.
+8. After restart, try `talk` or `do` to verify everything works. Tell the user the **exact** invocation syntax for the target(s) you installed for — don't make them guess:
    - **Claude Code** → `/talk <question>` and `/do <task>` (slash commands).
    - **Codex** → `$talk <question>` and `$do <task>` (dollar prefix).
    - **opencode** → invoke `/skills` and pick `talk` or `do` from the list.

--- a/.apm/skills/agency-setup/SKILL.md
+++ b/.apm/skills/agency-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: agency-setup
-description: Bootstrap or update srid/agency in this project — run apm via uvx, configure apm.yml, install skills, draft workflow instructions. Use for first-time setup or to refresh an existing install.
+description: Bootstrap or update srid/agency in this project — run apm via uvx, configure apm.yml, install skills, draft .agency/do.md. Use for first-time setup or to refresh an existing install.
 ---
 
 # Agency Setup
 
-Configure (or refresh) this repo to use [srid/agency](https://github.com/srid/agency). Each step below is **idempotent** — it inspects what's already on disk and acts only on what's missing or out of date. The skill works equally well as first-time bootstrap, full refresh, or **partial-install upgrade** (e.g. user already added `srid/agency` to `apm.yml` manually but never created `workflow.instructions.md` — the skill detects the gap and fills it without re-doing the parts that already exist).
+Configure (or refresh) this repo to use [srid/agency](https://github.com/srid/agency). Each step below is **idempotent** — it inspects what's already on disk and acts only on what's missing or out of date. The skill works equally well as first-time bootstrap, full refresh, or **partial-install upgrade** (e.g. user already added `srid/agency` to `apm.yml` manually but never created `.agency/do.md` — the skill detects the gap and fills it without re-doing the parts that already exist).
 
 When the repo already has `srid/agency` in `apm.yml`, this skill also refreshes it to the latest ref (via `apm deps update srid/agency` in step 6) — there's no separate "update" mode.
 
@@ -72,11 +72,11 @@ Don't touch unrelated entries. Refreshing an existing `srid/agency` pin is handl
 - `/.do-results.json`
 - `/apm_modules/` (verify; `apm install` may already have added it as `apm_modules/` — either form is fine)
 
-## 5. Draft `.apm/instructions/workflow.instructions.md`
+## 5. Draft `.agency/do.md`
 
 If this file already exists, **leave it alone** — the user has either already configured it or is intentionally hand-maintaining it. Skip to step 6.
 
-If it's missing (whether this is a first-time setup or an upgrade where the user added `srid/agency` to `apm.yml` themselves but never wrote workflow instructions), create it now.
+If it's missing (whether this is a first-time setup or an upgrade where the user added `srid/agency` to `apm.yml` themselves but never wrote a do config), create it now. Make sure the `.agency/` directory exists at the project root before writing.
 
 `do` runs autonomously but needs to know your project's check, format, test, and CI commands. Inspect the project to figure them out — look at:
 
@@ -94,14 +94,12 @@ For each of the four command sections (Check, Format, Test, CI), there are three
 
 Sections the user discards are **omitted from the generated file entirely** — no `# TODO` placeholders. `do` already handles missing sections by skipping the corresponding step with a note, which is the right behavior for a section the user has consciously declined.
 
-The file also hosts **four optional sections** that other agency skills (`code-police`, `hickey`, `lowy`, `/do` evidence) read at runtime. Don't fill these in autonomously — they're project-specific and can't be inferred. Mention them at report-back time (step 7) so the user can layer them on later. Each section is free-form: inline prose, a pointer to another file (`See ./code-police-rules.md`), or a script reference all work.
+The same file also hosts an optional `## PR evidence` section that `/do`'s evidence step reads at runtime. Don't fill it in autonomously — it's project-specific and can't be inferred. Mention it at report-back time (step 7) so the user can add it later if they want PR-comment screenshots/benchmarks/etc. The section is free-form (inline prose, file pointer, script reference — all work).
 
-Final file uses this template, including only the command sections the user kept and leaving the optional sections out (the user adds them manually if and when they want them):
+Final file uses this template, including only the command sections the user kept and leaving the optional `## PR evidence` section out (the user adds it manually if and when they want it):
 
 ```markdown
----
-description: Workflow commands for the do pipeline
----
+# /do config
 
 ## Check command
 <command>
@@ -118,10 +116,7 @@ description: Workflow commands for the do pipeline
 ## Documentation
 Keep `README.md` in sync with user-facing changes.
 
-<!-- Optional sections (add manually if needed):
-## Code-police rules
-## Hickey catalog
-## Lowy volatilities
+<!-- Optional (add manually for the evidence step):
 ## PR evidence
 -->
 ```
@@ -132,7 +127,7 @@ If `srid/agency` was already listed in `apm.yml` at the start of this run (you n
 
 Then, regenerate the host configs in a single pass. Run `<apm-invocation> install` from the directory containing `apm.yml`. `apm` reads `target:` / `targets:` from the yml and generates the runtime-specific folders (`.claude/` / `.opencode/` / `.codex/`), plus adds `apm_modules/` to `.gitignore`.
 
-**`install` does not generate the project-root `AGENTS.md` instruction file.** Codex and opencode read `AGENTS.md` at session start; without it they will not see the workflow instructions, code-police rules, or any other `.apm/instructions/` content. To produce it, also run:
+**`install` does not generate the project-root `AGENTS.md` instruction file.** Codex and opencode read `AGENTS.md` at session start; without it they will not see any `.apm/instructions/` content (project-wide preamble, conventions, etc.). To produce it, also run:
 
 ```sh
 <apm-invocation> compile -t <subset>
@@ -152,13 +147,13 @@ Summarize for the user, in this order:
 2. Which target(s) ended up in `apm.yml` (and which form — `target:` scalar or `targets:` list).
 3. Which workflow sections were filled in (and from where) versus skipped at the user's request.
 4. Files changed (staged, not committed). Tell them to review the diff before committing.
-5. **Optional sections to consider adding to `workflow.instructions.md`** — list whichever of these are **not** already present in the file, and explain briefly what each is for. They're project-specific and can't be auto-generated, but the user should know they exist so they can layer them on. Each is free-form: inline prose, a file pointer (`See ./<path>`), or a script reference all work.
-   - `## Code-police rules` — project-specific quality rules checked alongside the built-in `code-police` rules.
-   - `## Hickey catalog` — project-specific complecting/fragmentation patterns extending the Hickey Layer 4 catalog.
-   - `## Lowy volatilities` — project-declared areas of volatility used by the Lowy review pass.
-   - `## PR evidence` — opts the project into `/do`'s `evidence` step, which posts an `## Evidence` PR comment with project-defined empirical artifacts (UI screenshots via chrome-devtools MCP, benchmark numbers, demo recordings, etc.).
+5. **Optional `.agency/<name>.md` files to consider adding** — list whichever of these don't yet exist under `.agency/`, and explain briefly what each is for. They're project-specific and can't be auto-generated, but the user should know they exist so they can layer them on. Each file is plain Markdown — no frontmatter — and free-form (inline content or `See ./<path>` pointers all work).
+   - `.agency/code-police.md` — project-specific quality rules checked alongside the built-in `code-police` rules.
+   - `.agency/hickey.md` — project-specific complecting/fragmentation patterns extending the Hickey Layer 4 catalog.
+   - `.agency/lowy.md` — project-declared areas of volatility used by the Lowy review pass.
+   - `.agency/do.md` `## PR evidence` section (in the file you may have just written in step 5) — opts the project into `/do`'s `evidence` step, which posts an `## Evidence` PR comment with project-defined empirical artifacts (UI screenshots via chrome-devtools MCP, benchmark numbers, demo recordings, etc.).
 
-   Point them at [Kolu's `workflow.instructions.md`](https://github.com/juspay/kolu/blob/master/.apm/instructions/workflow.instructions.md) as a worked example. Skip sections that already exist.
+   Point them at [Kolu's `.agency/`](https://github.com/juspay/kolu/tree/master/.agency) as a worked example. Skip files/sections that already exist.
 6. **Restart the agent CLI** (Claude Code, Codex, opencode, etc.) so it picks up the newly generated skills — without a restart, the new skills won't be available in the running session.
 7. After restart, try `talk` or `do` to verify everything works. Tell the user the **exact** invocation syntax for the target(s) you installed for — don't make them guess:
    - **Claude Code** → `/talk <question>` and `/do <task>` (slash commands).

--- a/.apm/skills/code-police/SKILL.md
+++ b/.apm/skills/code-police/SKILL.md
@@ -9,9 +9,9 @@ Review the current changes (scoped to the current branch/PR) against the rules b
 
 ## Project rules
 
-Before Pass 1, read `.apm/instructions/workflow.instructions.md` (if present) and look for a `## Code-police rules` section. Treat any rules listed there — whether inline or as a pointer to another file (`See ./code-police-rules.md`) — as additions to the built-in rules below. They appear as separate rows in the Pass 1 checklist with the project's chosen rule IDs.
+Before Pass 1, read `.agency/code-police.md` if it exists. Treat any rules declared there — whether inline or as a pointer to another file (`See ./code-police-rules.md`) — as additions to the built-in rules below. They appear as separate rows in the Pass 1 checklist with the project's chosen rule IDs.
 
-If no such section exists, proceed with only the built-in rules.
+If `.agency/code-police.md` is missing, proceed with only the built-in rules. The file is project-defined and free-form (Markdown, no required frontmatter).
 
 ## Rules
 

--- a/.apm/skills/code-police/SKILL.md
+++ b/.apm/skills/code-police/SKILL.md
@@ -5,7 +5,13 @@ description: Review code for quality, simplicity, and common mistakes before dec
 
 # Code Police
 
-Review the current changes (scoped to the current branch/PR) against the rules below **and any additional code-police rules from project instructions**, then run three passes in order.
+Review the current changes (scoped to the current branch/PR) against the rules below **plus any additional rules from the project**, then run three passes in order.
+
+## Project rules
+
+Before Pass 1, read `.apm/instructions/workflow.instructions.md` (if present) and look for a `## Code-police rules` section. Treat any rules listed there — whether inline or as a pointer to another file (`See ./code-police-rules.md`) — as additions to the built-in rules below. They appear as separate rows in the Pass 1 checklist with the project's chosen rule IDs.
+
+If no such section exists, proceed with only the built-in rules.
 
 ## Rules
 

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -117,7 +117,7 @@ Research the task thoroughly before writing code.
 **Delegation rule — keep the main context lean.** Before your third `Read` in this step, stop and delegate the rest via `Agent(subagent_type=Explore)`. Main-context reads are reserved for:
 
   (a) specific files the user named in the prompt,
-  (b) `.apm/instructions/**` and files referenced from them,
+  (b) `.apm/instructions/**` and `.agency/**` (and files referenced from them),
   (c) verifying a specific file:line an Explore subagent cited — and only with `offset`/`limit`, never full-file.
 
 Anything that smells like "map the codebase", "find all callers", "understand how X works across the repo" — delegate. The Explore subagent returns a file:line map; keep that map and reference it in later steps instead of re-reading. Use `Grep`/`Glob` before `Read`: if the question can be answered by searching, don't open the file.
@@ -162,7 +162,7 @@ Otherwise: implement the planned changes. Prefer simplicity. Do the boring obvio
 
 ### check
 
-Read the project's instructions to find the check command — a fast static-correctness gate (e.g. `tsc --noEmit`, `cargo check`, `cabal build`, `mypy`, `dune build @check`). Run it.
+Read `.agency/do.md` and look for a `## Check command` section — a fast static-correctness gate (e.g. `tsc --noEmit`, `cargo check`, `cabal build`, `mypy`, `dune build @check`). Run it.
 
 This is the cheapest gate in the pipeline, so it runs first — fail fast on broken code before any downstream step does work over it. If no check command is documented, skip this step with a note.
 
@@ -173,7 +173,7 @@ This is the cheapest gate in the pipeline, so it runs first — fail fast on bro
 
 ### docs
 
-Read the project's instructions to find which documentation files to keep in sync (e.g., README.md). Compare those files against changes in this PR.
+Read `.agency/do.md` and look for a `## Documentation` section listing which docs to keep in sync (e.g., README.md). Compare those files against changes in this PR.
 
 If no documentation files are documented, skip this step with a note.
 
@@ -184,7 +184,7 @@ If no documentation files are documented, skip this step with a note.
 
 ### fmt
 
-Read the project's instructions to find the format command (typically documented in a workflow instruction). Run it.
+Read `.agency/do.md` and look for a `## Format command` section. Run it.
 
 If no format command is documented, skip this step with a note.
 
@@ -288,7 +288,7 @@ For the elegance pass specifically: `/simplify` applies fixes in batches across 
 
 ### test
 
-Read the project's instructions to find the test command and strategy. Run only the tests relevant to the code paths changed in this PR.
+Read `.agency/do.md` and look for a `## Test command` section. Run only the tests relevant to the code paths changed in this PR.
 
 Use `git diff origin/HEAD...HEAD --name-only` to identify changed files and determine which tests are relevant.
 
@@ -350,15 +350,15 @@ Re-check the PR title/body against current scope. If scope changed, update via `
 
 ### ci
 
-Read the project's instructions to find the CI command and verification method. Run CI with `run_in_background: true` if the command takes more than a few seconds.
+Read `.agency/do.md` and look for a `## CI command` section, plus any verification method documented there. Run CI with `run_in_background: true` if the command takes more than a few seconds.
 
 **Never pipe CI to `tail`/`head`**, and **never append `2>&1`** — background mode captures both streams.
 
 **Active state**: Before waiting for background CI, run `scripts/do-results set active waiting`. When CI returns (success or failure), run `scripts/do-results set active working` before proceeding. This lets the stop hook allow graceful exits while the agent is idle.
 
-CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are forge-independent — **run them regardless of forge**. Only the *verification method* may be forge-specific: if the project's instructions describe verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output for verification on non-GitHub forges, and note this in the step record. (Bitbucket `bkt pr checks` wiring is tracked in #10.)
+CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are forge-independent — **run them regardless of forge**. Only the *verification method* may be forge-specific: if `.agency/do.md` describes verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output for verification on non-GitHub forges, and note this in the step record. (Bitbucket `bkt pr checks` wiring is tracked in #10.)
 
-**Verify**: Use the verification method described in the project's instructions (e.g., checking commit statuses on GitHub, reading CI output elsewhere). If no CI command is documented, skip with a note. **The CI result must cover `HEAD`.** Before recording the step as passed, compare the commit SHA that CI ran against with `git rev-parse HEAD`. If they differ (e.g., a commit was pushed after CI started — whether from a fix retry, user-requested changes, or any other source), re-run CI against the current HEAD. CI passing on a stale commit does not satisfy verification.
+**Verify**: Use the verification method described in `.agency/do.md` (e.g., checking commit statuses on GitHub, reading CI output elsewhere). If no CI command is documented, skip with a note. **The CI result must cover `HEAD`.** Before recording the step as passed, compare the commit SHA that CI ran against with `git rev-parse HEAD`. If they differ (e.g., a commit was pushed after CI started — whether from a fix retry, user-requested changes, or any other source), re-run CI against the current HEAD. CI passing on a stale commit does not satisfy verification.
 
 **On failure** — read logs or output to diagnose.
 
@@ -378,7 +378,7 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 
 **If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. (Bitbucket comment wiring is tracked in #10.)
 
-**Otherwise**: Read the project's `.apm/instructions/workflow.instructions.md` and look for a `## PR evidence` section. If the section is missing or empty, skip with status `skipped` and reason `"no PR evidence section in workflow.instructions.md"` — the default for projects that haven't opted in.
+**Otherwise**: Read `.agency/do.md` and look for a `## PR evidence` section. If `.agency/do.md` is missing, or the section is missing or empty, skip with status `skipped` and reason `"no PR evidence section in .agency/do.md"` — the default for projects that haven't opted in.
 
 **If the section is present**:
 
@@ -386,7 +386,7 @@ The section is project-specific and free-form: it can be inline prose describing
 
 The sub-agent prompt should include:
 
-- The literal section content from `workflow.instructions.md`.
+- The literal section content from `.agency/do.md`.
 - Standard PR context: PR URL, branch name, base branch, current commit SHA, and `git diff origin/HEAD...HEAD --name-only` so the sub-agent knows which routes/files to exercise.
 - An explicit instruction that the sub-agent's job is to return a single block of markdown (image links embedded, table data inline, etc.) suitable for posting under a `## Evidence` heading. The sub-agent should not post the comment itself — only return the markdown.
 
@@ -415,7 +415,7 @@ Present a summary of all steps with their verification status. If any step has a
 
 1. A step `skipped` with `reason` beginning `"non-<forge> forge:"` (detected forge isn't GitHub).
 2. A step `skipped` with `reason` `"--no-git"` (user opted out of git operations).
-3. A step `skipped` with `reason` `"no PR evidence section in workflow.instructions.md"` (project hasn't opted into the evidence step — this is the default).
+3. A step `skipped` with `reason` `"no PR evidence section in .agency/do.md"` (project hasn't opted into the evidence step — this is the default).
 
 A `failed` step always blocks `"completed"`. No redefining "passed," no footnote caveats. Update via `scripts/do-results set status completed` or `scripts/do-results set status failed` accordingly.
 
@@ -484,7 +484,7 @@ COMMENT
 
 ## Rules
 
-- **Never skip steps** (unless skipped by `--no-git`, forge detection, or — for **evidence** — the project hasn't filled in a `## PR evidence` section in `workflow.instructions.md`). Run them in order from entry point to **done**.
+- **Never skip steps** (unless skipped by `--no-git`, forge detection, or — for **evidence** — the project hasn't filled in a `## PR evidence` section in `.agency/do.md`). Run them in order from entry point to **done**.
 - **Every commit is NEW.** Never amend, rebase, or force-push.
 - **Feature branches only.** Never commit to master/main. (Under `--no-git`, no commits happen at all, so this rule is moot — the agent leaves the user on whatever branch they started on.)
 - **Background for CI.** Run CI with `run_in_background: true`.

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -378,26 +378,32 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 
 **If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. (Bitbucket comment wiring is tracked in #10.)
 
-**If `.apm/instructions/pr-evidence.instructions.md` does not exist**: Skip with status `skipped` and reason `"no .apm/instructions/pr-evidence.instructions.md"`. This is the default for projects that haven't opted in.
+**Otherwise**: Read the project's `.apm/instructions/workflow.instructions.md` and look for a `## PR evidence` section. If the section is missing or empty, skip with status `skipped` and reason `"no PR evidence section in workflow.instructions.md"` — the default for projects that haven't opted in.
 
-**If the file exists**:
+**If the section is present**:
 
-Read it. The file is project-specific and describes how this project demonstrates a finished feature — what tools to use (e.g. `chrome-devtools` MCP for screenshots, `hyperfine` for benchmarks, `asciinema` for terminal demos), what to capture (which routes, which scenarios), and how to host any binary artifacts (screenshots typically need to be uploaded somewhere referenceable since `gh pr comment` does not attach files — the instruction file specifies the upload path). Agency does **not** prescribe any of this; follow whatever the file says.
+The section is project-specific and free-form: it can be inline prose describing the capture procedure, a pointer to another file (`See ./scripts/capture-evidence.md`), a script reference (`Run ./scripts/capture-pr-evidence.sh and use its stdout`), or any combination. Don't second-guess the form — read it, then **spawn a sub-agent** (`Agent(subagent_type: "general-purpose", ...)`) so the capture work (MCP calls, screenshot uploads, gh API requests) doesn't pollute `/do`'s main context.
 
-After gathering the evidence, post it as a single PR comment under a `## Evidence` heading using `gh pr comment`. Use the **single-quoted heredoc** pattern (see `forge-pr` → "Passing the body to `gh` safely") so backticks and `$` survive unescaped:
+The sub-agent prompt should include:
+
+- The literal section content from `workflow.instructions.md`.
+- Standard PR context: PR URL, branch name, base branch, current commit SHA, and `git diff origin/HEAD...HEAD --name-only` so the sub-agent knows which routes/files to exercise.
+- An explicit instruction that the sub-agent's job is to return a single block of markdown (image links embedded, table data inline, etc.) suitable for posting under a `## Evidence` heading. The sub-agent should not post the comment itself — only return the markdown.
+
+After the sub-agent returns, post its output as one PR comment using `gh pr comment` under a `## Evidence` heading. Use the **single-quoted heredoc** pattern (see `forge-pr` → "Passing the body to `gh` safely") so backticks and `$` survive unescaped:
 
 ```sh
 gh pr comment --body "$(cat <<'EOF'
 ## Evidence
 
-<markdown produced per pr-evidence.instructions.md>
+<markdown returned by the sub-agent>
 EOF
 )"
 ```
 
-Embed image/asset URLs inline in the markdown — `gh pr comment` itself cannot attach files.
+Embed image/asset URLs inline in the markdown — `gh pr comment` itself cannot attach files; the workflow section is responsible for telling the sub-agent how to host any binary artifacts so they end up referenceable.
 
-**Verify**: Either the step was skipped per the rules above, or a `## Evidence` PR comment exists (`gh pr view --comments` or equivalent) with the markdown produced from the instruction file.
+**Verify**: Either the step was skipped per the rules above, or a `## Evidence` PR comment exists (`gh pr view --comments` or equivalent) populated from the sub-agent's output.
 
 ---
 
@@ -409,7 +415,7 @@ Present a summary of all steps with their verification status. If any step has a
 
 1. A step `skipped` with `reason` beginning `"non-<forge> forge:"` (detected forge isn't GitHub).
 2. A step `skipped` with `reason` `"--no-git"` (user opted out of git operations).
-3. A step `skipped` with `reason` `"no .apm/instructions/pr-evidence.instructions.md"` (project hasn't opted into the evidence step — this is the default).
+3. A step `skipped` with `reason` `"no PR evidence section in workflow.instructions.md"` (project hasn't opted into the evidence step — this is the default).
 
 A `failed` step always blocks `"completed"`. No redefining "passed," no footnote caveats. Update via `scripts/do-results set status completed` or `scripts/do-results set status failed` accordingly.
 
@@ -478,7 +484,7 @@ COMMENT
 
 ## Rules
 
-- **Never skip steps** (unless skipped by `--no-git`, forge detection, or — for **evidence** — the project hasn't opted in via `.apm/instructions/pr-evidence.instructions.md`). Run them in order from entry point to **done**.
+- **Never skip steps** (unless skipped by `--no-git`, forge detection, or — for **evidence** — the project hasn't filled in a `## PR evidence` section in `workflow.instructions.md`). Run them in order from entry point to **done**.
 - **Every commit is NEW.** Never amend, rebase, or force-push.
 - **Feature branches only.** Never commit to master/main. (Under `--no-git`, no commits happen at all, so this rule is moot — the agent leaves the user on whatever branch they started on.)
 - **Background for CI.** Run CI with `run_in_background: true`.

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -112,13 +112,12 @@ Research the task thoroughly before writing code.
 
 - If given a GitHub issue URL **and** `forge == github`, fetch with `gh issue view`. On non-GitHub forges, treat any issue-like URL as opaque context — use the prompt text as-is and do not attempt to fetch. (Bitbucket issue/Jira fetching is tracked in #10.)
 - **Never assume** how something works. Read the code. Check the config.
-- If the prompt involves external tools/libraries, use WebSearch/WebFetch.
+- If the prompt involves external tools/libraries, prefer `git clone` to a scratch dir (e.g. `/tmp/<name>`) at the version the project actually uses, then read the source on disk with `Read`/`Grep`/`Glob`. Fall back to `WebSearch`/`WebFetch` only when the source genuinely isn't a clonable repo (vendor docs, blog posts, RFCs).
 
 **Delegation rule — keep the main context lean.** Before your third `Read` in this step, stop and delegate the rest via `Agent(subagent_type=Explore)`. Main-context reads are reserved for:
 
   (a) specific files the user named in the prompt,
-  (b) `.apm/instructions/**` and `.agency/**` (and files referenced from them),
-  (c) verifying a specific file:line an Explore subagent cited — and only with `offset`/`limit`, never full-file.
+  (b) verifying a specific file:line an Explore subagent cited — and only with `offset`/`limit`, never full-file.
 
 Anything that smells like "map the codebase", "find all callers", "understand how X works across the repo" — delegate. The Explore subagent returns a file:line map; keep that map and reference it in later steps instead of re-reading. Use `Grep`/`Glob` before `Read`: if the question can be answered by searching, don't open the file.
 

--- a/.apm/skills/hickey/SKILL.md
+++ b/.apm/skills/hickey/SKILL.md
@@ -61,7 +61,7 @@ Two abstractions serving one user-level concern = accidental concept multiplicat
 
 ### Layer 4: Check the Structural Pattern Catalog
 
-Scan for known structural patterns plus **any additional patterns the project has declared**. Before evaluating, read `.apm/instructions/workflow.instructions.md` (if present) and look for a `## Hickey catalog` section — its content is project-specific and may be inline patterns or a pointer to another file. Treat any patterns found there as additions to the catalog below. The catalog has two halves: complecting (things braided together that should be separate) and fragmentation (things split apart that should be one). Both directions are "interleaved vs. not-interleaved" — Hickey's principle is bidirectional.
+Scan for known structural patterns plus **any additional patterns the project has declared**. Before evaluating, read `.agency/hickey.md` if it exists — its content is project-specific (inline patterns, or a pointer to another file). Treat any patterns found there as additions to the catalog below. The catalog has two halves: complecting (things braided together that should be separate) and fragmentation (things split apart that should be one). Both directions are "interleaved vs. not-interleaved" — Hickey's principle is bidirectional.
 
 **Complecting patterns (things-that-should-be-separate braided together)**
 

--- a/.apm/skills/hickey/SKILL.md
+++ b/.apm/skills/hickey/SKILL.md
@@ -61,7 +61,7 @@ Two abstractions serving one user-level concern = accidental concept multiplicat
 
 ### Layer 4: Check the Structural Pattern Catalog
 
-Scan for known structural patterns **and any additional patterns from project instructions**. The catalog has two halves: complecting (things braided together that should be separate) and fragmentation (things split apart that should be one). Both directions are "interleaved vs. not-interleaved" — Hickey's principle is bidirectional.
+Scan for known structural patterns plus **any additional patterns the project has declared**. Before evaluating, read `.apm/instructions/workflow.instructions.md` (if present) and look for a `## Hickey catalog` section — its content is project-specific and may be inline patterns or a pointer to another file. Treat any patterns found there as additions to the catalog below. The catalog has two halves: complecting (things braided together that should be separate) and fragmentation (things split apart that should be one). Both directions are "interleaved vs. not-interleaved" — Hickey's principle is bidirectional.
 
 **Complecting patterns (things-that-should-be-separate braided together)**
 

--- a/.apm/skills/lowy/SKILL.md
+++ b/.apm/skills/lowy/SKILL.md
@@ -43,7 +43,7 @@ For every module boundary, service split, or new abstraction in the code under r
 
 What is likely to change behind this boundary? Be specific — not "requirements might change" but "the payment provider, the auth protocol, the notification channel." If you can't name concrete axes of change, the boundary may be arbitrary.
 
-**Consider project-declared areas of volatility.** If the project has enumerated its own areas of volatility — the term of art Lowy uses throughout *Righting Software* — those declarations surface as system-reminders when you read a matching file (Claude Code's `paths:`-scoped rule mechanism; it is wiring, not Lowy doctrine). The schema, loosely modeled on Lowy's TradeMe enumeration (*Righting Software*, Ch. 5), is:
+**Consider project-declared areas of volatility.** If the project has enumerated its own areas of volatility — the term of art Lowy uses throughout *Righting Software* — read `.apm/instructions/workflow.instructions.md` and look for a `## Lowy volatilities` section. Its content is project-specific (inline rows or a pointer to another file). The schema, loosely modeled on Lowy's TradeMe enumeration (*Righting Software*, Ch. 5), is:
 
 | Area of volatility | What changes | Why volatile (likelihood × effect) | Expected encapsulation |
 |--------------------|--------------|------------------------------------|------------------------|

--- a/.apm/skills/lowy/SKILL.md
+++ b/.apm/skills/lowy/SKILL.md
@@ -43,7 +43,7 @@ For every module boundary, service split, or new abstraction in the code under r
 
 What is likely to change behind this boundary? Be specific — not "requirements might change" but "the payment provider, the auth protocol, the notification channel." If you can't name concrete axes of change, the boundary may be arbitrary.
 
-**Consider project-declared areas of volatility.** If the project has enumerated its own areas of volatility — the term of art Lowy uses throughout *Righting Software* — read `.apm/instructions/workflow.instructions.md` and look for a `## Lowy volatilities` section. Its content is project-specific (inline rows or a pointer to another file). The schema, loosely modeled on Lowy's TradeMe enumeration (*Righting Software*, Ch. 5), is:
+**Consider project-declared areas of volatility.** If the project has enumerated its own areas of volatility — the term of art Lowy uses throughout *Righting Software* — read `.agency/lowy.md` if it exists. Its content is project-specific (inline rows or a pointer to another file). The schema, loosely modeled on Lowy's TradeMe enumeration (*Righting Software*, Ch. 5), is:
 
 | Area of volatility | What changes | Why volatile (likelihood × effect) | Expected encapsulation |
 |--------------------|--------------|------------------------------------|------------------------|

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The agent will:
 
 - Run `apm` via `uvx` (no install needed; falls back to `nix shell nixpkgs#uv -c uvx` if you have Nix but not `uvx`)
 - Create or extend `apm.yml` and run `apm install` (plus `apm compile -t codex,opencode` when those hosts are declared, since they need a project-root `AGENTS.md`)
-- Draft `.apm/instructions/workflow.instructions.md` from your project's existing scripts
+- Draft `.agency/do.md` from your project's existing scripts
 
 Review the staged changes before committing.
 
@@ -64,25 +64,40 @@ Type-checkers, tests, and CI catch correctness. They don't catch design. An LLM-
 
 Both default to Sonnet to keep the review cheap enough to run on every task. Pass **`--review-model=opus`** to `do` (or `talk`, which only runs Lowy) when the diff warrants a deeper pass — large or architecturally significant changes, cross-module refactors, anything you want extra-careful eyes on. `haiku` is also accepted for cheap scans.
 
-Read [**Hickey/Lowy on kolu.dev**](https://kolu.dev/blog/hickey-lowy/) for the full framing — what each lens looks for and why the pair catches what tests miss. Both can be extended with project-specific patterns via the `## Hickey catalog` and `## Lowy volatilities` sections of `workflow.instructions.md` (see [Project extensions](#project-extensions) below).
+Read [**Hickey/Lowy on kolu.dev**](https://kolu.dev/blog/hickey-lowy/) for the full framing — what each lens looks for and why the pair catches what tests miss. Both can be extended with project-specific patterns by dropping `.agency/hickey.md` / `.agency/lowy.md` files (see [Project config](#project-config) below).
 
-## Project extensions
+## Project config
 
-Four agency skills (`code-police`, `hickey`, `lowy`, `/do`'s `evidence` step) read project-specific configuration from named sections of `.apm/instructions/workflow.instructions.md` — the same file that already declares your `Check` / `Format` / `Test` / `CI` commands. One file, four optional sections; each is free-form and can be inline prose, a pointer to another file, or a script reference:
+Each agency skill reads its project-specific configuration from a single file named after itself, under a top-level `.agency/` directory:
+
+| File | Read by | Contains |
+|------|---------|----------|
+| `.agency/do.md` | `/do` | `## Check command` / `## Format command` / `## Test command` / `## CI command` / `## Documentation` (required for those steps to run) and an optional `## PR evidence` section that opts into the evidence step |
+| `.agency/code-police.md` | `code-police` | extra quality rules layered on top of the built-in checklist |
+| `.agency/hickey.md` | `hickey` | extra complecting/fragmentation patterns extending the Layer 4 catalog |
+| `.agency/lowy.md` | `lowy` | project-declared areas of volatility used by the review pass |
+
+All four files are **plain Markdown** — no frontmatter, no `applyTo:`, no APM ceremony — and **opt-in** (the consuming skill silently skips its extension behavior when the file is missing). Each skill reads only its own file; nothing crosses, so a project can adopt skills à la carte without touching the others.
+
+Content is free-form: inline prose, a pointer to another file (`See ./code-police-rules.md`), or a script reference all work. Example `.agency/do.md`:
 
 ```markdown
-## Code-police rules
-### no-raw-sql
-Use the query builder for all database access. No raw SQL strings outside migrations.
+# /do config
 
-### always-use-server-functions
-Data fetching must go through server functions, never direct API calls from components.
+## Check command
+just check
 
-## Hickey catalog
-See ./hickey-patterns.md.
+## Format command
+just fmt
 
-## Lowy volatilities
-See ./lowy-volatilities.md.
+## Test command
+just test
+
+## CI command
+just ci
+
+## Documentation
+Keep README.md in sync with user-facing changes.
 
 ## PR evidence
 For every PR that touches the UI:
@@ -90,13 +105,11 @@ For every PR that touches the UI:
 1. Use the `chrome-devtools` MCP to launch `npm run dev` and navigate to the affected route.
 2. Capture a screenshot of the new state and upload it via `gh api` to the repo's release-asset endpoint.
 3. Embed the resulting URL inline in the PR comment under `## Evidence`.
-
-For perf-sensitive changes, run `hyperfine` against `main` and the PR branch and paste the table into the comment instead.
 ```
 
-Each section is **opt-in** — the consuming skill skips its extension behavior when the section is missing. `code-police` and the structural reviewers fold the project content into their existing analysis; `/do`'s `evidence` step spawns a sub-agent so the capture work (MCP calls, image uploads) doesn't pollute `/do`'s main context. Agency does not prescribe any specific tool or format — `chrome-devtools` MCP, `hyperfine`, `asciinema`, custom scripts all work.
+Agency does not prescribe any specific tool or format — `chrome-devtools` MCP, `hyperfine`, `asciinema`, custom scripts all work.
 
-See [Kolu's `workflow.instructions.md`](https://github.com/juspay/kolu/blob/master/.apm/instructions/workflow.instructions.md) for a worked example.
+See [Kolu's `.agency/`](https://github.com/juspay/kolu/tree/master/.agency) for a worked example.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -64,54 +64,39 @@ Type-checkers, tests, and CI catch correctness. They don't catch design. An LLM-
 
 Both default to Sonnet to keep the review cheap enough to run on every task. Pass **`--review-model=opus`** to `do` (or `talk`, which only runs Lowy) when the diff warrants a deeper pass — large or architecturally significant changes, cross-module refactors, anything you want extra-careful eyes on. `haiku` is also accepted for cheap scans.
 
-Read [**Hickey/Lowy on kolu.dev**](https://kolu.dev/blog/hickey-lowy/) for the full framing — what each lens looks for and why the pair catches what tests miss. Both can be extended with project-specific patterns by dropping an `.apm/instructions/*.instructions.md` file with an `applyTo:` glob; see Kolu's [`hickey-catalog.instructions.md`](https://github.com/juspay/kolu/blob/master/.apm/instructions/hickey-catalog.instructions.md) and [`lowy-volatilities.instructions.md`](https://github.com/juspay/kolu/blob/master/.apm/instructions/lowy-volatilities.instructions.md) for worked examples.
+Read [**Hickey/Lowy on kolu.dev**](https://kolu.dev/blog/hickey-lowy/) for the full framing — what each lens looks for and why the pair catches what tests miss. Both can be extended with project-specific patterns via the `## Hickey catalog` and `## Lowy volatilities` sections of `workflow.instructions.md` (see [Project extensions](#project-extensions) below).
 
-## Project-specific code-police rules
+## Project extensions
 
-`code-police` ships with generic rules. Layer on your own by creating `.apm/instructions/code-police-rules.instructions.md`:
+Four agency skills (`code-police`, `hickey`, `lowy`, `/do`'s `evidence` step) read project-specific configuration from named sections of `.apm/instructions/workflow.instructions.md` — the same file that already declares your `Check` / `Format` / `Test` / `CI` commands. One file, four optional sections; each is free-form and can be inline prose, a pointer to another file, or a script reference:
 
 ```markdown
----
-description: Project-specific code-police rules
----
-
-## Code Police Rules
-
+## Code-police rules
 ### no-raw-sql
 Use the query builder for all database access. No raw SQL strings outside migrations.
 
 ### always-use-server-functions
 Data fetching must go through server functions, never direct API calls from components.
-```
 
-These get checked alongside the built-in rules during the police pass. See [Kolu's `code-police-rules.instructions.md`](https://github.com/juspay/kolu/blob/master/.apm/instructions/code-police-rules.instructions.md) for a worked example.
+## Hickey catalog
+See ./hickey-patterns.md.
 
-## Project-specific PR evidence
+## Lowy volatilities
+See ./lowy-volatilities.md.
 
-Mechanical gates (tests, CI, hickey/lowy) verify the diff is _correct_; they don't show the diff is _working_. `do`'s **`evidence` step** closes that gap by posting an `## Evidence` PR comment with project-defined empirical artifacts — UI screenshots, benchmark numbers, demo recordings — captured against the just-shipped change.
-
-The step is **opt-in**: it runs only when `.apm/instructions/pr-evidence.instructions.md` exists, and it skips silently otherwise. The instruction file is project-specific and tells the agent what to capture and how:
-
-```markdown
----
-description: How to capture and post post-merge evidence on PRs
----
-
-## PR Evidence
-
+## PR evidence
 For every PR that touches the UI:
 
-1. Use the `chrome-devtools` MCP to launch `npm run dev` and navigate to the
-   affected route.
-2. Capture a screenshot of the new state and upload it via `gh api` to the
-   repo's release-asset endpoint.
+1. Use the `chrome-devtools` MCP to launch `npm run dev` and navigate to the affected route.
+2. Capture a screenshot of the new state and upload it via `gh api` to the repo's release-asset endpoint.
 3. Embed the resulting URL inline in the PR comment under `## Evidence`.
 
-For perf-sensitive changes, run `hyperfine` against `main` and the PR branch
-and paste the table into the comment instead.
+For perf-sensitive changes, run `hyperfine` against `main` and the PR branch and paste the table into the comment instead.
 ```
 
-Agency does not prescribe the capture mechanism — chrome-devtools MCP, `hyperfine`, `asciinema`, manual scripts all work. The convention is just _"`/do`'s `evidence` step reads this file and follows it"_.
+Each section is **opt-in** — the consuming skill skips its extension behavior when the section is missing. `code-police` and the structural reviewers fold the project content into their existing analysis; `/do`'s `evidence` step spawns a sub-agent so the capture work (MCP calls, image uploads) doesn't pollute `/do`'s main context. Agency does not prescribe any specific tool or format — `chrome-devtools` MCP, `hyperfine`, `asciinema`, custom scripts all work.
+
+See [Kolu's `workflow.instructions.md`](https://github.com/juspay/kolu/blob/master/.apm/instructions/workflow.instructions.md) for a worked example.
 
 ## Examples
 


### PR DESCRIPTION
**Each agency skill reads its project-specific config from its own file under `.agency/`** — `code-police` reads `.agency/code-police.md`, `hickey` reads `.agency/hickey.md`, `lowy` reads `.agency/lowy.md`, and `/do` reads `.agency/do.md` (which holds the check/fmt/test/ci/docs commands plus an optional `## PR evidence` section that opts into the evidence step).

This replaces the old four `.apm/instructions/<name>.instructions.md` files. Each skill knows only about its own file; nothing crosses between skills, so a project can adopt skills à la carte. Files are plain Markdown — no frontmatter, no `applyTo:`, no APM ceremony — and silently no-op when missing.

`agency-setup` writes `.agency/do.md` for first-time bootstrap and mentions the optional skill-specific files at report-back time. Validated end-to-end against [juspay/kolu#750](https://github.com/juspay/kolu/pull/750), which migrates Kolu's existing rules / catalog / volatilities / evidence content into this layout.

> _Generated by [\`/do\`](https://github.com/srid/agency) on Claude Code (model \`claude-opus-4-7\`)._