### PR TITLE
talk: ban outsourcing follow-up research to the user

### DIFF
--- a/.apm/skills/talk/SKILL.md
+++ b/.apm/skills/talk/SKILL.md
@@ -15,6 +15,7 @@ You are now in **talk mode**. Have a conversation with the user — discuss idea
 - You MAY read files (`Read`, `Glob`, `Grep`), run read-only shell commands (`git log`, `git diff`, `ls`), search the web, and use Explore subagents — anything that helps you give better answers.
 - You MAY create temporary scratch files outside the repo when needed for research. Cloning an external repository into `/tmp/<name>` to inspect the exact upstream/library source is allowed. Keep that scratch work ephemeral and do not treat it as a place to make user-requested code changes.
 - You MAY use `AskUserQuestion` when the user's intent is genuinely ambiguous, or to collaborate on a design decision (e.g. proposing a phase split — see below). You MAY NOT use it to ask permission to research something ("want me to check X?", "should I look at Y?") — if you're tempted to ask, just do the research and report back. Asking to research is the single most common way talk mode fails.
+- **Don't outsource follow-up research to the user either.** The symmetric lazy is closing a response with "you should grep for other X" or "worth checking whether Y elsewhere" — that's the same vice as asking permission, just dressed as advice. If you surface a follow-up as worth doing, do it before responding. Don't surface follow-ups you're not willing to investigate.
 - **Talk mode ends when the user invokes an action skill** (e.g., `do`). Until then, stay in talk mode.
 
 ## Research before answering — MANDATORY
@@ -59,6 +60,7 @@ If you're about to emit "probably", "almost certainly", "I suspect", "my #1 susp
 - ❌ "This pattern usually means..." (pattern-matching from training data instead of reading the actual codebase)
 - ❌ Recommending a library API that may not exist in the installed version
 - ❌ "Want me to check whether `fit()` is actually a no-op?" — don't ask, check.
+- ❌ "Worth grepping for other `selectedX` signals — same gap likely exists elsewhere." — if you flagged it, you check it; don't hand the user homework.
 - ❌ "My #1 suspect is `debouncedFit()`" without a file:line inside the library proving it.
 - ❌ Citing a subagent's claim about `FitAddon.ts:45` without opening `FitAddon.ts:45` yourself first.
 - ✅ "I read `Viewport.ts:106-107` and `IViewport` declares `handleTouchStart` but the implementation in `Viewport.ts` (192 lines) has no touch wiring — so the type is aspirational, not functional."


### PR DESCRIPTION
## Summary

- The `talk` skill already bans asking permission to research (\"want me to check X?\"). The symmetric lazy — closing a response with \"you should grep for other X\" as parting advice — was slipping through as confident-sounding homework for the user.
- Add a Rules bullet making the symmetry explicit: if you surface a follow-up as worth doing, do it before responding. Don't surface follow-ups you're not willing to investigate.
- Add a matching anti-pattern (\"Worth grepping for other `selectedX` signals…\") so the lesson is concrete.

## Test plan

- [ ] On the next `/talk` turn that produces a fix, confirm the response either investigates the suggested follow-up itself or omits it — no \"you should grep for…\" tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)