### PR TITLE
do, talk: tighten skill descriptions to block auto-invocation

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do
-description: Do a task end-to-end — implement, PR, CI loop, ship
+description: Do a task end-to-end — implement, PR, CI loop, ship. ONLY invoke when the user explicitly types `/do` or `$do`; never auto-select from a natural-language request, even one that sounds like an end-to-end task.
 argument-hint: "<issue-url | prompt> [--review] [--no-git] [--minimal] [--from <step>] [--review-model=<opus|sonnet|haiku>]"
 ---
 

--- a/.apm/skills/talk/SKILL.md
+++ b/.apm/skills/talk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: talk
-description: Enter talk mode — conversation and research, no repo changes
+description: Enter talk mode — conversation and research, no repo changes. ONLY invoke when the user explicitly types `/talk` or `$talk`; never auto-select from a natural-language question or design discussion.
 argument-hint: "[--no-laconic] [--review-model=<opus|sonnet|haiku>] <topic or question>"
 ---
 


### PR DESCRIPTION
## Summary

- Codex auto-invoked `/do` on a "set up this repo to use srid/agency" prompt — its skill-matcher pattern-matched the natural-language request against `do`'s description (`Do a task end-to-end — implement, PR, CI loop, ship`).
- `/do` and `/talk` are slash commands; they should only fire when the user explicitly types `/do`, `$do`, `/talk`, or `$talk`.
- Append an explicit `ONLY invoke when the user explicitly types …; never auto-select from a natural-language request` directive to both `description` fields so the skill-matcher reads the guard before routing.

## Test plan

- [ ] Re-run the "Set up this repo to use srid/agency …" prompt under Codex and confirm it does not auto-invoke `/do`.
- [ ] Confirm explicit `$do <task>` / `/do <task>` invocation still routes to the do workflow.
- [ ] Same check for `talk` with a natural-language design question vs. an explicit `/talk` invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)