### PR TITLE
do: add --minimal flag for trivially-scoped diffs

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: do
 description: Do a task end-to-end — implement, PR, CI loop, ship
-argument-hint: "<issue-url | prompt> [--review] [--no-git] [--from <step>] [--review-model=<opus|sonnet|haiku>]"
+argument-hint: "<issue-url | prompt> [--review] [--no-git] [--minimal] [--from <step>] [--review-model=<opus|sonnet|haiku>]"
 ---
 
 # Do Workflow
@@ -12,14 +12,15 @@ Take a task and do it top-to-bottom: research, branch, implement, pass CI, open 
 
 ## Arguments
 
-Parse the arguments string: `[--review] [--no-git] [--from <step-id>] [--review-model=<opus|sonnet|haiku>] <task description or issue-url>`
+Parse the arguments string: `[--review] [--no-git] [--minimal] [--from <step-id>] [--review-model=<opus|sonnet|haiku>] <task description or issue-url>`
 
 The workflow is **forge-aware**: it auto-detects whether the repo lives on GitHub or elsewhere during the **sync** step (see Forge Detection). Only GitHub has an active code path today — Bitbucket/other forges gracefully skip PR-related steps. Tracking: [srid/agency#10](https://github.com/srid/agency/issues/10).
 
 - `--review`: Pause after **research** for user plan approval via `EnterPlanMode`/`ExitPlanMode`, then continue autonomously. (hickey/lowy now runs post-implement on a concrete diff, so there's no plan-approval moment attached to that step anymore — the review point is pre-implement, before any code is written.)
 - `--no-git`: Extend the working tree **in place** — do not create a branch, commit, push, or touch any PR. Research, implement, check, docs, police, fmt, and test all run; git-mutating steps (**branch**, **commit**, **create-pr**) are skipped. Use this when you have uncommitted local work and want the agent to build on it without taking over git state. Feedback from a Bitbucket user in [#26](https://github.com/srid/agency/issues/26).
+- `--minimal`: Skip the steps whose value is disproportionate on trivially-scoped diffs: **docs**, **hickey+lowy**, **police**, and **evidence**. The remaining flow runs in order: sync → research → branch → implement → check → fmt → commit → test → create-pr → ci → done. Use this when the change is obviously confined (one-line bug fix, typo, config tweak) and structural review / docs sync / quality gate / PR evidence are overkill — PR comments on small `/do` runs frequently note this. The four skipped steps each record `status="skipped"` with `reason="--minimal"`.
 - `--from <step-id>`: Start from a specific step (see entry points below)
-- `--review-model=<model>`: Model to use for the **hickey+lowy** sub-agent invocations. Accepts `opus`, `sonnet`, or `haiku`. Defaults to `sonnet` — cheap enough to run on every task without thinking about cost. Pass `opus` when the task warrants deeper structural critique (large or architecturally significant diffs, refactors that cross module boundaries, work the user wants an extra-careful second pair of eyes on). Takes precedence over the `model: sonnet` in the hickey/lowy agent frontmatter via the `Agent` tool's `model` parameter.
+- `--review-model=<model>`: Model to use for the **hickey+lowy** sub-agent invocations. Accepts `opus`, `sonnet`, or `haiku`. Defaults to `sonnet` — cheap enough to run on every task without thinking about cost. Pass `opus` when the task warrants deeper structural critique (large or architecturally significant diffs, refactors that cross module boundaries, work the user wants an extra-careful second pair of eyes on). Takes precedence over the `model: sonnet` in the hickey/lowy agent frontmatter via the `Agent` tool's `model` parameter. Has no effect under `--minimal` since hickey+lowy is skipped.
 
 ## Results Tracking
 
@@ -29,7 +30,7 @@ Every step is bookended by two `scripts/do-results` calls: `step-start <name>` b
 
 **Lifecycle the script tracks intrinsically**:
 
-- Step `status` — `passed`, `failed`, or `skipped`. A `skipped` step must include a `reason` (e.g. `"non-github forge: bitbucket"`, `"--no-git"`, `"no check command configured"`).
+- Step `status` — `passed`, `failed`, or `skipped`. A `skipped` step must include a `reason` (e.g. `"non-github forge: bitbucket"`, `"--no-git"`, `"--minimal"`, `"no check command configured"`).
 - `active` — state enum (not a boolean). Set to `working` when the workflow starts (**sync**), `waiting` when the agent is idle waiting for an external process (e.g. background CI), back to `working` when that process returns, and `false` when **done** is reached. The stop hook uses this: `working` blocks exits; `waiting` and `false` allow them.
 - Workflow `status` — `completed` when **done** finishes, `failed` if halted. Informational.
 
@@ -163,6 +164,8 @@ This is the cheapest gate in the pipeline, so it runs first — fail fast on bro
 
 ### docs
 
+**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **fmt**.
+
 Read `.agency/do.md` and look for a `## Documentation` section listing which docs to keep in sync (e.g., README.md). Compare those files against changes in this PR.
 
 If no documentation files are documented, skip this step with a note.
@@ -195,6 +198,8 @@ This is the **primary feature commit**. Downstream **hickey+lowy** and **police*
 ---
 
 ### hickey + lowy
+
+**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **police** (which will also skip under `--minimal`). Do not spawn either sub-agent.
 
 Invoke `hickey` and `lowy` as two **parallel sub-agents** via the harness's agent tool (`subagent_type: "hickey"` and `subagent_type: "lowy"`). On Claude Code this is the `Agent` tool. On Codex this is the sub-agent spawning tool for delegated work. Invoking `/do` is explicit authorization to run these two review agents; do not wait for a second user prompt before spawning them.
 
@@ -247,6 +252,8 @@ For each flipped finding, apply it in this PR using the per-commit rules below. 
 ---
 
 ### police
+
+**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **test**. Do not invoke `/code-police`.
 
 Use `git diff origin/HEAD...HEAD --name-only` to check if the PR contains code changes. If all changed files are documentation-only (e.g., `.md`, `.txt`, `README`, docs/) — skip this step with a note.
 
@@ -364,6 +371,8 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 
 **Opt-in step.** Most projects skip this. The step exists so projects with empirical "did the feature actually work" needs — UI screenshots, performance benchmarks, demo recordings, output transcripts — can attach that evidence to the PR without baking the mechanism into agency.
 
+**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **done**.
+
 **If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to attach evidence to.
 
 **If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. (Bitbucket comment wiring is tracked in #10.)
@@ -401,11 +410,12 @@ Embed image/asset URLs inline in the markdown — `gh pr comment` itself cannot 
 
 Present a summary of all steps with their verification status. If any step has a non-success status, retry it (max 3 attempts from done). If still failing after retries, set `status: "failed"`.
 
-`"completed"` requires **all steps `passed`**, with three exceptions that count toward completion:
+`"completed"` requires **all steps `passed`**, with four exceptions that count toward completion:
 
 1. A step `skipped` with `reason` beginning `"non-<forge> forge:"` (detected forge isn't GitHub).
 2. A step `skipped` with `reason` `"--no-git"` (user opted out of git operations).
 3. A step `skipped` with `reason` `"no PR evidence section in .agency/do.md"` (project hasn't opted into the evidence step — this is the default).
+4. A step `skipped` with `reason` `"--minimal"` (user opted out of structural review / docs / quality gate / evidence on a trivial diff).
 
 A `failed` step always blocks `"completed"`. No redefining "passed," no footnote caveats. Update via `scripts/do-results set status completed` or `scripts/do-results set status failed` accordingly.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Pasting the same prompt again later acts as an **update** — it detects the exi
 
 #### Primary skills
 
-- **`do`** — Full pipeline: research → implement → structural review (hickey, lowy) → quality gate (code-police) → CI → evidence (opt-in) → ship. Structural review runs **post-implement on the concrete diff**, and each "Fix in this PR" finding lands as its own commit — so the PR history reads as a progression from primary implementation to each refinement. Fully autonomous; skip specific steps by mentioning them in the prompt.
+- **`do`** — Full pipeline: research → implement → structural review (hickey, lowy) → quality gate (code-police) → CI → evidence (opt-in) → ship. Structural review runs **post-implement on the concrete diff**, and each "Fix in this PR" finding lands as its own commit — so the PR history reads as a progression from primary implementation to each refinement. Fully autonomous; skip specific steps by mentioning them in the prompt, or pass **`--minimal`** to skip docs/hickey+lowy/police/evidence wholesale on trivially-scoped diffs (one-line fixes, typos, config tweaks).
 - **`talk`** — Conversation-and-research mode. Discuss ideas, explore approaches, read code, inspect upstream sources in temporary scratch space when needed — no repo changes allowed.
 - **`ralph`** — Iterative measurement-driven improvement loop. Measure, profile, mutate, re-measure, commit. Works for performance, bundle size, complexity — anything quantifiable.
 


### PR DESCRIPTION
Addresses **F1** of #128.

## Why

PR comments on small `/do` runs frequently note that structural review or quality-gate work was overkill for a trivial diff. Examples from kolu PRs:

- kolu#660 (1-line `pointer-events-auto` fix): "On trivially-scoped diffs (one class addition on an existing JSX node), collapsing the three structural passes into one targeted pass would recover most of that."
- kolu#688 (2-line viewport screenshot tweak): "For smaller diffs where structural review is obviously overkill … consider a `--minimal` path."
- kolu#696 (60-line cache-control fix): "For small focused fixes like this, `--review-model=haiku` would likely land the same findings (the two lowy extractions were structural, not subtle) at a fraction of the time."

Today the advice is "say it in the prompt" — that's a footnote, not a flag.

## What

`--minimal` skips four steps wholesale:

| Skipped | Why it's overkill on a trivial diff |
|---------|--------------------------------------|
| `docs` | one-liner doesn't shift architecture |
| `hickey+lowy` | structural review on 2 lines is theatre |
| `police` | rule checklist + fact-check + elegance can't beat eyeballs on 5 lines |
| `evidence` | nothing demoable to capture |

The remaining flow runs in order: `sync → research → branch → implement → check → fmt → commit → test → create-pr → ci → done`. **`test` stays** — correctness gate, not review overhead. F1's keep-list omitted `test`, but the explicit skip-list didn't include it; conservative reading wins.

Each skipped step records `status="skipped"` with `reason="--minimal"`. The done step's "completed" criteria gain a 4th acceptable skip reason alongside the existing three (`non-github forge:`, `--no-git`, `no PR evidence section in .agency/do.md`).

`--review-model` becomes a no-op under `--minimal` since hickey+lowy is skipped — noted in its description so the user isn't confused.

## Files

- `.apm/skills/do/SKILL.md` — argument-hint, arg-parse list, flag description, four step-level skip notes (docs / hickey+lowy / police / evidence), updated `done` completion criteria, updated example skip reasons.
- `README.md` — `/do` skill summary mentions the flag.

## Test plan

- [ ] Run `/do --minimal "fix typo in README link"` and confirm docs / hickey+lowy / police / evidence all show `skipped` with `reason="--minimal"` in the PR results comment.
- [ ] Confirm `test` still runs.
- [ ] Confirm `done` reports the workflow as `completed` (not `failed`) despite the four skipped steps.
- [ ] Run `/do --minimal --no-git "..."` and confirm both flag's skips are honored without conflict.