### PR TITLE
do, ralph: seed task list in one round-trip, not one per task

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -60,6 +60,8 @@ Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a 
 sync, research, branch, implement, check, docs, fmt, commit, hickey+lowy, police, test, create-pr, ci, evidence, done
 ```
 
+**Emit all `TaskCreate` calls as parallel `tool_use` blocks in a single assistant turn** — one model round-trip, not one per task. The seeded steps have no `addBlocks` / `addBlockedBy` dependencies, so there is nothing to serialize on. Sequential seeding (15 round-trips before any real work) is a regression: it adds latency to every `/do` invocation and clutters the transcript with 15 wrapper turns of "Task #N created successfully" before `sync` even starts.
+
 **Under `--minimal`, omit the four steps the flag skips** (`docs`, `hickey+lowy`, `police`, `evidence`) from the seeded list — the user explicitly opted out of them, so they shouldn't clutter the human-facing checklist. The seeded list becomes 11 items in `--minimal` runs. (Run-inherent skips like `--no-git` and forge skips stay in the list — see the Skipped steps rule below.)
 
 The `scripts/do-results` lifecycle still records `--minimal`-skipped steps with `status="skipped"` and `reason="--minimal"` via back-to-back `step-start` / `step-end` calls — that's what keeps the final timing table and `completed`-status logic correct. The task UI is independent of that recording.

--- a/.apm/skills/ralph/SKILL.md
+++ b/.apm/skills/ralph/SKILL.md
@@ -21,7 +21,7 @@ Use `AskUserQuestion` to collect:
 - Create a feature branch and **draft PR** early (load `forge-pr` skill for title/body). PR description includes a measurements table updated as cycles complete.
 - **Baseline**: measure at least 5 runs, report **median**. For time: distinguish cold (no cache) from hot (cached). Document methodology.
 - Create `docs/<target>-ralph-report.md` with baseline, methodology, optimization log table, and findings.
-- Seed `TaskCreate` list with N cycle tasks.
+- Seed `TaskCreate` list with N cycle tasks — emit all calls as parallel `tool_use` blocks in a single assistant turn so the seed is one model round-trip, not N.
 
 ## 2. The loop
 


### PR DESCRIPTION
**`/do` and `/ralph` now seed their task lists as a single batch of parallel `tool_use` blocks**, not one `TaskCreate` per round-trip. One model round-trip replaces fifteen, with no UX change to the live checklist.

### What was happening

A real `/do` session in Kolu ([JSONL transcript](https://github.com/srid/agency/pull/140) — same one that motivated PR #140) showed the model calling `TaskCreate` fifteen times, each in its own assistant turn, each waiting on a `"Task #N created successfully"` tool_result before the next. The seeded inputs had no `addBlocks` / `addBlockedBy` dependencies — nothing to serialize on:

| Turn | Action |
| --- | --- |
| L269 | `ToolSearch` to load `Task*` schemas (deferred tools) |
| L272 | `TaskCreate` subject=`sync` |
| L274 | `TaskCreate` subject=`research` |
| L276 | `TaskCreate` subject=`branch` |
| … | … |
| L303 | `TaskCreate` subject=`done` (15th) |
| L305 | `TaskUpdate` taskId=1 status=`in_progress` (real work begins) |

Fifteen wrapper turns of round-tripped boilerplate before `sync` even started. Latency on every `/do` invocation, transcript noise, no benefit.

### Why it was sequential

`do/SKILL.md:57` said _"seed a task list with the step names in order"_ — _"in order"_ got read as _"one after another."_ Nothing in the skill authorized batching, and Claude Code's `TaskCreate` schema takes a single `subject` / `description` per call (no `tasks: [...]` array, no `TaskCreateBatch`), so the model defaulted to the cautious sequential pattern.

### Fix

Both skills now explicitly require parallel emission. `TaskCreate` is still one task per call, but the model can emit N `tool_use` blocks in one assistant message — Claude Code runs them in parallel and returns all `tool_result`s in a single user turn. _N round-trips collapse to one._

> _Generated by Claude Code (model `claude-opus-4-7`)._