### PR TITLE
code-police: skip elegance pass on tiny diffs

### DIFF
--- a/.apm/skills/code-police/SKILL.md
+++ b/.apm/skills/code-police/SKILL.md
@@ -101,6 +101,8 @@ For each finding: file, line, one-line risk, concrete fix. If no issues, say so 
 
 ## Pass 3: Elegance
 
+**Skip on tiny diffs.** Run `git diff origin/HEAD...HEAD --shortstat` (or the appropriate base-branch ref). If the diff is **under 50 lines** OR touches **fewer than 5 files**, skip this pass and report `Elegance | 0 | Skipped (tiny diff)` in the summary. The elegance pass's three-lens fan-out has overhead that's disproportionate to a few-line change; rules and fact-check still run. If the diff exceeds either threshold, proceed below.
+
 Review the changes for elegance and simplicity.
 
 **If running under Claude Code** (the `Skill` tool is available): invoke the bundled `/simplify` skill via the Skill tool. It runs three parallel lenses — reuse, quality, efficiency — over the current diff and applies fixes. Prefer this path.

--- a/.apm/skills/code-police/SKILL.md
+++ b/.apm/skills/code-police/SKILL.md
@@ -101,7 +101,7 @@ For each finding: file, line, one-line risk, concrete fix. If no issues, say so 
 
 ## Pass 3: Elegance
 
-**Skip on tiny diffs.** Run `git diff origin/HEAD...HEAD --shortstat` (or the appropriate base-branch ref). If the diff is **under 50 lines** OR touches **fewer than 5 files**, skip this pass and report `Elegance | 0 | Skipped (tiny diff)` in the summary. The elegance pass's three-lens fan-out has overhead that's disproportionate to a few-line change; rules and fact-check still run. If the diff exceeds either threshold, proceed below.
+**Skip on tiny diffs.** Run `git diff origin/HEAD...HEAD --shortstat` (or the appropriate base-branch ref). If the diff is **under 10 lines**, skip this pass and report `Elegance | 0 | Skipped (tiny diff)` in the summary. The elegance pass's three-lens fan-out has overhead that's disproportionate to a few-line change; rules and fact-check still run. If the diff exceeds the threshold, proceed below.
 
 Review the changes for elegance and simplicity.
 


### PR DESCRIPTION
Addresses **A2** of #128. (A3 deferred — see below.)

## A2 — code-police: skip elegance pass on tiny diffs

The Pass 3 fan-out spawns three `/simplify` sub-agents (reuse, quality, efficiency) and routinely takes 2–4 minutes. On small diffs that overhead is disproportionate — kolu#660 (a 1-line `pointer-events-auto` fix) spent 2m 41s on the fan-out and found nothing.

Threshold: **< 10 lines** skips Pass 3 with `Elegance | 0 | Skipped (tiny diff)`. Pass 1 (rules) and Pass 2 (fact-check) are cheap and stay.

## Why A3 was dropped from this PR

A3 wanted to run hickey + lowy + code-police as parallel sub-agents for a wall-clock cut. The first cut of A3 hit a real design problem: `/code-police`'s Pass 3 invokes `/simplify`, which actively edits the working tree. Running code-police as a sub-agent in parallel with hickey/lowy creates two issues:

1. **Race**: `/simplify` mutates files while hickey/lowy are still reading them.
2. **Per-finding commit attribution**: sub-agent applies a bag of edits; main `/do` would have to forensically split them into per-refactor commits.

The fix needs `/code-police` itself restructured so Pass 3 emits findings instead of applying them — that's a bigger change than fits this PR. Reopening A3 for a follow-up with proper scope.

## Test plan

- [ ] Run `/do` (or `/code-police` directly) on a tiny change (< 10 lines) and confirm Pass 3 reports `Skipped (tiny diff)`.
- [ ] Run on a larger diff (≥ 10 lines) and confirm Pass 3 still runs `/simplify`.
- [ ] Confirm Pass 1 and Pass 2 run regardless of diff size.