### PR TITLE
hickey, lowy: review whole module, not just the trigger

### DIFF
--- a/.apm/skills/hickey/SKILL.md
+++ b/.apm/skills/hickey/SKILL.md
@@ -24,6 +24,16 @@ Source: [Full talk transcript](https://github.com/matthiasn/talk-transcripts/blo
 
 **Compose** (com-ponere, "to place together"): Combine independent things side by side, preserving isolation. Hickey: _"I'd rather have more things hanging nice, straight down, not twisted together, than just a couple of things tied in a knot."_
 
+## Scope of Review
+
+The trigger — "review this for X", "extract Y", "look at file Z", a `/do` diff with N touched files — is a *starting point*, not a frame. The structural questions in this skill (concept multiplication, fragmentation, complecting) are most legible at module boundaries; reviewing only the lines the user (or upstream issue) pointed at is how recurring patterns in the same file get missed.
+
+**Default to whole-module scope.** When the trigger lives inside a single file or component, read the whole file — not just the cited region. When invoked on a multi-file diff, each touched file is in scope, and cross-file structural patterns (concept multiplication across modules, fragmentation that spans files) are in scope too. Adjacent files in the same directory are fair game when the trigger's pattern recurs there — concept multiplication often lives across siblings.
+
+**Don't let the user's framing define the scope.** A trigger that says "extract `<ValueInputMode>`" implies a UI extraction; if the surrounding code shows the same fragmentation pattern recurring, name *that* — even when the implied fix is elsewhere (e.g., a discriminated data-model change rather than a sub-component split). The reviewer's job is to surface what the evidence on disk says, not to confirm the trigger's framing.
+
+**Push back when the evidence contradicts the trigger.** If the prompt narrows the question to one symptom but the file shows the symptom is one instance of a broader structural issue, the broader finding is the headline, not a footnote. *"Issue #N described an extraction; the actual leverage is the data model"* is a valid first finding, not an out-of-scope tangent. Anchoring on the trigger's framing is itself a Layer 2 silence — a finding the review never let form.
+
 ## The Evaluation Process
 
 Work through these layers in order. **Every finding must survive `/fact-check`** — after completing all layers, invoke the `fact-check` skill on your own evaluation to catch wishful justifications and bogus dismissals.

--- a/.apm/skills/lowy/SKILL.md
+++ b/.apm/skills/lowy/SKILL.md
@@ -36,6 +36,16 @@ Conflating these two — putting orchestration logic and activity logic in the s
 
 Not everything that varies is volatile. Lowy makes a critical distinction: adding an attribute to a data model is *variable* but not *volatile* — the architecture won't suffer. **"If you cannot clearly state what the volatility is, why it is volatile, and what risk the volatility poses in terms of likelihood and effect, then you need to look further."** Decomposing around things that merely vary (rather than things that are genuinely volatile) produces over-engineered boundaries that add cost without containing real change.
 
+## Scope of Review
+
+The trigger — "review this boundary", "should we split X", "look at module Y", a `/do` diff inside one component — is a *starting point*, not a frame. Volatility-based decomposition is most legible at module boundaries; reviewing only the lines the user (or upstream issue) pointed at is how a missing volatility seam in the surrounding module gets missed.
+
+**Default to whole-module scope.** When the trigger lives inside a single file or component, read the whole file — not just the cited region. When invoked on a multi-file diff, each touched file is in scope, and cross-file boundary questions (does this volatility actually live in one place, or is it sprayed across modules?) are in scope too. Sibling modules are fair game when the same boundary question recurs there.
+
+**Don't let the user's framing define the scope.** A trigger that says "extract this into a new component" implies the boundary is the right shape and only the placement is wrong; if the surrounding module shows the volatility axis is actually elsewhere — the data model, the consumer pattern, a sequence/activity split — name *that*, even when the implied fix lands at a different layer than the trigger suggests. The reviewer's job is to surface what the evidence says about volatility, not to confirm the trigger's framing.
+
+**Push back when the evidence contradicts the trigger.** If the prompt narrows the question to one boundary but the surrounding code shows the volatility doesn't track that boundary at all, the redirected finding is the headline, not a footnote. *"Issue #N described a UI extraction; the volatility actually splits the data model into two kinds"* is a valid first finding, not an out-of-scope tangent.
+
 ## The Evaluation
 
 For every module boundary, service split, or new abstraction in the code under review:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The autonomous loop is only as good as the feedback signal it gets. If the agent
 - **Nix-based infra** → NixOS VM tests. Honest tradeoff: a VM isn't a live environment, mocking is often required, and reaching real fidelity for non-trivial infra takes effort — but it's still the closest thing to an executable spec the agent can drive.
 - **Backend / library** → fast, deterministic e2e suites the agent can run in a tight loop. Slow or flaky suites destroy the loop; a 30-second deterministic run beats a 10-minute thorough one.
 
+`/do` enforces this end of the bargain: any change that introduces new behavior (services, endpoints, configuration, env vars, network connectivity, persistence) writes its test before the implementation, and the `test` step fails the run if no test actually exercises the changed paths. Bug fixes get the same test-first treatment; refactors and pure docs are exempt only when there's no observable behavior to verify.
+
 ### State, within and across PRs
 
 **Within a PR**, `/do` writes per-step lifecycle, status, and timing to `.do-results.json` at the repo root. The `do-stop-guard` Stop hook reads this so the agent can't bail mid-workflow — if a run is still `working`, stops are blocked until it reaches `done` or is explicitly marked `failed`.
@@ -37,7 +39,7 @@ Type-checkers, tests, and CI catch correctness; they don't catch design. An LLM-
 - **`hickey`** — accidental complexity, after Rich Hickey's [*Simple Made Easy*](https://www.infoq.com/presentations/Simple-Made-Easy/).
 - **`lowy`** — volatility-based decomposition, after Juval Lowy's [*Righting Software*](https://rightingsoftware.org/) (building on [Parnas 1972](https://www.win.tue.nl/~wstomv/edu/2ip30/references/criteria_for_modularization.pdf)).
 
-Each "Fix in this PR" finding lands as its own commit, so PR history reads as a progression from primary implementation through each structural refinement. The full findings ledger is posted as a PR comment. Both default to Sonnet on Claude Code to keep review cheap enough to run on every task; on harnesses that don't honor the `model:` skill extension (opencode, Codex), reviews use the active model. Both are also auto-invoked from `/talk` against design sketches, so the same lenses shape the spec before you ship it.
+Every finding lands as its own commit in the same PR — there is no Defer disposition, no follow-up issue, no "out of scope" exit. The PR's scope expands to absorb each finding, even when the fix grows the diff substantially; the alternative is shipping the complected version and trusting a "broader refactor" follow-up that statistically never happens. Reviewers default to whole-module scope, not just the diff lines — recurring patterns in the same file are in scope even when the trigger pointed only at one symptom. PR history reads as a progression from primary implementation through each structural refinement; the full findings ledger ships as a PR comment. Both default to Sonnet on Claude Code to keep review cheap enough to run on every task; on harnesses that don't honor the `model:` skill extension (opencode, Codex), reviews use the active model. Both are also auto-invoked from `/talk` against design sketches, so the same lenses shape the spec before you ship it.
 
 Read [**Hickey/Lowy on kolu.dev**](https://kolu.dev/blog/hickey-lowy/) for the full framing — what each lens looks for and why the pair catches what tests miss. Both can be extended with project-specific patterns via `.agency/hickey.md` / `.agency/lowy.md` (see [Project config](#project-config)).
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -117,6 +117,15 @@ const year = new Date().getFullYear();
         </p>
       </li>
     </ul>
+
+    <div class="body body--coda">
+      <p>
+        <Skill name="do" /> writes the test before the implementation for any
+        change that introduces new behavior — services, endpoints, config,
+        persistence. A green run that didn't cover the new code is a
+        coverage gap, not a pass.
+      </p>
+    </div>
   </section>
 
   <section class="sec wrap">
@@ -134,9 +143,9 @@ const year = new Date().getFullYear();
     <div class="body body--lede">
       <p>
         After implementing, <Skill name="do" /> runs <Skill name="hickey" /> +
-        <Skill name="lowy" /> in parallel against the actual diff. Each
-        finding lands as its own commit; the full ledger ships as a PR
-        comment.
+        <Skill name="lowy" /> in parallel against the actual diff. Every
+        finding lands as its own commit in the same PR — no defers, no
+        follow-up issues. The full ledger ships as a PR comment.
       </p>
     </div>
 


### PR DESCRIPTION
## Summary

Closes #158. Stops `hickey` and `lowy` from anchoring on whatever the prompt or upstream issue pointed at, by establishing module-scope as the default reviewing posture in both skills. Also brings the README and landing page into sync with this change plus the two recently-merged reviewer-workflow PRs (#157, #160).

## The trigger-anchoring problem

In the kolu run that motivated #158: a \`/talk\` review of "extract the value-input mode of \`CommandPalette\`" produced **one** finding confirming the issue's own framing. A re-run with explicit whole-file scope on the same diff produced **6–8 findings** — including a critique of the issue's framing itself (the actual leverage was a discriminated data-model change, not a UI extraction). The diff between the two runs was prompt scope, nothing else.

The fix is a posture change in the reviewer skills, not new machinery in `/do` or `/talk`. The reviewers now treat the trigger as a starting point, default to whole-module scope when the trigger lives inside a single file, and push back on the trigger's framing when the evidence on disk contradicts it.

## What changed

### Reviewer skills

- **`.apm/skills/hickey/SKILL.md`** — new `## Scope of Review` section between Key Definitions and The Evaluation Process. Establishes whole-module scope as default, calls out trigger-anchoring as a Layer 2 silence (a finding the review never let form), explicitly licenses redirecting the headline finding when evidence contradicts the prompt's framing.
- **`.apm/skills/lowy/SKILL.md`** — symmetrical `## Scope of Review` section between Variable-vs-Volatile and The Evaluation. Same posture, framed in volatility terms (does this volatility actually live in one place, or is it sprayed across modules?).

### Doc sync for #157, #160, and this PR

The README and landing page hadn't picked up the recent reviewer-workflow changes. Bringing them in sync:

- **`README.md` → "Feedback is the bottleneck"** — short paragraph about `/do` writing the test before the implementation for new behavior, and the test step failing on coverage gaps. (#157 territory.)
- **`README.md` → "Structural reviews catch what tests don't"** — replaces the *"Each Fix-in-this-PR finding lands as its own commit"* sentence with the post-#160 reality: every finding lands in this PR; the PR's scope expands to absorb each finding; no defers; reviewers default to whole-module scope (this PR).
- **`website/src/pages/index.astro` → section 02 (feedback)** — short coda paragraph mirroring the test-first / coverage-gap rule.
- **`website/src/pages/index.astro` → section 03 (structural review)** — *"Each finding lands as its own commit"* → *"Every finding lands as its own commit in the same PR — no defers, no follow-up issues."*

## Test plan

- [x] \`just website check\` — pre-existing \`process\` typing error in \`astro.config.mjs:9\`, unrelated to the edits here. Index.astro itself reports no diagnostics.
- [x] \`just website build\` — builds clean, produces \`dist/index.html\`.
- [ ] Re-read the new "Scope of Review" sections in both skills end-to-end and confirm they read cleanly alongside the existing Layer 1–7 / Step 1–7 evaluation flow.
- [ ] Re-run the kolu#834 review with this PR's skills and confirm the reviewer surfaces the data-model finding without needing an explicit "review the whole file" prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)