### PR TITLE
do-results: echo on stdout, hide JSON from agent, decomplect from /do

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -51,14 +51,16 @@ Each step is bookended by two calls to the `scripts/do-results` script (in this 
 
 - `active` is a state enum, not a boolean. Set it to `"working"` when the workflow starts (**sync**), `"waiting"` when the agent is idle waiting for an external process (e.g., background CI), back to `"working"` when the external process returns, and `false` when the workflow ends (**done**). The stop hook uses this field: `"working"` blocks exits; `"waiting"` and `false` allow them.
 - Set `status` to `"completed"` when **done** is reached, or `"failed"` if halted. This field is informational only.
-- **Always use the `scripts/do-results` script** (in this skill's directory, alongside `scripts/steps/`) — never write the JSON file directly. Invoke with the full path (e.g. `.../skills/do/scripts/do-results ...`). Commands:
-  - **Initialize**: `scripts/do-results init <forge> <noGit>` — creates the skeleton with a timestamp
-  - **Start a step**: `scripts/do-results step-start <name>` — stamps `pendingStep` with the current UTC time. Call this **before** doing the step's work.
-  - **End a step**: `scripts/do-results step-end <status> "<verification>" ["<reason>"]` — pops `pendingStep` and appends the completed step with `completedAt` set to the current UTC time.
-  - **Record a step in one call** (advanced): `scripts/do-results step <name> <status> "<verification>" <startedAt> <completedAt> ["<reason>"]` — used by `scripts/steps/sync` where `startedAt` is captured in shell. Agent code should prefer `step-start` / `step-end`.
-  - **Update top-level field**: `scripts/do-results set <field> <value>` (e.g., `set active waiting`, `set status completed`)
+- **Always use the `scripts/do-results` script** (in this skill's directory, alongside `scripts/steps/`) — never write the JSON file directly. Invoke with the full path (e.g. `.../skills/do/scripts/do-results ...`). Every command echoes a one-line confirmation on stdout (see _Stdout confirmations_ below). Commands:
+  - **Initialize**: `scripts/do-results init <forge> <noGit>` — creates the skeleton with a timestamp. Echoes `init: forge=<f> noGit=<bool>`.
+  - **Start a step**: `scripts/do-results step-start <name>` — stamps `pendingStep` with the current UTC time. Call this **before** doing the step's work. Echoes `pending: <name>`.
+  - **End a step**: `scripts/do-results step-end <status> "<verification>" ["<reason>"]` — pops `pendingStep` and appends the completed step with `completedAt` set to the current UTC time. Echoes `recorded: <name> <status> (steps=<count>, pending=<none|name>)`.
+  - **Record a step in one call** (advanced): `scripts/do-results step <name> <status> "<verification>" <startedAt> <completedAt> ["<reason>"]` — used by `scripts/steps/sync` where `startedAt` is captured in shell. Echoes `recorded: <name> <status> (steps=<count>)`. Agent code should prefer `step-start` / `step-end`.
+  - **Update top-level field**: `scripts/do-results set <field> <value>` (e.g., `set active waiting`, `set status completed`). Echoes `set: <field>=<value>`.
 - **Bookend every step with `step-start` at the top and `step-end` at the bottom.** Calling `step-end` without a prior `step-start` is an error, and calling `step` with `now` for both timestamps collapses duration to 0 — neither pattern is allowed. The only exceptions: `sync` is recorded by `scripts/steps/sync` itself, and skipped steps (where duration is always 0 by definition) may use `step-start` followed immediately by `step-end` with status `skipped`.
 - Do not run `date` yourself or guess timestamps — `do-results` resolves the current UTC time internally.
+
+**Stdout confirmations — trust them, don't re-read.** Every mutation prints its result on stdout. Use that line as your confirmation that the write succeeded; do **not** `Read` `.do-results.json` to verify your own writes. The JSON file is machine state for the stop hook (and for `scripts/steps/done` at the end), not a polling target for the agent. Re-reading it after each step costs tokens and adds nothing the echo doesn't already convey. The only legitimate reason to inspect `.do-results.json` directly is failure recovery on a mid-workflow restart (e.g., after a crash), and even then, prefer reading the **last echo line** in the surrounding shell output if it's still in scope.
 
 ## Progress tracking
 
@@ -102,7 +104,7 @@ The script:
 
 **Only `github` has an active code path today.** Both `bitbucket` and `unknown` cause forge-dependent steps (PR creation, PR comments, PR edits, CI status) to skip gracefully. Bitbucket support is planned — see [srid/agency#10](https://github.com/srid/agency/issues/10).
 
-**Verify**: Script exited 0 and printed a `forge=` line. `.do-results.json` exists and its `forge`/`noGit` fields match.
+**Verify**: Script exited 0 and printed `forge=`, `branch=`, `defaultBranch=` lines on stdout. (Sync's `do-results init`/`step sync` calls are silenced — sync owns its own stdout protocol — so don't expect their echoes here. The JSON file is now established; trust it without re-reading.)
 
 ---
 

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -27,21 +27,24 @@ Every step is bookended by two `scripts/do-results` calls: `step-start <name>` b
 
 **Trust the script's stdout.** Every mutation echoes a one-line confirmation. Treat that line as your confirmation that the write succeeded; the script is the only public surface, and whatever it persists internally is private.
 
-**Concepts the script tracks** (passed in as arguments):
+**Lifecycle the script tracks intrinsically**:
 
-- `forge` — `github`, `bitbucket`, or `unknown`. Set by the sync script.
-- `noGit` — `true` or `false`. Reflects the `--no-git` flag. Git-mutating steps (**branch**, **commit**, **create-pr**) skip with `reason="--no-git"` when set.
 - Step `status` — `passed`, `failed`, or `skipped`. A `skipped` step must include a `reason` (e.g. `"non-github forge: bitbucket"`, `"--no-git"`, `"no check command configured"`).
 - `active` — state enum (not a boolean). Set to `working` when the workflow starts (**sync**), `waiting` when the agent is idle waiting for an external process (e.g. background CI), back to `working` when that process returns, and `false` when **done** is reached. The stop hook uses this: `working` blocks exits; `waiting` and `false` allow them.
 - Workflow `status` — `completed` when **done** finishes, `failed` if halted. Informational.
 
+**Workflow fields /do also stashes via `set`** (the script doesn't interpret these — it just remembers them):
+
+- `forge` — `github`, `bitbucket`, or `unknown`. Populated by `scripts/steps/sync` after forge detection.
+- `noGit` — `true` or `false`. Reflects the `--no-git` flag. Git-mutating steps (**branch**, **commit**, **create-pr**) skip with `reason="--no-git"` when set.
+
 **Commands** (invoke with the full path, e.g. `.../skills/do/scripts/do-results ...`):
 
-- `init <forge> <noGit>` — initialize. Echoes `init: forge=<f> noGit=<bool>`.
+- `init` — initialize the workflow's lifecycle skeleton. Echoes `init: startedAt=<ts>`.
 - `step-start <name>` — call before step work. Echoes `pending: <name>`.
 - `step-end <status> "<verification>" ["<reason>"]` — call after verification. Echoes `recorded: <name> <status> (steps=<count>, pending=<none|name>)`.
 - `step <name> <status> "<verification>" <startedAt> <completedAt> ["<reason>"]` — single-call form used by `scripts/steps/sync` where `startedAt` was captured in shell. Echoes `recorded: <name> <status> (steps=<count>)`. Agent code should prefer `step-start` / `step-end`.
-- `set <field> <value>` — update `active` or `status` (e.g. `set active waiting`, `set status completed`). Echoes `set: <field>=<value>`.
+- `set <field> <value>` — set an arbitrary top-level field. Used both for lifecycle (`set active waiting`, `set status completed`) and for /do-specific values that sync stashes (`set forge github`, `set noGit false`). Echoes `set: <field>=<value>`.
 
 **Discipline**:
 

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -23,44 +23,30 @@ The workflow is **forge-aware**: it auto-detects whether the repo lives on GitHu
 
 ## Results Tracking
 
-Each step is bookended by two calls to the `scripts/do-results` script (in this skill's directory): `step-start <name>` before the work begins, and `step-end <status> <verification> [reason]` after verification. This is what keeps per-step timing accurate — collapsing both into a single end-of-step call produces zero-second durations and worthless timing tables. The script manages a JSON file with this schema:
+Every step is bookended by two `scripts/do-results` calls: `step-start <name>` before the work begins, and `step-end <status> <verification> [reason]` after verification. This is what keeps per-step timing accurate — collapsing both into a single end-of-step call produces zero-second durations and worthless timing tables. The script tracks workflow state and emits the final timing table during **done**.
 
-```json
-{
-  "workflow": "do",
-  "startedAt": "<ISO timestamp>",
-  "active": "working",
-  "status": "running",
-  "forge": "github",
-  "noGit": false,
-  "steps": [
-    {
-      "name": "sync",
-      "status": "passed",
-      "verification": "...",
-      "startedAt": "...",
-      "completedAt": "..."
-    }
-  ]
-}
-```
+**Trust the script's stdout.** Every mutation echoes a one-line confirmation. Treat that line as your confirmation that the write succeeded; the script is the only public surface, and whatever it persists internally is private.
 
-- `forge` is set during **sync** (see Forge Detection below). One of `github`, `bitbucket`, `unknown`.
-- `noGit` is `true` if the user passed `--no-git`. When set, git-mutating steps (**branch**, **commit**, **create-pr**) record status `skipped` with reason `"--no-git"`.
-- Step `status` is one of `passed`, `failed`, or `skipped`. A `skipped` step must include a `reason` field explaining why (e.g., `"non-github forge: bitbucket"`, `"--no-git"`, `"no check command configured"`).
+**Concepts the script tracks** (passed in as arguments):
 
-- `active` is a state enum, not a boolean. Set it to `"working"` when the workflow starts (**sync**), `"waiting"` when the agent is idle waiting for an external process (e.g., background CI), back to `"working"` when the external process returns, and `false` when the workflow ends (**done**). The stop hook uses this field: `"working"` blocks exits; `"waiting"` and `false` allow them.
-- Set `status` to `"completed"` when **done** is reached, or `"failed"` if halted. This field is informational only.
-- **Always use the `scripts/do-results` script** (in this skill's directory, alongside `scripts/steps/`) — never write the JSON file directly. Invoke with the full path (e.g. `.../skills/do/scripts/do-results ...`). Every command echoes a one-line confirmation on stdout (see _Stdout confirmations_ below). Commands:
-  - **Initialize**: `scripts/do-results init <forge> <noGit>` — creates the skeleton with a timestamp. Echoes `init: forge=<f> noGit=<bool>`.
-  - **Start a step**: `scripts/do-results step-start <name>` — stamps `pendingStep` with the current UTC time. Call this **before** doing the step's work. Echoes `pending: <name>`.
-  - **End a step**: `scripts/do-results step-end <status> "<verification>" ["<reason>"]` — pops `pendingStep` and appends the completed step with `completedAt` set to the current UTC time. Echoes `recorded: <name> <status> (steps=<count>, pending=<none|name>)`.
-  - **Record a step in one call** (advanced): `scripts/do-results step <name> <status> "<verification>" <startedAt> <completedAt> ["<reason>"]` — used by `scripts/steps/sync` where `startedAt` is captured in shell. Echoes `recorded: <name> <status> (steps=<count>)`. Agent code should prefer `step-start` / `step-end`.
-  - **Update top-level field**: `scripts/do-results set <field> <value>` (e.g., `set active waiting`, `set status completed`). Echoes `set: <field>=<value>`.
-- **Bookend every step with `step-start` at the top and `step-end` at the bottom.** Calling `step-end` without a prior `step-start` is an error, and calling `step` with `now` for both timestamps collapses duration to 0 — neither pattern is allowed. The only exceptions: `sync` is recorded by `scripts/steps/sync` itself, and skipped steps (where duration is always 0 by definition) may use `step-start` followed immediately by `step-end` with status `skipped`.
-- Do not run `date` yourself or guess timestamps — `do-results` resolves the current UTC time internally.
+- `forge` — `github`, `bitbucket`, or `unknown`. Set by the sync script.
+- `noGit` — `true` or `false`. Reflects the `--no-git` flag. Git-mutating steps (**branch**, **commit**, **create-pr**) skip with `reason="--no-git"` when set.
+- Step `status` — `passed`, `failed`, or `skipped`. A `skipped` step must include a `reason` (e.g. `"non-github forge: bitbucket"`, `"--no-git"`, `"no check command configured"`).
+- `active` — state enum (not a boolean). Set to `working` when the workflow starts (**sync**), `waiting` when the agent is idle waiting for an external process (e.g. background CI), back to `working` when that process returns, and `false` when **done** is reached. The stop hook uses this: `working` blocks exits; `waiting` and `false` allow them.
+- Workflow `status` — `completed` when **done** finishes, `failed` if halted. Informational.
 
-**Stdout confirmations — trust them, don't re-read.** Every mutation prints its result on stdout. Use that line as your confirmation that the write succeeded; do **not** `Read` `.do-results.json` to verify your own writes. The JSON file is machine state for the stop hook (and for `scripts/steps/done` at the end), not a polling target for the agent. Re-reading it after each step costs tokens and adds nothing the echo doesn't already convey. The only legitimate reason to inspect `.do-results.json` directly is failure recovery on a mid-workflow restart (e.g., after a crash), and even then, prefer reading the **last echo line** in the surrounding shell output if it's still in scope.
+**Commands** (invoke with the full path, e.g. `.../skills/do/scripts/do-results ...`):
+
+- `init <forge> <noGit>` — initialize. Echoes `init: forge=<f> noGit=<bool>`.
+- `step-start <name>` — call before step work. Echoes `pending: <name>`.
+- `step-end <status> "<verification>" ["<reason>"]` — call after verification. Echoes `recorded: <name> <status> (steps=<count>, pending=<none|name>)`.
+- `step <name> <status> "<verification>" <startedAt> <completedAt> ["<reason>"]` — single-call form used by `scripts/steps/sync` where `startedAt` was captured in shell. Echoes `recorded: <name> <status> (steps=<count>)`. Agent code should prefer `step-start` / `step-end`.
+- `set <field> <value>` — update `active` or `status` (e.g. `set active waiting`, `set status completed`). Echoes `set: <field>=<value>`.
+
+**Discipline**:
+
+- Bookend every step with `step-start` at the top and `step-end` at the bottom. Calling `step-end` without a prior `step-start` is an error; calling `step` with `now` for both timestamps collapses duration to 0 — neither pattern is allowed. Exceptions: `sync` is recorded by `scripts/steps/sync` itself, and skipped steps (duration always 0) may use back-to-back `step-start` / `step-end skipped`.
+- Don't run `date` yourself or guess timestamps — `do-results` resolves UTC internally.
 
 ## Progress tracking
 
@@ -70,7 +56,7 @@ Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a 
 sync, research, branch, implement, check, docs, fmt, commit, hickey+lowy, police, test, create-pr, ci, evidence, done
 ```
 
-At each step boundary, update task state **alongside** the `scripts/do-results` script call — they are not redundant. The JSON file is machine state for the stop hook; the task list is the human-facing UI. Miss either and the workflow is inconsistent.
+At each step boundary, update task state **alongside** the `scripts/do-results` script call — they are not redundant. The script's state drives the stop hook; the task list is the human-facing UI. Miss either and the workflow is inconsistent.
 
 Rules:
 
@@ -104,7 +90,7 @@ The script:
 
 **Only `github` has an active code path today.** Both `bitbucket` and `unknown` cause forge-dependent steps (PR creation, PR comments, PR edits, CI status) to skip gracefully. Bitbucket support is planned — see [srid/agency#10](https://github.com/srid/agency/issues/10).
 
-**Verify**: Script exited 0 and printed `forge=`, `branch=`, `defaultBranch=` lines on stdout. (Sync's `do-results init`/`step sync` calls are silenced — sync owns its own stdout protocol — so don't expect their echoes here. The JSON file is now established; trust it without re-reading.)
+**Verify**: Script exited 0 and printed `forge=`, `branch=`, `defaultBranch=` lines on stdout. (Sync silences `do-results`' own confirmation echoes so the protocol stays clean.)
 
 ---
 
@@ -422,7 +408,7 @@ A `failed` step always blocks `"completed"`. No redefining "passed," no footnote
 
 #### Timing summary
 
-Run `scripts/steps/done` in this skill's directory. The script reads `.do-results.json` and emits:
+Run `scripts/steps/done` in this skill's directory. It emits:
 
 1. A markdown timing table (step, status, duration, verification), with any step that took ≥30% of total time shown in **bold**.
 2. A total wall-clock line (`startedAt` of first step → `completedAt` of last step).

--- a/.apm/skills/do/scripts/do-results
+++ b/.apm/skills/do/scripts/do-results
@@ -12,6 +12,14 @@
 #                                               (use when startedAt comes from a single-shell caller)
 #                                               pass "now" for startedAt/completedAt to auto-generate UTC timestamp
 #   do-results set <field> <value>            — update a top-level field (active, status)
+#
+# Every mutation echoes a one-line confirmation on stdout so the caller can
+# trust the write succeeded without re-reading .do-results.json. Format:
+#   init       — init: forge=<forge> noGit=<bool>
+#   step-start — pending: <name>
+#   step-end   — recorded: <name> <status> (steps=<count>, pending=<none|name>)
+#   step       — recorded: <name> <status> (steps=<count>)
+#   set        — set: <field>=<value>
 
 set -euo pipefail
 
@@ -43,6 +51,7 @@ case "$cmd" in
   "steps": []
 }
 ENDJSON
+    echo "init: forge=$forge noGit=$noGit"
     ;;
 
   step-start)
@@ -56,6 +65,7 @@ ENDJSON
     $JQ --arg n "$name" --arg sa "$startedAt" \
        '.pendingStep = {"name":$n,"startedAt":$sa}' \
        "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
+    echo "pending: $name"
     ;;
 
   step-end)
@@ -82,6 +92,9 @@ ENDJSON
          '.steps += [{"name":$n,"status":$s,"verification":$v,"startedAt":$sa,"completedAt":$ca}] | del(.pendingStep)' \
          "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
     fi
+    count="$($JQ -r '.steps | length' "$FILE")"
+    pending="$($JQ -r '.pendingStep.name // "none"' "$FILE")"
+    echo "recorded: $name $status (steps=$count, pending=$pending)"
     ;;
 
   step)
@@ -107,6 +120,8 @@ ENDJSON
          '.steps += [{"name":$n,"status":$s,"verification":$v,"startedAt":$sa,"completedAt":$ca}]' \
          "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
     fi
+    count="$($JQ -r '.steps | length' "$FILE")"
+    echo "recorded: $name $status (steps=$count)"
     ;;
 
   set)
@@ -118,6 +133,7 @@ ENDJSON
     else
       $JQ --arg f "$field" --arg v "$value" '.[$f] = $v' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
     fi
+    echo "set: $field=$value"
     ;;
 
   *)

--- a/.apm/skills/do/scripts/do-results
+++ b/.apm/skills/do/scripts/do-results
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
-# Manages .do-results.json for the /do workflow.
-# Avoids LLM token generation by handling all JSON mutations in bash+jq.
+# Generic step-results recorder. Manages a workflow's lifecycle state +
+# step-record list in a JSON file, with all mutations done in bash+jq so the
+# caller doesn't burn LLM tokens on JSON arithmetic.
+#
+# The script knows only about workflow lifecycle (active, status), step records
+# (name, status, verification, timestamps, optional reason), and arbitrary
+# top-level fields the caller wants to remember. It does NOT know about any
+# workflow-specific concepts (e.g. forge or noGit are /do's business — the
+# /do workflow stashes them via `set` after init, not as init arguments).
 #
 # Usage:
-#   do-results init <forge> <noGit>           — create initial skeleton
+#   do-results init                           — create the lifecycle skeleton
 #   do-results step-start <name>              — stamp pendingStep with now; call at step start
 #   do-results step-end <status> <verif> [reason]
 #                                             — pop pendingStep, append with completedAt=now
@@ -11,11 +18,11 @@
 #                                             — append a completed step with explicit timestamps
 #                                               (use when startedAt comes from a single-shell caller)
 #                                               pass "now" for startedAt/completedAt to auto-generate UTC timestamp
-#   do-results set <field> <value>            — update a top-level field (active, status)
+#   do-results set <field> <value>            — set/update an arbitrary top-level field
 #
 # Every mutation echoes a one-line confirmation on stdout so the caller can
-# trust the write succeeded without re-reading .do-results.json. Format:
-#   init       — init: forge=<forge> noGit=<bool>
+# trust the write succeeded without re-reading the JSON. Format:
+#   init       — init: startedAt=<ts>
 #   step-start — pending: <name>
 #   step-end   — recorded: <name> <status> (steps=<count>, pending=<none|name>)
 #   step       — recorded: <name> <status> (steps=<count>)
@@ -37,8 +44,6 @@ shift
 
 case "$cmd" in
   init)
-    forge="${1:?forge required (github|bitbucket|unknown)}"
-    noGit="${2:?noGit required (true|false)}"
     startedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     cat > "$FILE" <<ENDJSON
 {
@@ -46,12 +51,10 @@ case "$cmd" in
   "startedAt": "$startedAt",
   "active": "working",
   "status": "running",
-  "forge": "$forge",
-  "noGit": $noGit,
   "steps": []
 }
 ENDJSON
-    echo "init: forge=$forge noGit=$noGit"
+    echo "init: startedAt=$startedAt"
     ;;
 
   step-start)

--- a/.apm/skills/do/scripts/steps/sync
+++ b/.apm/skills/do/scripts/steps/sync
@@ -53,11 +53,13 @@ case "$origin_url" in
   *)             forge="unknown" ;;
 esac
 
-# Initialize results skeleton and record the sync step
-"$DO_RESULTS" init "$forge" "$noGit"
+# Initialize results skeleton and record the sync step. Suppress do-results'
+# stdout confirmations — sync emits its own forge/branch/defaultBranch protocol
+# below and shouldn't pollute it with do-results' echo lines.
+"$DO_RESULTS" init "$forge" "$noGit" >/dev/null
 "$DO_RESULTS" step sync passed \
   "git fetch ok; forge=$forge; noGit=$noGit" \
-  "$startedAt" now
+  "$startedAt" now >/dev/null
 
 # Emit structured facts the agent uses for downstream steps
 branch="$(git rev-parse --abbrev-ref HEAD)"

--- a/.apm/skills/do/scripts/steps/sync
+++ b/.apm/skills/do/scripts/steps/sync
@@ -53,10 +53,13 @@ case "$origin_url" in
   *)             forge="unknown" ;;
 esac
 
-# Initialize results skeleton and record the sync step. Suppress do-results'
-# stdout confirmations — sync emits its own forge/branch/defaultBranch protocol
-# below and shouldn't pollute it with do-results' echo lines.
-"$DO_RESULTS" init "$forge" "$noGit" >/dev/null
+# Initialize results, stash /do-specific top-level fields (forge, noGit) via
+# the generic `set` command, then record the sync step. Suppress do-results'
+# stdout confirmations — sync emits its own forge/branch/defaultBranch
+# protocol below and shouldn't pollute it with do-results' echo lines.
+"$DO_RESULTS" init >/dev/null
+"$DO_RESULTS" set forge "$forge" >/dev/null
+"$DO_RESULTS" set noGit "$noGit" >/dev/null
 "$DO_RESULTS" step sync passed \
   "git fetch ok; forge=$forge; noGit=$noGit" \
   "$startedAt" now >/dev/null


### PR DESCRIPTION
Addresses **C1** of #128, plus a follow-on cleanup that fell out of review.

## Three commits

### 1. Echo confirmation on stdout

JSONL transcripts of kolu `/do` runs show the agent re-reading `.do-results.json` **11–13 times per workflow** (solid-circus 13, bleak-mold 11). It re-reads because the script writes silently — there's no other confirmation that `step-start` / `step-end` / `set` actually persisted.

Every mutation now prints a one-line confirmation:

| Command | Echo |
|---------|------|
| `init` | `init: startedAt=<ts>` |
| `step-start <name>` | `pending: <name>` |
| `step-end <status> <verif> [reason]` | `recorded: <name> <status> (steps=<count>, pending=<none\|name>)` |
| `step <name> <status> ...` | `recorded: <name> <status> (steps=<count>)` |
| `set <field> <value>` | `set: <field>=<value>` |

`scripts/steps/sync` silences these — sync owns its own `forge=`/`branch=`/`defaultBranch=` stdout protocol.

### 2. Hide the JSON file from the SKILL

The agent doesn't need to know `.do-results.json` exists. The script is the public surface; what it persists is private. So:

- Deleted the JSON schema block from SKILL.md.
- Removed file mentions from the sync verify line, the progress-tracking note, and the done step description.
- Restructured Results Tracking into **concepts** + **commands** + **discipline** buckets.

### 3. Decomplect `do-results` from /do-specific args

`forge` and `noGit` are pure `/do` concepts; baking them into `init`'s signature meant a generic step-results recorder was leaking one workflow's vocabulary.

- `init` now takes **no arguments** — just creates the lifecycle skeleton (`workflow`, `startedAt`, `active`, `status`, empty `steps`).
- `scripts/steps/sync` stashes `forge` and `noGit` via the existing `set` command: `set forge <forge>` / `set noGit <noGit>`. The mechanism was already there; this just stops privileging two fields at init time.
- SKILL.md splits the Concepts section into two explicit buckets: **lifecycle the script tracks intrinsically** (active, status, step status) vs **workflow fields /do stashes via `set`** (forge, noGit).

On-disk JSON shape is unchanged — `forge` and `noGit` still appear as top-level fields, so the stop hook and `scripts/steps/done` need no changes.

## Smoke test

End-to-end run against a temp git repo:
```
forge=github
branch=master
defaultBranch=master
```
JSON ended up with `workflow`, `startedAt`, `active=working`, `status=running`, sync step recorded, plus `forge=github`/`noGit=false` populated by sync's `set` calls. Sync's stdout protocol stayed clean (only the three protocol lines, no `do-results` echo pollution).

## Test plan

- [ ] Run `/do` on a real change and confirm the agent's transcript no longer contains repeated `Read` calls on `.do-results.json` between steps.
- [ ] Confirm `/do` still completes through the `done` step.
- [ ] Confirm the do-stop-guard hook still gates exits correctly (it reads `.do-results.json` directly; schema is unchanged).