### PR TITLE
do: extend test-first rule to all new behavior

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -146,13 +146,19 @@ That's it — just the local branch. No commit, no push, no PR. The branch is pu
 
 ### implement
 
-If the task is a bug fix: write a failing test first (e2e or unit, whichever is appropriate), then fix the bug.
+The test-first rule depends on what the change is:
 
-Otherwise: implement the planned changes. Prefer simplicity. Do the boring obvious thing.
+- **Bug fix**: write a failing test first (e2e or unit, whichever is appropriate), then fix the bug.
+- **New behavior** — anything that fails at runtime if it's wrong: new endpoints or routes, new services or modules, configuration paths, environment variables, secrets wiring, network connectivity, data persistence (migrations, preStart scripts, schema changes), auth/OIDC flows. Write an integration or unit test covering the new behavior **before** implementing. NixOS service modules need a VM test; new HTTP endpoints need an e2e or integration test; new modules with logic need at least a unit test.
+- **Otherwise** — documentation, refactors with no behavioral change, purely internal cleanups, dependency bumps that don't change behavior. Just implement the planned changes; no test-first requirement.
+
+If you're not sure which bucket the change falls into, treat it as new behavior. The cost of an unnecessary test is small; the cost of a silent deployment failure is not.
+
+Prefer simplicity. Do the boring obvious thing.
 
 **E2E coverage**: When the change introduces multiple user-facing paths (e.g., a dialog that appears under different conditions), write e2e scenarios for **each distinct path**. Enumerate the user-visible paths, then check that every one has a corresponding test.
 
-**Verify**: Code changes match the planned approach. All distinct user-facing paths have test coverage.
+**Verify**: Code changes match the planned approach. For bug fixes and new-behavior changes, at least one test exercises the changed behavior; multi-path changes have one test per distinct user-visible path. Refactor/docs/cleanup diffs are exempt.
 
 ---
 
@@ -296,7 +302,9 @@ Use `git diff origin/HEAD...HEAD --name-only` to identify changed files and dete
 
 If changes are purely internal with no user-facing impact, unit tests may suffice — skip e2e if no relevant scenarios exist. If no test command is documented, skip with a note.
 
-**Verify**: Tests pass (exit code 0), or no relevant tests to run.
+**Coverage gap check**: After the test command exits 0, confirm at least one of the tests run actually exercised the new behavior (per the **implement** step's classification). A green run that didn't touch the changed code paths — e.g. a new NixOS service module with no corresponding VM test, or a new endpoint with no integration test — is a coverage gap, not a pass. Refactor/docs/internal-cleanup diffs are exempt. The implement step should have caught this; if it didn't, treat it as a real failure: write the missing test, then loop through **fmt** → **commit** → **test** as below.
+
+**Verify**: Tests pass (exit code 0) **and** the new behavior is covered, or the diff is exempt from the coverage check, or no relevant tests to run.
 **If failed** (max 4 attempts): Analyze the failure. If flaky, re-run. If real: fix → go to **fmt**, then retry.
 
 ---


### PR DESCRIPTION
## Summary

Closes #146.

The `implement` step's test-first rule fired only on bug fixes — new services, endpoints, configuration paths, env vars, secrets wiring, and persistence changes shipped to commit with no coverage requirement. The `test` step then ran whatever tests existed and silently passed when nothing covered the new behavior. The discussion documents a real deployment gap (a LiteLLM proxy on NixOS, where the integration test was written *retroactively* and would have caught the bug in 17 seconds).

This PR adopts the three-way classification proposed in the discussion:

- **Bug fix** → failing test first, then fix.
- **New behavior** (endpoints, services, modules, config paths, env vars, network connectivity, data persistence, auth flows) → integration or unit test first, then implement.
- **Otherwise** (docs, no-op refactors, internal cleanups, behavior-preserving dep bumps) → implement; no test-first requirement.

When unsure, treat the change as new behavior.

The `test` step gains a **coverage gap check**: after a green run, verify at least one test actually exercised the changed paths. A run that passes by ignoring the new code is a gap, not a success — surface it as a failure so the agent loops back to write the missing test instead of moving on to `create-pr`.

## What changed

- `.apm/skills/do/SKILL.md` — `implement` step rewritten as a 3-way rule with examples per surface (NixOS VM test, e2e endpoint test, unit test). Verify clause updated. `test` step gains a Coverage gap check paragraph and a strengthened verify clause.

## Notes

- README and landing page intentionally untouched: this is an internal workflow rule, not a user-visible capability change. The README's "Feedback is the bottleneck" section already says e2e tests are a prerequisite — this PR makes `/do` enforce that.
- The discussion's open question on automated coverage detection (`git diff --name-only` cross-referenced with test file patterns) is left as a follow-up. This PR keeps the gap check as a judgment-based step the agent performs after the test command runs, which matches the rest of `/do`'s verify clauses.

## Test plan

- [ ] Re-read `implement` and `test` steps end-to-end and confirm the 3-way rule reads cleanly alongside the existing E2E coverage paragraph.
- [ ] Sanity-check that the `test` step's "If failed" loop still makes sense when the failure source is a coverage gap (writes test → fmt → commit → re-run test).
- [ ] Run `/do` against a small new-behavior task in a downstream repo and confirm the agent actually writes a test before implementing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)