### PR TITLE
RFC: recast /do as a workflow graph (alternative to #99, OpenProse-derived primitives)

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -10,491 +10,145 @@ Take a task and do it top-to-bottom: research, branch, implement, pass CI, open 
 
 **Mostly autonomous.** Do NOT use `AskUserQuestion` at any point (except during the `--review` planning pause). Make sensible default choices and keep moving. If the user wants to skip specific steps, they can say so in the prompt — honor it.
 
+This skill is a **workflow graph**, not a single recipe. The graph and its node files live in this directory. Reading these files causes you to embody the workflow; there is no separate engine.
+
+## Layout
+
+```
+.apm/skills/do/
+  SKILL.md            # this file: the loop, the language, the cross-cutting concerns
+  execution.md        # the pinned order; read this immediately after this file
+  workspace.md        # bindings that cross between nodes vs scratch that stays put
+  patterns/           # reusable shapes nodes instance
+    worker-critic.md  # produce → critique → revise (with budget)
+    check-loop.md     # run → on fail, fix → retry (optional flaky/real split)
+    fanout-fix.md     # parallel reviewers → for each finding, commit per fix
+  nodes/              # one file per workflow step (15 files, sync.md … done.md)
+  scripts/            # do-results, steps/sync, steps/done — unchanged
+```
+
+## Language
+
+Each node and pattern is a Markdown file with YAML frontmatter and a small set of canonical `###` sections. The vocabulary is borrowed from [OpenProse](https://github.com/openprose/prose) — see [Provenance](#provenance) below — but this skill ships no runtime dependency on it. The agent is the runtime, same as today.
+
+Node sections:
+
+| Section | Meaning |
+|---------|---------|
+| `### Requires` | Inputs the node needs — caller flags or values published by upstream nodes |
+| `### Ensures` | Values the node publishes for downstream nodes, **plus** durable side effects (commits, PR comments) |
+| `### Strategies` | Judgment rules: when to skip, what to fall back to, how to classify failures |
+| `### Errors` | Declared failure modes (`max_attempts_exhausted`, etc.) and what each does to workflow status |
+| `### Pattern` | If this node instances a pattern, name it and bind its slots and config |
+| `### Receipt` | The `do-results` bookend protocol for this node |
+
+Pattern sections:
+
+| Section | Meaning |
+|---------|---------|
+| `### Slots` | Sub-roles the pattern needs from its caller (with their own Requires/Ensures) |
+| `### Config` | Pattern parameters with defaults |
+| `### Requires` / `### Ensures` | Outer contract: what the pattern instance needs from its caller and produces back |
+| `### Invariants` | Properties that hold regardless of slot implementation |
+| `### Delegation` | Pseudocode describing slot interaction and termination |
+
+Unknown `###` sections are documentation; only the names above are load-bearing.
+
+## How to walk the graph
+
+1. Parse arguments (see [Arguments](#arguments)).
+2. Read [`execution.md`](execution.md) for the pinned order, conditional branches, and entry points.
+3. Read [`workspace.md`](workspace.md) for the bindings that cross between nodes — **only these survive the boundary**; per-node scratch (sub-agent transcripts, mid-step retry attempts, file reads done for verification) does not.
+4. Seed the TaskCreate checklist (see [Progress tracking](#progress-tracking)).
+5. Initialize results: `.../scripts/do-results init`, then stash the caller flags (`set forge ...`, `set noGit ...`).
+6. For each node in order:
+   - Read `nodes/<name>.md`.
+   - If the node has a `### Pattern` section, also read `patterns/<pattern-name>.md` and embody the pattern with the slot bindings.
+   - Bookend with `step-start <name>` then `step-end <status> "<verification>" [reason]` (sync is the exception — its script handles its own bookend).
+   - Update the corresponding TaskCreate task to `in_progress` then `completed`.
+
 ## Arguments
 
 Parse the arguments string: `[--review] [--no-git] [--minimal] [--from <step-id>] <task description or issue-url>`
 
-The workflow is **forge-aware**: it auto-detects whether the repo lives on GitHub or elsewhere during the **sync** step (see Forge Detection). Only GitHub has an active code path today — Bitbucket/other forges gracefully skip PR-related steps. Tracking: [srid/agency#10](https://github.com/srid/agency/issues/10).
+The workflow is **forge-aware**: it auto-detects whether the repo lives on GitHub or elsewhere during the **sync** node. Only GitHub has an active code path today — Bitbucket/other forges gracefully skip PR-related steps. Tracking: [srid/agency#10](https://github.com/srid/agency/issues/10).
 
-- `--review`: Pause after **research** for user plan approval via `EnterPlanMode`/`ExitPlanMode`, then continue autonomously. (hickey/lowy now runs post-implement on a concrete diff, so there's no plan-approval moment attached to that step anymore — the review point is pre-implement, before any code is written.)
-- `--no-git`: Extend the working tree **in place** — do not create a branch, commit, push, or touch any PR. Research, implement, check, docs, police, fmt, and test all run; git-mutating steps (**branch**, **commit**, **create-pr**) are skipped. Use this when you have uncommitted local work and want the agent to build on it without taking over git state. Feedback from a Bitbucket user in [#26](https://github.com/srid/agency/issues/26).
-- `--minimal`: Skip the steps whose value is disproportionate on trivially-scoped diffs: **docs**, **hickey+lowy**, **police**, and **evidence**. The remaining flow runs in order: sync → research → branch → implement → check → fmt → commit → test → create-pr → ci → done. Use this when the change is obviously confined (one-line bug fix, typo, config tweak) and structural review / docs sync / quality gate / PR evidence are overkill — PR comments on small `/do` runs frequently note this. The four skipped steps each record `status="skipped"` with `reason="--minimal"`.
-- `--from <step-id>`: Start from a specific step (see entry points below)
+- `--review`: Pause after **research** for user plan approval via `EnterPlanMode`/`ExitPlanMode`, then continue autonomously.
+- `--no-git`: Extend the working tree **in place** — do not create a branch, commit, push, or touch any PR. Research, implement, check, docs, police, fmt, hickey-lowy, and test all run; git-mutating nodes (**branch**, **commit**, **create-pr**) skip.
+- `--minimal`: Skip the nodes whose value is disproportionate on trivially-scoped diffs: **docs**, **hickey-lowy**, **police**, and **evidence**. Use this for one-line bug fixes, typos, config tweaks. The four skipped nodes record `status="skipped"` with `reason="--minimal"`.
+- `--from <step-id>`: Start from a specific node. See [`execution.md`](execution.md) for entry points.
 
 ## Results Tracking
 
-Every step is bookended by two `scripts/do-results` calls: `step-start <name>` before the work begins, and `step-end <status> <verification> [reason]` after verification. This is what keeps per-step timing accurate — collapsing both into a single end-of-step call produces zero-second durations and worthless timing tables. The script tracks workflow state and emits the final timing table during **done**.
+Every node is bookended by two `scripts/do-results` calls: `step-start <name>` before the work begins, and `step-end <status> <verification> [reason]` after verification. This is what keeps per-step timing accurate — collapsing both into a single end-of-step call produces zero-second durations and worthless timing tables. The script tracks workflow state and emits the final timing table during **done**.
 
 **Trust the script's stdout.** Every mutation echoes a one-line confirmation. Treat that line as your confirmation that the write succeeded; the script is the only public surface, and whatever it persists internally is private.
 
 **Lifecycle the script tracks intrinsically**:
 
-- Step `status` — `passed`, `failed`, or `skipped`. A `skipped` step must include a `reason` (e.g. `"non-github forge: bitbucket"`, `"--no-git"`, `"--minimal"`, `"no check command configured"`).
+- Node `status` — `passed`, `failed`, or `skipped`. A `skipped` node must include a `reason` (e.g. `"non-github forge: bitbucket"`, `"--no-git"`, `"--minimal"`, `"no check command configured"`).
 - `active` — state enum (not a boolean). Set to `working` when the workflow starts (**sync**), `waiting` when the agent is idle waiting for an external process (e.g. background CI), back to `working` when that process returns, and `false` when **done** is reached. The stop hook uses this: `working` blocks exits; `waiting` and `false` allow them.
 - Workflow `status` — `completed` when **done** finishes, `failed` if halted. Informational.
 
 **Workflow fields /do also stashes via `set`** (the script doesn't interpret these — it just remembers them):
 
 - `forge` — `github`, `bitbucket`, or `unknown`. Populated by `scripts/steps/sync` after forge detection.
-- `noGit` — `true` or `false`. Reflects the `--no-git` flag. Git-mutating steps (**branch**, **commit**, **create-pr**) skip with `reason="--no-git"` when set.
+- `noGit` — `true` or `false`. Reflects the `--no-git` flag.
 
 **Commands** (invoke with the full path, e.g. `.../skills/do/scripts/do-results ...`):
 
 - `init` — initialize the workflow's lifecycle skeleton. Echoes `init: startedAt=<ts>`.
-- `step-start <name>` — call before step work. Echoes `pending: <name>`.
+- `step-start <name>` — call before node work. Echoes `pending: <name>`.
 - `step-end <status> "<verification>" ["<reason>"]` — call after verification. Echoes `recorded: <name> <status> (steps=<count>, pending=<none|name>)`.
-- `step <name> <status> "<verification>" <startedAt> <completedAt> ["<reason>"]` — single-call form used by `scripts/steps/sync` where `startedAt` was captured in shell. Echoes `recorded: <name> <status> (steps=<count>)`. Agent code should prefer `step-start` / `step-end`.
-- `set <field> <value>` — set an arbitrary top-level field. Used both for lifecycle (`set active waiting`, `set status completed`) and for /do-specific values that sync stashes (`set forge github`, `set noGit false`). Echoes `set: <field>=<value>`.
+- `step <name> <status> "<verification>" <startedAt> <completedAt> ["<reason>"]` — single-call form used by `scripts/steps/sync`. Agent code should prefer `step-start` / `step-end`.
+- `set <field> <value>` — set an arbitrary top-level field. Echoes `set: <field>=<value>`.
 
 **Discipline**:
 
-- Bookend every step with `step-start` at the top and `step-end` at the bottom. Calling `step-end` without a prior `step-start` is an error; calling `step` with `now` for both timestamps collapses duration to 0 — neither pattern is allowed. Exceptions: `sync` is recorded by `scripts/steps/sync` itself, and skipped steps (duration always 0) may use back-to-back `step-start` / `step-end skipped`.
+- Bookend every node with `step-start` at the top and `step-end` at the bottom. Calling `step-end` without a prior `step-start` is an error; calling `step` with `now` for both timestamps collapses duration to 0 — neither pattern is allowed. Exceptions: `sync` is recorded by `scripts/steps/sync` itself, and skipped nodes (duration always 0) may use back-to-back `step-start` / `step-end skipped`.
 - Don't run `date` yourself or guess timestamps — `do-results` resolves UTC internally.
+- The bookending is per-node, declared in each node's `### Receipt` section. Re-state nothing here that the node already declares.
 
 ## Progress tracking
 
-Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a live checklist of the workflow. At the start of **sync** (or the chosen `--from` entry point), seed a task list with the step names in order:
+Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a live checklist of the workflow. At the start of **sync** (or the chosen `--from` entry point), seed a task list with the node names in order from `execution.md`:
 
 ```
-sync, research, branch, implement, check, docs, fmt, commit, hickey+lowy, police, test, create-pr, ci, evidence, done
+sync, research, branch, implement, check, docs, fmt, commit, hickey-lowy, police, test, create-pr, ci, evidence, done
 ```
 
-**Emit all `TaskCreate` calls as parallel `tool_use` blocks in a single assistant turn** — one model round-trip, not one per task. The seeded steps have no `addBlocks` / `addBlockedBy` dependencies, so there is nothing to serialize on. Sequential seeding (15 round-trips before any real work) is a regression: it adds latency to every `/do` invocation and clutters the transcript with 15 wrapper turns of "Task #N created successfully" before `sync` even starts.
+**Emit all `TaskCreate` calls as parallel `tool_use` blocks in a single assistant turn** — one model round-trip, not one per task. The seeded nodes have no dependencies declared in TaskCreate (the dependency model lives in `execution.md`), so there is nothing to serialize on. Sequential seeding (15 round-trips before any real work) is a regression: it adds latency and clutters the transcript.
 
-**Under `--minimal`, omit the four steps the flag skips** (`docs`, `hickey+lowy`, `police`, `evidence`) from the seeded list — the user explicitly opted out of them, so they shouldn't clutter the human-facing checklist. The seeded list becomes 11 items in `--minimal` runs. (Run-inherent skips like `--no-git` and forge skips stay in the list — see the Skipped steps rule below.)
+**Under `--minimal`, omit the four nodes the flag skips** (`docs`, `hickey-lowy`, `police`, `evidence`) from the seeded list — the user explicitly opted out, so they shouldn't clutter the human-facing checklist. The seeded list becomes 11 items in `--minimal` runs. (Run-inherent skips like `--no-git` and forge skips stay in the list — see Skipped nodes below.)
 
-The `scripts/do-results` lifecycle still records `--minimal`-skipped steps with `status="skipped"` and `reason="--minimal"` via back-to-back `step-start` / `step-end` calls — that's what keeps the final timing table and `completed`-status logic correct. The task UI is independent of that recording.
+The `scripts/do-results` lifecycle still records `--minimal`-skipped nodes with `status="skipped"` and `reason="--minimal"` via back-to-back `step-start` / `step-end` calls — that's what keeps the final timing table and `completed`-status logic correct. The task UI is independent of that recording.
 
-At each step boundary, update task state **alongside** the `scripts/do-results` script call — they are not redundant. The script's state drives the stop hook; the task list is the human-facing UI. Miss either and the workflow is inconsistent.
+At each node boundary, update task state **alongside** the `scripts/do-results` script call — they are not redundant. The script's state drives the stop hook; the task list is the human-facing UI. Miss either and the workflow is inconsistent.
 
 Rules:
 
-- **Flip to `in_progress` when a step starts, `completed` when it verifies.** One step `in_progress` at a time.
-- **Retries stay `in_progress`.** If `check`, `test`, or `ci` loop through their retry budget, do **not** bounce the task state back to `pending` or flicker it — leave it `in_progress` until the step finally verifies (or the retries exhaust and the workflow fails).
-- **`--from <step>` entry points**: still seed the full list (minus any `--minimal` omissions). Mark steps earlier than the entry point as `completed` immediately after seeding, so the checklist shows a consistent view regardless of entry point.
-- **Skipped steps that stay in the list** (e.g. `branch`/`commit`/`create-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. Record the skip with a back-to-back `scripts/do-results step-start <name>` / `scripts/do-results step-end skipped ... "<reason>"`; the task list just shows the step as done. `--minimal` skips are **not** in this category — they're omitted from the seeded list entirely (see above), so there's no task entry to flip.
-- **Failure**: if retries exhaust and the workflow halts, leave the failing step `in_progress`, mark `done` `completed` after the failure summary is written, and run `scripts/do-results set status failed`.
+- **Flip to `in_progress` when a node starts, `completed` when it verifies.** One node `in_progress` at a time.
+- **Retries stay `in_progress`.** If `check`, `test`, `ci`, or `docs` loop through their retry budget, do **not** bounce the task state back to `pending` or flicker it — leave it `in_progress` until the node finally verifies (or retries exhaust and the workflow fails).
+- **`--from <step>` entry points**: still seed the full list (minus any `--minimal` omissions). Mark nodes earlier than the entry point as `completed` immediately after seeding.
+- **Skipped nodes that stay in the list** (e.g. `branch`/`commit`/`create-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. Record the skip with a back-to-back `do-results step-start` / `step-end skipped ... "<reason>"`.
+- **Failure**: if retries exhaust and the workflow halts, leave the failing node `in_progress`, mark `done` `completed` after the failure summary is written, and run `scripts/do-results set status failed`.
 
-## Steps
+## Invariants (workflow-wide)
 
-### sync
+These hold regardless of which nodes are running:
 
-Run the `scripts/steps/sync` script in this skill's directory, passing `true` or `false` for `--no-git`:
-
-```
-.../skills/do/scripts/steps/sync <noGit>
-```
-
-The script:
-
-- Fetches `origin` and pins `origin/HEAD`
-- If `--no-git` is **not** set and the branch is behind origin (ahead-count 0), fast-forwards with `git pull --ff-only`. Under `--no-git`, fetching happens but the working tree is not touched — uncommitted work is preserved.
-- Prints the dirty-tree hint to stderr (no pause) when the tree is dirty and `--no-git` is not set:
-
-  > _Dirty tree detected. Continuing will create a fresh branch on top of these changes. If you wanted the agent to extend your WIP in place without touching git, re-run with `--no-git`._
-
-- Classifies the forge from `git remote get-url origin` — `github.com` → `github`, `bitbucket.` (covers `bitbucket.org` and self-hosted servers like `bitbucket.juspay.net`) → `bitbucket`, otherwise `unknown`.
-- Calls `scripts/do-results init <forge> <noGit>` then `scripts/do-results step sync passed ...`.
-- Prints `forge=<value>`, `branch=<value>`, `defaultBranch=<value>` on stdout for downstream steps.
-
-**Only `github` has an active code path today.** Both `bitbucket` and `unknown` cause forge-dependent steps (PR creation, PR comments, PR edits, CI status) to skip gracefully. Bitbucket support is planned — see [srid/agency#10](https://github.com/srid/agency/issues/10).
-
-**Verify**: Script exited 0 and printed `forge=`, `branch=`, `defaultBranch=` lines on stdout. (Sync silences `do-results`' own confirmation echoes so the protocol stays clean.)
-
----
-
-### research
-
-Research the task thoroughly before writing code.
-
-- If given a GitHub issue URL **and** `forge == github`, fetch with `gh issue view`. On non-GitHub forges, treat any issue-like URL as opaque context — use the prompt text as-is and do not attempt to fetch. (Bitbucket issue/Jira fetching is tracked in #10.)
-- **Never assume** how something works. Read the code. Check the config.
-- If the prompt involves external tools/libraries, prefer `git clone` to a scratch dir (e.g. `/tmp/<name>`) at the version the project actually uses, then read the source on disk with `Read`/`Grep`/`Glob`. Fall back to `WebSearch`/`WebFetch` only when the source genuinely isn't a clonable repo (vendor docs, blog posts, RFCs).
-
-**Delegation rule — keep the main context lean.** Before your third `Read` in this step, stop and delegate the rest via `Agent(subagent_type=Explore)`. Main-context reads are reserved for:
-
-  (a) specific files the user named in the prompt,
-  (b) verifying a specific file:line an Explore subagent cited — and only with `offset`/`limit`, never full-file.
-
-Anything that smells like "map the codebase", "find all callers", "understand how X works across the repo" — delegate. The Explore subagent returns a file:line map; keep that map and reference it in later steps instead of re-reading. Use `Grep`/`Glob` before `Read`: if the question can be answered by searching, don't open the file.
-
-**Verify**: Can articulate what needs to change, where, and why, with file:line citations drawn from the research map (not re-read in main context).
-
-**If `--review`**: Use `EnterPlanMode` to present the approach for user approval:
-
-- **Clarify ambiguities** first — ask via `AskUserQuestion` if anything is unclear. Don't guess.
-- **High-level plan**: what to do and why, not implementation details. Include an **Architecture section** (affected modules, new abstractions, ripple effects).
-- **Split non-trivial plans into phases** — MVP first, each phase functionally self-sufficient.
-
-Use `ExitPlanMode` to present the plan. Once approved, continue autonomously to **branch**. Structural critique from hickey/lowy isn't available at this point — it runs post-implement on a concrete diff and surfaces as commits + a PR comment later.
-
----
-
-### branch
-
-**If `--no-git`**: Skip this step entirely with status `skipped` and reason `"--no-git"`. Stay on the current branch — do not create, commit, or push anything. Move to **implement**.
-
-Detect the default branch: `git symbolic-ref refs/remotes/origin/HEAD`
-
-1. Create a descriptive feature branch from `origin/<default>`
-
-That's it — just the local branch. No commit, no push, no PR. The branch is pushed later in **commit**, and the PR is created in **create-pr** after all changes are done.
-
-**Verify**: On a feature branch (not master/main).
-
----
-
-### implement
-
-The test-first rule depends on what the change is:
-
-- **Bug fix**: write a failing test first (e2e or unit, whichever is appropriate), then fix the bug.
-- **New behavior** — anything that fails at runtime if it's wrong: new endpoints or routes, new services or modules, configuration paths, environment variables, secrets wiring, network connectivity, data persistence (migrations, preStart scripts, schema changes), auth/OIDC flows. Write an integration or unit test covering the new behavior **before** implementing. NixOS service modules need a VM test; new HTTP endpoints need an e2e or integration test; new modules with logic need at least a unit test.
-- **Otherwise** — documentation, refactors with no behavioral change, purely internal cleanups, dependency bumps that don't change behavior. Just implement the planned changes; no test-first requirement.
-
-If you're not sure which bucket the change falls into, treat it as new behavior. The cost of an unnecessary test is small; the cost of a silent deployment failure is not.
-
-Prefer simplicity. Do the boring obvious thing.
-
-**E2E coverage**: When the change introduces multiple user-facing paths (e.g., a dialog that appears under different conditions), write e2e scenarios for **each distinct path**. Enumerate the user-visible paths, then check that every one has a corresponding test.
-
-**Verify**: Code changes match the planned approach. For bug fixes and new-behavior changes, at least one test exercises the changed behavior; multi-path changes have one test per distinct user-visible path. Refactor/docs/cleanup diffs are exempt.
-
----
-
-### check
-
-Read `.agency/do.md` and look for a `## Check command` section — a fast static-correctness gate (e.g. `tsc --noEmit`, `cargo check`, `cabal build`, `mypy`, `dune build @check`). Run it.
-
-This is the cheapest gate in the pipeline, so it runs first — fail fast on broken code before any downstream step does work over it. If no check command is documented, skip this step with a note.
-
-**Verify**: Check ran without errors, or no command configured.
-**If failed** (max 3 attempts): Fix the errors and re-run check. Do not fall back to **implement** — the agent is already in fix mode and the failure is local to just-written code.
-
----
-
-### docs
-
-**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **fmt**.
-
-Read `.agency/do.md` and look for a `## Documentation` section listing which docs to keep in sync (e.g., README.md). Compare those files against changes in this PR.
-
-If no documentation files are documented, skip this step with a note.
-
-**Verify**: Docs match current code.
-**If outdated** (max 3 attempts): Fix the outdated sections and re-verify.
-
----
-
-### fmt
-
-Read `.agency/do.md` and look for a `## Format command` section. Run it.
-
-If no format command is documented, skip this step with a note.
-
-**Verify**: Format command ran without error, or no command configured.
-
----
-
-### commit
-
-**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. Move to **hickey+lowy**. The working-tree changes stay uncommitted — that is the point.
-
-Create a NEW commit (never amend) with a conventional commit message for the primary implementation. Push to the feature branch with `git push -u origin <branch>` (sets upstream on first push).
-
-This is the **primary feature commit**. Downstream **hickey+lowy** and **police** steps produce their own follow-up commits — one per finding or violation addressed — which keeps the PR history a readable progression of "what was built, then what was refined" rather than a single opaque squash.
-
-**Verify**: `git log -1` shows a new commit on the feature branch, and it's pushed to remote.
-
----
-
-### hickey + lowy
-
-**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **police** (which will also skip under `--minimal`). Do not spawn either sub-agent.
-
-Invoke `hickey` and `lowy` as two **parallel sub-agents** via the harness's agent tool (`subagent_type: "hickey"` and `subagent_type: "lowy"`). On Claude Code this is the `Agent` tool. On opencode this is the `task` tool (with `subagent_type` parameter). On Codex this is the sub-agent spawning tool for delegated work. Invoking `/do` is explicit authorization to run these two review agents; do not wait for a second user prompt before spawning them.
-
-**Fallback, never skip.** If the harness cannot honor the model declared in the reviewer skill's frontmatter, run hickey and lowy as sub-agents on the available model instead — this is the expected path on harnesses that ignore Claude Code's `model:` skill extension (opencode, Codex, etc.). If a sub-agent invocation fails for harness/tooling reasons before producing a review, retry that reviewer once; if it still cannot produce a sub-agent review, run that review in the main model by loading the reviewer skill against the same diff. This fallback is slower and uses more main-context budget, but it is still the `/do` hickey+lowy step. Do not replace it with an informal/manual review, and do not mark the step `skipped` because a preferred model was unavailable.
-
-**Why post-implement, not pre-implement.** Hickey's complecting critique and Lowy's volatility lens both bite harder on a concrete diff than on a plan sketch. Reviewing a plan tends to surface generic concerns; reviewing a real diff surfaces the specific interleavings and boundary misalignments that matter. Running here also means the review covers *everything* the diff contains — including whatever the plan glossed over and whatever drifted during implementation.
-
-<use_parallel_tool_calls>
-For maximum efficiency, invoke the `hickey` and `lowy` Agent tools **in parallel** rather than sequentially. You MUST use parallel tool calls: emit both `Agent` tool_use blocks (one with `subagent_type: "hickey"`, one with `subagent_type: "lowy"`) in a single response, with no other tool calls or text in that response.
-</use_parallel_tool_calls>
-
-Each `Agent` prompt must be self-contained (sub-agents do not inherit this conversation's context). Brief each one with:
-
-- The full task prompt plus anything relevant that **research** uncovered (file paths, intended approach, key constraints)
-- The scope to analyze: the actual diff, `git diff origin/HEAD...HEAD` — this is the same scope regardless of entry point (default or followup), since the branch at this point holds the primary feature commit (plus any cumulative followup commits) and no further work is pending
-
-The sub-agent already knows to read its skill file and follow that methodology; don't re-state it in the prompt.
-
-**Model selection lives in the skill, not here.** Both `hickey/SKILL.md` and `lowy/SKILL.md` declare `model: sonnet` in their frontmatter — Claude Code honors this and runs the review on Sonnet to keep the per-task cost cheap; opencode/Codex ignore the field (it isn't part of the Agent Skills standard) and fall through to the active model, which is the right behavior for harnesses that don't have Sonnet. Don't pass `model:` at the `Agent` tool level — the skill frontmatter is the single source of truth.
-
-**No deferrals.** The hickey and lowy skills emit two dispositions: **Fix in this PR** and **No-op**. There is no Defer. `/do` is not optimizing for minimal diff — it is optimizing for the simpler artifact landing in `master`. A PR that grows from 50 lines to 400 because hickey caught a real fragmentation bug is a *better* PR, not a worse one; the alternative is shipping the complected version and trusting a "broader refactor" follow-up that statistically never happens.
-
-If a sub-agent emits anything resembling a defer — `Defer #N`, "out of scope", "follow-up", "pre-existing, separate PR", "should be its own change", any phrasing that punts a finding to a future issue — treat it as a sub-agent rule violation. Flip the disposition to **Fix in this PR** unconditionally and apply the fix here. Do not create a follow-up issue, do not record the finding as deferred in the PR body, do not surface it as outstanding structural debt. The only way out of a finding is through it.
-
-(`No-op` survives without code action — but it is narrow: the diff already deletes the offending code, or the finding is subsumed verbatim by another entry in the same review. Anything resembling deferred-work-for-later is a Fix, not a No-op.)
-
-Findings that genuinely require coordination outside this repo (upstream library bug, breaking dep upgrade, schema migration that must ship separately) shouldn't have surfaced as findings of this structural review in the first place; if one did, apply a local workaround or interface boundary in this PR rather than punt — and flag the upstream dependency in the PR description as a strategic note, not as a deferred finding.
-
-After the audit, every finding lands as a commit, except entries dispositioned **No-op**.
-
-**Apply each "Fix in this PR" finding as its own commit** — do not batch multiple findings into one commit. A reviewer reading the PR's commit history should be able to read one "address hickey finding: decomplect viewportDimensions" commit at a time and follow the structural refinement as a sequence, not decode a grab-bag diff. For each finding in turn:
-
-1. Apply the fix narrowly — only the lines that address this specific finding.
-2. Run the project's format command (from **fmt** instructions) on the changed files, if one is configured.
-3. `git add <changed files>` — stage only the files this fix touched.
-4. `git commit -m "refactor(hickey): <short finding label>"` (or `refactor(lowy): …` depending on the lens). The body of the message should restate the finding in one line so the commit is self-explanatory in `git log`.
-5. `git push` — push after each commit so the draft PR (once created) accumulates commits in real time. (The `-u` flag is only needed on the first push, which already happened in **commit**.)
-
-**Under `--no-git`**: Skip the commit/push steps entirely. Apply fixes to the working tree and move on — the user will review the combined working-tree delta themselves. Record the step as passed with verification noting "--no-git: fixes applied to working tree, not committed."
-
-**Verify**: Both hickey and lowy produced review output using their respective skills, either through sub-agents or the main-model fallback. Every finding has an action recorded — either **Fix in this PR** or **No-op** (no defers; if the sub-agent emitted one, the audit step above flipped it to Fix in this PR). Every "Fix in this PR" finding has a corresponding commit on the feature branch (check via `git log origin/HEAD..HEAD --oneline`), except under `--no-git`. No unactioned findings; no deferred findings.
-
----
-
-### police
-
-**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **test**. Do not invoke `/code-police`.
-
-Use `git diff origin/HEAD...HEAD --name-only` to check if the PR contains code changes. If all changed files are documentation-only (e.g., `.md`, `.txt`, `README`, docs/) — skip this step with a note.
-
-Otherwise, invoke the `/code-police` skill via the Skill tool. It runs three passes: rule checklist, fact-check, and elegance (which delegates to `/simplify` when available).
-
-When `/code-police` asks about scope: **changes in the current branch/PR only**.
-
-**Commit each violation fix individually.** The same rule as **hickey + lowy**: PR history is the story of the work, and a reviewer should see one commit per rule violation or elegance refinement, not a lump "police pass" commit covering eight unrelated things.
-
-For each violation reported by `/code-police` (across all three passes), in turn:
-
-1. Apply the fix for that one violation — scope the edit tightly.
-2. Run the project's format command on changed files, if configured.
-3. `git add <changed files>` — stage only this fix.
-4. Commit with a conventional prefix identifying the pass and rule:
-   - Rules pass: `fix(police): <rule-id> — <short description>` (e.g. `fix(police): no-dead-code — remove commented-out fallback`)
-   - Fact-check pass: `fix(police): fact-check — <short description>` (e.g. `fix(police): fact-check — propagate error from loader`)
-   - Elegance pass (`/simplify`-applied or inline-loop-applied): `refactor(police): elegance — <short description>`
-5. `git push`.
-
-For the elegance pass specifically: `/simplify` applies fixes in batches across three lenses (reuse, quality, efficiency). Commit each distinct refactor as a separate commit — do not roll them into one "elegance" commit. If a lens produces multiple independent changes (two reuse-via-helper refactors in different files, say), those are separate commits too.
-
-**Under `--no-git`**: Skip the commit/push steps. Apply fixes to the working tree and continue. The user reviews the combined delta.
-
-**Verify**: All 3 passes clean ("All clear"). Under `--no-git`, the tree reflects the fixes; otherwise `git log origin/HEAD..HEAD --oneline` shows one commit per violation addressed.
-**If violations found** (max 3 attempts): Fix the violations (one commit per fix, as above) and re-invoke `/code-police`.
-
----
-
-### test
-
-Read `.agency/do.md` and look for a `## Test command` section. Run only the tests relevant to the code paths changed in this PR.
-
-Use `git diff origin/HEAD...HEAD --name-only` to identify changed files and determine which tests are relevant.
-
-If changes are purely internal with no user-facing impact, unit tests may suffice — skip e2e if no relevant scenarios exist. If no test command is documented, skip with a note.
-
-**Coverage gap check**: After the test command exits 0, confirm at least one of the tests run actually exercised the new behavior (per the **implement** step's classification). A green run that didn't touch the changed code paths — e.g. a new NixOS service module with no corresponding VM test, or a new endpoint with no integration test — is a coverage gap, not a pass. Refactor/docs/internal-cleanup diffs are exempt. The implement step should have caught this; if it didn't, treat it as a real failure: write the missing test, then loop through **fmt** → **commit** → **test** as below.
-
-**Verify**: Tests pass (exit code 0) **and** the new behavior is covered, or the diff is exempt from the coverage check, or no relevant tests to run.
-**If failed** (max 4 attempts): Analyze the failure. If flaky, re-run. If real: fix → go to **fmt**, then retry.
-
----
-
-### create-pr
-
-**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to create. Proceed to **ci**.
-
-**If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. (Bitbucket `bkt pr edit` wiring is tracked in #10.) Proceed to **ci**.
-
-**If `forge == github`**:
-
-Check whether a PR already exists for this branch (`gh pr view`).
-
-**If no PR exists** (first run, normal path):
-
-1. Create a draft PR: `gh pr create --draft`
-
-   **MANDATORY**: Load the `forge-pr` skill (via Skill tool) BEFORE writing the PR title/body.
-
-2. **Post hickey/lowy results**: Post the hickey and lowy analysis as a PR comment using `gh pr comment` with a `## [Hickey/Lowy](https://kolu.dev/blog/hickey-lowy/) Analysis` header (the heading links to the blog post explaining the two lenses, mirroring how the final step status comment links `/do` to the agency repo). Always post when the steps ran — reviewers should see the structural analysis even if every finding was a No-op.
-
-   **Format the comment with a leading findings ledger.** Compose a single table from both sub-agents' Actions sections — one row per finding — so a reviewer can see disposition at a glance without parsing paragraphs. Put each lens's prose underneath as rationale:
-
-   ```md
-   ## [Hickey/Lowy](https://kolu.dev/blog/hickey-lowy/) Analysis
-
-   | # | Lens   | Finding                                  | Disposition       |
-   |---|--------|------------------------------------------|-------------------|
-   | 1 | Hickey | viewportDimensions complects two roles   | Fixed in this PR  |
-   | 2 | Lowy   | useViewport encapsulates ghost concern   | Fixed in this PR  |
-
-   ### Hickey rationale
-   <prose from the hickey sub-agent>
-
-   ### Lowy rationale
-   <prose from the lowy sub-agent>
-   ```
-
-   The Disposition cell mirrors the sub-agent's Actions disposition verbatim — **Fixed in this PR** or **No-op** (deletion-only / subsumed by another finding). There is no Deferred disposition; if a sub-agent emitted one, the audit step above flipped it to Fixed in this PR. The Finding cell is the short bolded label the sub-agent emits at the start of each Actions entry. If both lenses produced zero findings, write a one-line "No findings — analysis below" instead of an empty table.
-
-**If PR already exists** (followup runs, `--from` entry points):
-
-Re-check the PR title/body against current scope. If scope changed, update via `gh pr edit` per the `forge-pr` skill.
-
-**Why this runs before `ci`**: The draft PR is the canonical home for CI status. Opening it before CI runs means CI checks land directly on the PR, reviewers see the run history as it happens, and a failing run doesn't leave an orphaned branch with red statuses and no PR to explain them. If retries exhaust in **ci**, the draft PR remains as the artifact of the failed attempt — visible, reviewable, and ready to resume via `--from ci-only`.
-
-**Verify**: Draft PR exists (`gh pr view` succeeds), PR title/body matches the delivered scope, hickey/lowy findings posted if any.
-
----
-
-### ci
-
-Read `.agency/do.md` and look for a `## CI command` section, plus any verification method documented there. Run CI with `run_in_background: true` if the command takes more than a few seconds.
-
-**Never pipe CI to `tail`/`head`**, and **never append `2>&1`** — background mode captures both streams.
-
-**Active state**: Before waiting for background CI, run `scripts/do-results set active waiting`. When CI returns (success or failure), run `scripts/do-results set active working` before proceeding. This lets the stop hook allow graceful exits while the agent is idle.
-
-CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are forge-independent — **run them regardless of forge**. Only the *verification method* may be forge-specific: if `.agency/do.md` describes verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output for verification on non-GitHub forges, and note this in the step record. (Bitbucket `bkt pr checks` wiring is tracked in #10.)
-
-**Verify**: Use the verification method described in `.agency/do.md` (e.g., checking commit statuses on GitHub, reading CI output elsewhere). If no CI command is documented, skip with a note. **The CI result must cover `HEAD`.** Before recording the step as passed, compare the commit SHA that CI ran against with `git rev-parse HEAD`. If they differ (e.g., a commit was pushed after CI started — whether from a fix retry, user-requested changes, or any other source), re-run CI against the current HEAD. CI passing on a stale commit does not satisfy verification.
-
-**On failure** — read logs or output to diagnose.
-
-**Flaky vs real**: A test is flaky only if it **passes on a subsequent retry**. Consistent failure = real bug. Before retrying, read the failing test code to judge if the failure pattern is inherently flaky (race conditions, timing, async waits).
-
-**If flaky** (max 3 retries): Retry just the failing step.
-**If real bug** (max 5 fixes): Fix → **fmt** → **commit** → retry CI. Under `--no-git`, drop **commit** from the loop (Fix → **fmt** → retry CI). The draft PR already exists — subsequent pushes update it automatically, no re-run of **create-pr** needed.
-**If retries exhausted**: Set workflow status to `"failed"`, skip to **done**. The draft PR stays open as the record of the failed attempt.
-
----
-
-### evidence
-
-**Opt-in step.** Most projects skip this. The step exists so projects with empirical "did the feature actually work" needs — UI screenshots, performance benchmarks, demo recordings, output transcripts — can attach that evidence to the PR without baking the mechanism into agency.
-
-**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **done**.
-
-**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to attach evidence to.
-
-**If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. (Bitbucket comment wiring is tracked in #10.)
-
-**Otherwise**: Read `.agency/do.md` and look for a `## PR evidence` section. If `.agency/do.md` is missing, or the section is missing or empty, skip with status `skipped` and reason `"no PR evidence section in .agency/do.md"` — the default for projects that haven't opted in.
-
-**If the section is present**:
-
-The section is project-specific and free-form: it can be inline prose describing the capture procedure, a pointer to another file (`See ./scripts/capture-evidence.md`), a script reference (`Run ./scripts/capture-pr-evidence.sh and use its stdout`), or any combination. Don't second-guess the form — read it, then **spawn a sub-agent** (`Agent(subagent_type: "general-purpose", ...)`) so the capture work (MCP calls, screenshot uploads, gh API requests) doesn't pollute `/do`'s main context.
-
-The sub-agent prompt should include:
-
-- The literal section content from `.agency/do.md`.
-- Standard PR context: PR URL, branch name, base branch, current commit SHA, and `git diff origin/HEAD...HEAD --name-only` so the sub-agent knows which routes/files to exercise.
-- An explicit instruction that the sub-agent's job is to return a single block of markdown (image links embedded, table data inline, etc.) suitable for posting under a `## Evidence` heading. The sub-agent should not post the comment itself — only return the markdown.
-
-After the sub-agent returns, post its output as one PR comment using `gh pr comment` under a `## Evidence` heading. Use the **single-quoted heredoc** pattern (see `forge-pr` → "Passing the body to `gh` safely") so backticks and `$` survive unescaped:
-
-```sh
-gh pr comment --body "$(cat <<'EOF'
-## Evidence
-
-<markdown returned by the sub-agent>
-EOF
-)"
-```
-
-Embed image/asset URLs inline in the markdown — `gh pr comment` itself cannot attach files; the workflow section is responsible for telling the sub-agent how to host any binary artifacts so they end up referenceable.
-
-**Verify**: Either the step was skipped per the rules above, or a `## Evidence` PR comment exists (`gh pr view --comments` or equivalent) populated from the sub-agent's output.
-
----
-
-### done
-
-Present a summary of all steps with their verification status. If any step has a non-success status, retry it (max 3 attempts from done). If still failing after retries, set `status: "failed"`.
-
-`"completed"` requires **all steps `passed`**, with four exceptions that count toward completion:
-
-1. A step `skipped` with `reason` beginning `"non-<forge> forge:"` (detected forge isn't GitHub).
-2. A step `skipped` with `reason` `"--no-git"` (user opted out of git operations).
-3. A step `skipped` with `reason` `"no PR evidence section in .agency/do.md"` (project hasn't opted into the evidence step — this is the default).
-4. A step `skipped` with `reason` `"--minimal"` (user opted out of structural review / docs / quality gate / evidence on a trivial diff).
-
-A `failed` step always blocks `"completed"`. No redefining "passed," no footnote caveats. Update via `scripts/do-results set status completed` or `scripts/do-results set status failed` accordingly.
-
-#### Timing summary
-
-Run `scripts/steps/done` in this skill's directory. It emits:
-
-1. A markdown timing table (step, status, duration, verification), with any step that took ≥30% of total time shown in **bold**.
-2. A total wall-clock line (`startedAt` of first step → `completedAt` of last step).
-3. A `**Slowest step**:` line.
-4. A `<<<FACTS ... FACTS` block with machine-readable summary data (`totalSeconds`, `slowestStep`, `slowestSeconds`, `dominantSteps`, `skippedSteps`, `failedSteps`) — use this to compose optimization suggestions below.
-
-Do not compute durations yourself — the script handles all timestamp arithmetic.
-
-#### Optimization suggestions
-
-Read the `FACTS` block the `done` script emitted and generate 2–4 concrete suggestions for reducing time-to-completion in future runs. Base these on the actual timing data — for example:
-
-- If **ci** dominates: suggest `--from ci-only` for re-runs, or note which CI sub-step was slowest
-- If **research** was slow: suggest pre-reading relevant code before invoking `/do`
-- If **test** had retries: note the flaky test and suggest hardening it
-- If **police** required fix iterations: note which pass caught issues (rules/fact-check/elegance)
-- If **implement** was the bottleneck: suggest breaking the task into smaller PRs
-
-Be specific to this run's data, not generic advice.
-
-#### PR comment & wrap-up
-
-**If `--no-git`**: There is no branch or PR to report against. Print the timing table and optimization suggestions to the terminal only. List the files modified in the working tree (`git status --porcelain`) so the user can see what the agent touched. Remind the user that changes are uncommitted — the commit/push/PR steps are theirs to run.
-
-**If `forge != github`**: Report the branch name (and remote URL, if available via `git remote get-url origin`) instead of a PR URL. Print the timing table and optimization suggestions to the terminal only — do **not** attempt to post a PR comment. (Bitbucket `bkt pr comment` wiring is tracked in #10.)
-
-**If `forge == github`**: Report the PR URL. Then post the final step status table as a **PR comment** using `gh pr comment`. Use the markdown table and slowest-step line emitted by `scripts/steps/done` verbatim (strip the trailing `<<<FACTS ... FACTS` block — that's internal). Format:
-
-```
-gh pr comment --body "$(cat <<'COMMENT'
-## [`/do`](https://github.com/srid/agency) results
-
-| Step | Status | Duration | Verification |
-|------|--------|----------|-------------|
-| sync | ✓ | 3s | ... |
-| research | ✓ | 45s | ... |
-...
-| **Total** | | **4m 32s** | |
-
-### Optimization suggestions
-
-- <2–4 concrete suggestions based on timing data>
-
-Workflow completed at <timestamp>.
-COMMENT
-)"
-```
-
----
-
-## Entry Points
-
-| ID               | Starts at             | Use case                                |
-| ---------------- | --------------------- | --------------------------------------- |
-| `default`        | **sync**              | Full workflow from scratch              |
-| `followup`       | **implement**         | Additional changes on existing PR       |
-| `post-implement` | **fmt**               | Skip research/impl, start at formatting |
-| `polish`         | **hickey+lowy**       | Structural review + quality gate        |
-| `ci-only`        | **ci**                | Just run CI                             |
-
-## Rules
-
-- **Never skip steps** (unless skipped by `--no-git`, forge detection, or — for **evidence** — the project hasn't filled in a `## PR evidence` section in `.agency/do.md`). Run them in order from entry point to **done**.
+- **Never skip nodes** unless skipped by `--no-git`, forge detection, `--minimal`, or — for **evidence** — the project hasn't filled in a `## PR evidence` section in `.agency/do.md`. Run them in order from entry point to **done**.
 - **Every commit is NEW.** Never amend, rebase, or force-push.
-- **Feature branches only.** Never commit to master/main. (Under `--no-git`, no commits happen at all, so this rule is moot — the agent leaves the user on whatever branch they started on.)
+- **Feature branches only.** Never commit to master/main. (Under `--no-git`, no commits happen at all, so this is moot.)
 - **Background for CI.** Run CI with `run_in_background: true`.
-- **No questions.** Don't use `AskUserQuestion` outside the `--review` plan pause (post-research).
-- **Never stop between steps.** After completing a step, immediately proceed to the next one.
-- **Complete the full workflow.** Implementing code is one step of many. The task is not done until a PR URL (GitHub), a pushed branch name (non-GitHub forges), or a working-tree summary (`--no-git`) is reported.
-- **Exhausted retries = halt.** If `ci` or `test` retries are exhausted, set status to `"failed"` and skip to **done**. On `ci` failure the draft PR (opened in the preceding **create-pr** step) stays open as the record of the failed attempt — do not close, undraft, or otherwise mutate it.
+- **No questions.** Don't use `AskUserQuestion` outside the `--review` plan pause.
+- **Never stop between nodes.** After completing a node, immediately proceed to the next one.
+- **Complete the full workflow.** Implementing code is one node of many. The task is not done until a PR URL (GitHub), a pushed branch name (non-GitHub), or a working-tree summary (`--no-git`) is reported.
+- **Exhausted retries = halt.** If `ci` or `test` retries are exhausted, set status to `"failed"` and skip to **done**. On `ci` failure the draft PR (opened in the preceding **create-pr** node) stays open as the record of the failed attempt — do not close, undraft, or otherwise mutate it.
+- **No Defer disposition.** The hickey-lowy node and the `fanout-fix` pattern's disposition audit flip any deferred-work-for-later finding to "Fix in this PR". The only way out of a finding is through it.
+
+## Provenance
+
+The section vocabulary (`### Requires`, `### Ensures`, `### Strategies`, `### Errors`, `### Pattern`) and the pattern-as-reusable-shape concept are lifted from [OpenProse](https://github.com/openprose/prose) — specifically from `skills/open-prose/contract-markdown.md` and the bundled `worker-critic` pattern. The bindings/scratch boundary in [`workspace.md`](workspace.md) mirrors OpenProse's workspace/bindings split. We do **not** depend on the OpenProse runtime, harness adapter, or `*.prose.md` file convention; this skill is self-contained markdown that the agent reads directly. See PR #99's discussion thread for the design rationale and how this differs from PR #99's bespoke `next:`/`depends_on:`/`output_schema:` frontmatter.
 
 ARGUMENTS: $ARGUMENTS

--- a/.apm/skills/do/execution.md
+++ b/.apm/skills/do/execution.md
@@ -1,0 +1,108 @@
+# Execution
+
+The pinned order /do walks. Each step name refers to a node file (e.g. `sync` → `nodes/sync.md`). Conditional skips are baked into each node's `### Strategies`; this file shows the order, the high-level branches, and which patterns each node instances.
+
+This file is the **system-level Execution block** — the pinned choreography. Borrowed conceptually from OpenProse's `### Execution` ProseScript syntax, but written as readable pseudocode. The agent walks the order; nodes describe the work; patterns describe shared shapes.
+
+## Order
+
+```prose
+# Coordination + research
+call sync
+  noGit: noGit                         # caller flag
+
+call research
+  task: task
+  forge: sync.forge
+
+if review:
+  call plan-approval
+    plan: research.plan
+
+# Local in-place work
+if not noGit:
+  call branch
+    default_branch: sync.default_branch
+
+call implement
+  plan: research.plan
+
+# Cheapest verification gate first
+call check                             # pattern: check-loop, max_attempts: 3
+if not minimal:
+  call docs                            # pattern: check-loop, max_attempts: 3
+
+call fmt                               # one-shot, no retry pattern
+
+if not noGit:
+  call commit                          # one-shot
+
+# Structural review fanout (post-implement, on a concrete diff)
+if not minimal:
+  call hickey-lowy                     # pattern: fanout-fix, reviewers: [hickey, lowy]
+  call police                          # pattern: check-loop, loop_artifacts: commit-per-fix
+
+call test                              # pattern: check-loop, coverage_check: true
+
+# Forge integration
+call create-pr                         # one-shot; skipped under --no-git or non-github
+
+call ci                                # pattern: check-loop, flaky_classification: true
+                                       # max_attempts: 5 real, flaky_budget: 3
+                                       # rerun_on_new_commit: true
+
+call evidence                          # opt-in; skipped unless .agency/do.md declares it
+
+call done                              # one-shot; emits timing table + status
+```
+
+## Why this order
+
+Read each node for its full rationale. The high-level reasoning:
+
+- **Cheap gates first** (check before docs before fmt) — fail fast on broken code before any downstream node does work over it. `check` is typically `tsc --noEmit` or `cargo check` or `cabal build`, which is the cheapest verification in the pipeline.
+- **commit before hickey-lowy** — reviewers operate on a real diff (`git diff origin/HEAD...HEAD`), not a plan. Reviewing a plan tends to surface generic concerns; reviewing a real diff surfaces the specific interleavings and boundary misalignments that matter.
+- **fmt before commit** — the primary feature commit should land already-formatted; downstream `hickey-lowy` and `police` commits each run `fmt` on their own changes inside the `commit-per-fix` loop.
+- **create-pr before ci** — the draft PR is the canonical home for CI status. Opening it before CI runs means CI checks land directly on the PR, reviewers see the run history as it happens, and a failing CI doesn't leave an orphaned branch with red statuses and no PR to explain them.
+- **evidence after ci passes** — capturing screenshots/benchmarks/transcripts of broken code wastes both the capture work and the reviewer's time.
+- **done last, always** — the timing table needs every node's bookend already recorded.
+
+## Patterns referenced
+
+| Node | Pattern | Why |
+|------|---------|-----|
+| check | check-loop | Run a verification command; on failure, fix the just-written code and retry. |
+| docs | check-loop | Verify docs match code; on staleness, update and re-verify. |
+| police | check-loop (`loop_artifacts: commit-per-fix`) | `/code-police` reports violations; each fix is its own commit. |
+| test | check-loop (`coverage_check: true`, `loop_artifacts: commit-per-fix`) | Run tests; on real failure, fix + commit + retry. Coverage check verifies the new behavior is actually exercised. |
+| ci | check-loop (`flaky_classification: true`, `flaky_budget: 3`, `loop_artifacts: commit-per-fix`, `rerun_on_new_commit: true`) | CI flakes are expected; real failures get fix + commit + retry. CI on a stale SHA does not satisfy verification. |
+| hickey-lowy | fanout-fix | Two reviewers in parallel; one commit per finding. |
+
+The other nodes (sync, research, plan-approval, branch, implement, fmt, commit, create-pr, evidence, done) are one-shot — they do specific work, verify, and move on. They don't instance a pattern.
+
+## Entry points
+
+`--from <id>` shifts the start position. Earlier nodes are still seeded in TaskCreate and immediately marked `completed` so the checklist is consistent.
+
+| ID | Starts at | Use case |
+|----|-----------|----------|
+| `default` | sync | Full workflow from scratch |
+| `followup` | implement | Additional changes on an existing PR |
+| `post-implement` | fmt | Skip research/impl, start at formatting |
+| `polish` | hickey-lowy | Structural review + quality gate |
+| `ci-only` | ci | Just run CI |
+
+When entering at `polish` or `ci-only`, the workflow assumes the PR already exists; `create-pr` re-checks via `gh pr view` and only edits title/body if scope changed.
+
+## Skip taxonomy
+
+A node is `skipped` for one of four reasons. Each reason carries through to `done`'s "completed" predicate (see `nodes/done.md`):
+
+| Reason | Triggered by | Counts toward "completed" |
+|--------|--------------|---------------------------|
+| `--minimal` | caller flag | yes |
+| `--no-git` | caller flag, on git-mutating nodes | yes |
+| `non-<forge> forge: <forge>` | sync's forge detection, on PR/CI nodes | yes |
+| `no <command> configured` | nodes that read `.agency/do.md` (check, docs, fmt, test, ci, evidence) | yes |
+
+Any other skip reason is suspect. A `failed` node always blocks `completed`.

--- a/.apm/skills/do/nodes/branch.md
+++ b/.apm/skills/do/nodes/branch.md
@@ -1,0 +1,37 @@
+---
+name: branch
+kind: node
+---
+
+# branch
+
+Create a descriptive feature branch from `origin/<default>`.
+
+## Requires
+
+- `noGit` — caller flag
+- `default_branch` — from sync
+
+## Ensures
+
+- `branch` — overwrites the binding sync set; downstream nodes read the new feature-branch name
+
+## Strategies
+
+- **If `noGit`**: skip entirely with `status="skipped"` and `reason="--no-git"`. Stay on the current branch — do not create, commit, or push anything. Move to **implement**.
+- Otherwise: detect the default branch with `git symbolic-ref refs/remotes/origin/HEAD` and create a descriptive feature branch from `origin/<default>`.
+- That's it — just the local branch. No commit, no push, no PR. The branch is pushed later in **commit**, and the PR is created in **create-pr** after all changes are done.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start branch
+# under noGit, immediately:
+.../skills/do/scripts/do-results step-end skipped "stayed on current branch" "--no-git"
+# otherwise, after creating:
+.../skills/do/scripts/do-results step-end passed "on feature branch <name>"
+```
+
+## Verify
+
+On a feature branch (not master/main). Under `--no-git`, on whatever branch the user started on (verify via `git symbolic-ref --short HEAD` ≠ `default_branch`, **only** when not skipped).

--- a/.apm/skills/do/nodes/check.md
+++ b/.apm/skills/do/nodes/check.md
@@ -1,0 +1,54 @@
+---
+name: check
+kind: node
+pattern: check-loop
+---
+
+# check
+
+Cheapest static-correctness gate in the pipeline (typeck/buildcheck). Runs first so broken code fails fast before any downstream node does work over it.
+
+## Requires
+
+- `noGit` — caller flag (does not skip this node; only affects whether fixes commit)
+
+## Ensures
+
+- `verdict` — `pass` | `failed-after-budget` | `no-command-configured`
+
+## Pattern
+
+Instances [`check-loop`](../patterns/check-loop.md) with:
+
+```yaml
+slots:
+  runner: run-check-command       # reads .agency/do.md ## Check command, runs it, classifies exit code
+  fixer: fix-check-errors          # re-reads just-changed files, applies minimal fix
+config:
+  max_attempts: 3
+  flaky_classification: false      # check failures are not flaky; they're real
+  loop_artifacts: none             # fixes stay in the working tree (commit happens later in commit node)
+```
+
+## Strategies
+
+- Read `.agency/do.md` and look for a `## Check command` section — a fast static-correctness gate (e.g. `tsc --noEmit`, `cargo check`, `cabal build`, `mypy`, `dune build @check`). Run it.
+- If no check command is documented, the runner returns `no-command-configured`; record this node as `skipped` with reason `"no check command configured"`.
+- This is the cheapest gate in the pipeline, so it runs first.
+- On failure: fix the errors and re-run check. Do not fall back to **implement** — the agent is already in fix mode and the failure is local to just-written code.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start check
+# ... pattern delegation ...
+.../skills/do/scripts/do-results step-end {passed|skipped|failed} "<verification>" ["<reason>"]
+```
+
+## Verify
+
+Check command ran without errors, or no command configured. Specifically: pattern returned `verdict == pass` or `verdict == no-command-configured`.
+
+## Errors
+
+- `failed-after-budget` (3 attempts) — halt workflow with `do-results set status failed`. The just-written code does not pass static correctness; downstream gates would all be operating on broken code.

--- a/.apm/skills/do/nodes/ci.md
+++ b/.apm/skills/do/nodes/ci.md
@@ -1,0 +1,73 @@
+---
+name: ci
+kind: node
+pattern: check-loop
+---
+
+# ci
+
+Run CI and verify it passes against current HEAD.
+
+## Requires
+
+- `noGit` — caller flag (CI runs locally regardless of forge, but verification method may differ)
+- `forge` — from sync
+- `pr_url` — from create-pr (used for `gh pr checks` verification on github)
+
+## Ensures
+
+- `verdict` — `pass` | `failed-after-budget` | `no-command-configured`
+- `ci_run_sha` — git sha CI ran against (must equal current `HEAD` when `verdict == pass`)
+- (side effect, unless `noGit`) one commit per real-failure fix, pushed
+
+## Pattern
+
+Instances [`check-loop`](../patterns/check-loop.md) with:
+
+```yaml
+slots:
+  runner: ci-command                # reads .agency/do.md ## CI command, runs in background, classifies via verification method
+  fixer: fix-ci-failure-and-commit
+config:
+  max_attempts: 5                   # real failures
+  flaky_classification: true
+  flaky_budget: 3                   # CI is allowed to flake more than test
+  loop_artifacts: commit-per-fix
+  rerun_on_new_commit: true         # CI on stale SHA does not satisfy verification
+```
+
+## Strategies
+
+- Read `.agency/do.md` and look for a `## CI command` section, plus any verification method documented there. Run CI with `run_in_background: true` if the command takes more than a few seconds.
+- **Never pipe CI to `tail`/`head`**, and **never append `2>&1`** — background mode captures both streams.
+- **Active state**: Before waiting for background CI, run `scripts/do-results set active waiting`. When CI returns (success or failure), run `scripts/do-results set active working` before proceeding. This lets the stop hook allow graceful exits while the agent is idle.
+- CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are **forge-independent** — run them regardless of forge. Only the *verification method* may be forge-specific: if `.agency/do.md` describes verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output for verification on non-GitHub forges, and note this in the step record. (Bitbucket `bkt pr checks` wiring is tracked in [srid/agency#10](https://github.com/srid/agency/issues/10).)
+- **The CI result must cover `HEAD`** (the `rerun_on_new_commit: true` config). Before recording the step as passed, the runner compares the commit SHA that CI ran against with `git rev-parse HEAD`. If they differ (e.g., a commit was pushed after CI started — whether from a fix retry, user-requested changes, or any other source), the runner re-runs CI against the current HEAD. CI passing on a stale commit does not satisfy verification.
+
+### Failure classification
+
+Read logs or output to diagnose.
+
+**Flaky vs real**: A test is flaky only if it **passes on a subsequent retry**. Consistent failure = real bug. Before retrying, read the failing test code to judge if the failure pattern is inherently flaky (race conditions, timing, async waits).
+
+- **If flaky** (max 3 retries, the `flaky_budget`): retry just the failing step, no fix.
+- **If real bug** (max 5 fixes, the `max_attempts`): fix → fmt → commit → retry CI. Under `noGit`, the `commit-per-fix` arm of the pattern skips the commit/push (per the pattern's `noGit` handling), so the loop becomes fix → fmt → retry CI. The draft PR already exists — subsequent pushes update it automatically, no re-run of **create-pr** needed.
+- **If retries exhausted**: pattern returns `failed-after-budget`. Set workflow status to `"failed"`, skip to **done**. The draft PR stays open as the record of the failed attempt.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start ci
+.../skills/do/scripts/do-results set active waiting    # before background wait
+# ... CI runs ...
+.../skills/do/scripts/do-results set active working    # after CI returns
+.../skills/do/scripts/do-results step-end {passed|skipped|failed} "<verification>" ["<reason>"]
+```
+
+## Verify
+
+Use the verification method described in `.agency/do.md` (e.g., checking commit statuses on GitHub, reading CI output elsewhere). If no CI command is documented, skip with `status="skipped"` and `reason="no CI command configured"`. The CI result must cover current `HEAD` — see Strategies above.
+
+## Errors
+
+- `failed-after-budget` (5 real fix attempts or 3 flaky retries) — halt workflow with `do-results set status failed`. The draft PR stays open; the user resumes via `--from ci-only`.

--- a/.apm/skills/do/nodes/commit.md
+++ b/.apm/skills/do/nodes/commit.md
@@ -1,0 +1,43 @@
+---
+name: commit
+kind: node
+---
+
+# commit
+
+Create the primary feature commit and push the branch. One-shot.
+
+## Requires
+
+- `noGit` — caller flag
+- `branch` — from sync (current) or branch (new feature branch)
+
+## Ensures
+
+- `primary_commit_sha` — git sha of the new commit (absent under `noGit`)
+- (side effect) feature branch pushed to remote with `git push -u origin <branch>`
+
+## Strategies
+
+- **If `noGit`**: skip with `status="skipped"` and `reason="--no-git"`. Move to **hickey-lowy**. The working-tree changes stay uncommitted — that is the point.
+- Otherwise: create a NEW commit (never amend) with a conventional commit message for the primary implementation. Push to the feature branch with `git push -u origin <branch>` (the `-u` sets upstream on first push).
+- This is the **primary feature commit**. Downstream **hickey-lowy** and **police** nodes produce their own follow-up commits — one per finding or violation addressed — which keeps the PR history a readable progression of "what was built, then what was refined" rather than a single opaque squash.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start commit
+# under noGit, immediately:
+.../skills/do/scripts/do-results step-end skipped "no commit; working tree unchanged" "--no-git"
+# otherwise, after committing + pushing:
+.../skills/do/scripts/do-results step-end passed "primary commit <sha> pushed to origin/<branch>"
+```
+
+## Verify
+
+- Under `noGit`: skipped, no git operations performed.
+- Otherwise: `git log -1` shows a new commit on the feature branch, and it's pushed to remote (verify via `git rev-parse origin/<branch>` matching local HEAD).
+
+## Errors
+
+- `push_failed` — halt workflow. The branch is local-only and the rest of the workflow assumes it's pushed.

--- a/.apm/skills/do/nodes/create-pr.md
+++ b/.apm/skills/do/nodes/create-pr.md
@@ -1,0 +1,81 @@
+---
+name: create-pr
+kind: node
+---
+
+# create-pr
+
+Open the draft PR and post the hickey/lowy analysis comment. Forge-aware. One-shot (idempotent on followup runs).
+
+## Requires
+
+- `noGit` — caller flag
+- `forge` — from sync
+- `branch` — from sync (current) or branch (new feature branch)
+- `review_findings` — from hickey-lowy (may be empty)
+- `task`, `research.plan` — for PR body composition
+
+## Ensures
+
+- `pr_url` — string; absent under `noGit` or non-github forge
+- (side effect) draft PR created (or re-checked if already exists)
+- (side effect) hickey/lowy analysis posted as a PR comment
+
+## Strategies
+
+- **If `noGit`**: skip with `status="skipped"` and `reason="--no-git"`. There is no PR to create. Proceed to **ci**.
+- **If `forge != github`**: skip with `status="skipped"` and `reason="non-<forge> forge: <forge>"`. (Bitbucket `bkt pr edit` wiring is tracked in [srid/agency#10](https://github.com/srid/agency/issues/10).) Proceed to **ci**.
+- **If `forge == github`**:
+
+### First run (no PR exists)
+
+Check whether a PR already exists for this branch (`gh pr view`). If not:
+
+1. Create a draft PR: `gh pr create --draft`. **MANDATORY**: Load the `forge-pr` skill (via Skill tool) BEFORE writing the PR title/body.
+
+2. **Post hickey/lowy results**: Post the `review_findings` as a PR comment using `gh pr comment` with a `## [Hickey/Lowy](https://kolu.dev/blog/hickey-lowy/) Analysis` header (the heading links to the blog post explaining the two lenses, mirroring how the final step status comment links `/do` to the agency repo). Always post when the hickey-lowy node ran — reviewers should see the structural analysis even if every finding was a No-op.
+
+   **Format the comment with a leading findings ledger.** Compose a single table from both sub-agents' Actions sections — one row per finding — so a reviewer can see disposition at a glance without parsing paragraphs. Put each lens's prose underneath as rationale:
+
+   ```md
+   ## [Hickey/Lowy](https://kolu.dev/blog/hickey-lowy/) Analysis
+
+   | # | Lens   | Finding                                  | Disposition       |
+   |---|--------|------------------------------------------|-------------------|
+   | 1 | Hickey | viewportDimensions complects two roles   | Fixed in this PR  |
+   | 2 | Lowy   | useViewport encapsulates ghost concern   | Fixed in this PR  |
+
+   ### Hickey rationale
+   <prose from the hickey sub-agent>
+
+   ### Lowy rationale
+   <prose from the lowy sub-agent>
+   ```
+
+   The Disposition cell mirrors the sub-agent's Actions disposition verbatim — **Fixed in this PR** or **No-op** (deletion-only / subsumed by another finding). There is no Deferred disposition; if a sub-agent emitted one, the disposition audit (in the `fanout-fix` pattern) flipped it to Fixed in this PR. The Finding cell is the short bolded label the sub-agent emits at the start of each Actions entry. If both lenses produced zero findings, write a one-line "No findings — analysis below" instead of an empty table.
+
+### Followup runs (PR already exists, `--from` entry points)
+
+Re-check the PR title/body against current scope. If scope changed, update via `gh pr edit` per the `forge-pr` skill. Don't re-post the hickey/lowy comment — the existing one stays as the record of the original review pass; followup runs that re-execute hickey-lowy will post a new analysis comment as part of that node, not here.
+
+## Why this runs before `ci`
+
+The draft PR is the canonical home for CI status. Opening it before CI runs means CI checks land directly on the PR, reviewers see the run history as it happens, and a failing run doesn't leave an orphaned branch with red statuses and no PR to explain them. If retries exhaust in **ci**, the draft PR remains as the artifact of the failed attempt — visible, reviewable, and ready to resume via `--from ci-only`.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start create-pr
+# under --no-git or non-github, immediately:
+.../skills/do/scripts/do-results step-end skipped "<reason>" "<reason-tag>"
+# otherwise, after creating + posting:
+.../skills/do/scripts/do-results step-end passed "draft PR <url> created; hickey/lowy comment posted"
+```
+
+## Verify
+
+Draft PR exists (`gh pr view` succeeds), PR title/body matches the delivered scope, hickey/lowy findings posted if any.
+
+## Errors
+
+- `pr_create_failed` — halt workflow. Cannot proceed to `ci` without a PR target for status checks.

--- a/.apm/skills/do/nodes/docs.md
+++ b/.apm/skills/do/nodes/docs.md
@@ -1,0 +1,54 @@
+---
+name: docs
+kind: node
+pattern: check-loop
+---
+
+# docs
+
+Keep declared documentation in sync with code changes.
+
+## Requires
+
+- `minimal` — caller flag
+
+## Ensures
+
+- `verdict` — `pass` | `failed-after-budget` | `no-command-configured`
+- (side effect) docs files updated if they were stale
+
+## Pattern
+
+Instances [`check-loop`](../patterns/check-loop.md) with:
+
+```yaml
+slots:
+  runner: docs-staleness            # reads .agency/do.md ## Documentation, compares listed files vs current diff
+  fixer: docs-update                 # updates the stale section(s)
+config:
+  max_attempts: 3
+  flaky_classification: false
+  loop_artifacts: none               # docs fixes go to the working tree; they're commited later (or in a follow-up commit during hickey-lowy/police if a finding requires it)
+```
+
+## Strategies
+
+- **If `minimal`**: skip with `status="skipped"` and `reason="--minimal"`. Move to **fmt**.
+- Read `.agency/do.md` and look for a `## Documentation` section listing which docs to keep in sync (e.g., `README.md`, `website/src/pages/index.astro`). Compare those files against changes in this PR.
+- If no documentation files are documented, the runner returns `no-command-configured`; record as `skipped` with reason `"no documentation declared in .agency/do.md"`.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start docs
+# ... pattern delegation, or immediate skip under --minimal ...
+.../skills/do/scripts/do-results step-end {passed|skipped|failed} "<verification>" ["<reason>"]
+```
+
+## Verify
+
+Docs match current code, or no docs declared, or `--minimal` skip.
+
+## Errors
+
+- `failed-after-budget` (3 attempts) — halt workflow. The fixer couldn't bring docs into sync within the budget; this is unusual and warrants stopping.

--- a/.apm/skills/do/nodes/done.md
+++ b/.apm/skills/do/nodes/done.md
@@ -1,0 +1,102 @@
+---
+name: done
+kind: node
+---
+
+# done
+
+Emit the timing summary, optimization suggestions, and the final status comment.
+
+## Requires
+
+- `noGit` — caller flag
+- `forge` — from sync
+- `pr_url` — from create-pr (absent under `noGit` or non-github)
+- All preceding nodes' receipts via `.do-results.json` (read by the script)
+
+## Ensures
+
+- `timing_table` — markdown table of all nodes (step, status, duration, verification)
+- (side effect) workflow `status` set to `completed` or `failed`
+- (side effect) workflow `active` set to `false`
+- (side effect, when github + not noGit) final status comment posted to the PR
+
+## Strategies
+
+Present a summary of all nodes with their verification status. If any node has a non-success status, retry it (max 3 attempts from done). If still failing after retries, set `status: "failed"`.
+
+`"completed"` requires **all nodes `passed`**, with four exceptions that count toward completion (the [skip taxonomy in execution.md](../execution.md#skip-taxonomy)):
+
+1. A node `skipped` with `reason` beginning `"non-<forge> forge:"` (detected forge isn't GitHub).
+2. A node `skipped` with `reason` `"--no-git"` (user opted out of git operations).
+3. A node `skipped` with `reason` `"no PR evidence section in .agency/do.md"` (project hasn't opted into the evidence step — this is the default).
+4. A node `skipped` with `reason` `"--minimal"` (user opted out of structural review / docs / quality gate / evidence on a trivial diff).
+
+A `failed` node always blocks `"completed"`. No redefining "passed," no footnote caveats. Update via `scripts/do-results set status completed` or `scripts/do-results set status failed` accordingly.
+
+### Timing summary
+
+Run `scripts/steps/done` in this skill's directory. It emits:
+
+1. A markdown timing table (step, status, duration, verification), with any step that took ≥30% of total time shown in **bold**.
+2. A total wall-clock line (`startedAt` of first step → `completedAt` of last step).
+3. A `**Slowest step**:` line.
+4. A `<<<FACTS ... FACTS` block with machine-readable summary data (`totalSeconds`, `slowestStep`, `slowestSeconds`, `dominantSteps`, `skippedSteps`, `failedSteps`) — use this to compose optimization suggestions below.
+
+Do not compute durations yourself — the script handles all timestamp arithmetic.
+
+### Optimization suggestions
+
+Read the `FACTS` block the `done` script emitted and generate 2–4 concrete suggestions for reducing time-to-completion in future runs. Base these on the actual timing data — for example:
+
+- If **ci** dominates: suggest `--from ci-only` for re-runs, or note which CI sub-step was slowest.
+- If **research** was slow: suggest pre-reading relevant code before invoking `/do`.
+- If **test** had retries: note the flaky test and suggest hardening it.
+- If **police** required fix iterations: note which pass caught issues (rules/fact-check/elegance).
+- If **implement** was the bottleneck: suggest breaking the task into smaller PRs.
+
+Be specific to this run's data, not generic advice.
+
+### PR comment & wrap-up
+
+- **If `noGit`**: There is no branch or PR to report against. Print the timing table and optimization suggestions to the terminal only. List the files modified in the working tree (`git status --porcelain`) so the user can see what the agent touched. Remind the user that changes are uncommitted — the commit/push/PR steps are theirs to run.
+- **If `forge != github`**: Report the branch name (and remote URL, if available via `git remote get-url origin`) instead of a PR URL. Print the timing table and optimization suggestions to the terminal only — do **not** attempt to post a PR comment. (Bitbucket `bkt pr comment` wiring is tracked in [srid/agency#10](https://github.com/srid/agency/issues/10).)
+- **If `forge == github`**: Report the PR URL. Then post the final step status table as a **PR comment** using `gh pr comment`. Use the markdown table and slowest-step line emitted by `scripts/steps/done` verbatim (strip the trailing `<<<FACTS ... FACTS` block — that's internal). Format:
+
+```sh
+gh pr comment --body "$(cat <<'COMMENT'
+## [\`/do\`](https://github.com/srid/agency) results
+
+| Step | Status | Duration | Verification |
+|------|--------|----------|-------------|
+| sync | ✓ | 3s | ... |
+| research | ✓ | 45s | ... |
+...
+| **Total** | | **4m 32s** | |
+
+### Optimization suggestions
+
+- <2–4 concrete suggestions based on timing data>
+
+Workflow completed at <timestamp>.
+COMMENT
+)"
+```
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start done
+# ... emit summary, post comment ...
+.../skills/do/scripts/do-results set active false
+.../skills/do/scripts/do-results set status {completed|failed}
+.../skills/do/scripts/do-results step-end passed "summary emitted; status comment posted"
+```
+
+Note: `done` itself always records `step-end passed` for itself — even if the workflow status is `failed`, the done node successfully did its job (emitting the failure summary).
+
+## Verify
+
+- Timing table printed (or posted to PR on github + not noGit).
+- Workflow `status` set to `completed` or `failed` per the predicate above.
+- Workflow `active` set to `false` (the stop hook checks this to allow graceful exit).

--- a/.apm/skills/do/nodes/evidence.md
+++ b/.apm/skills/do/nodes/evidence.md
@@ -1,0 +1,67 @@
+---
+name: evidence
+kind: node
+---
+
+# evidence
+
+Opt-in: capture and post empirical evidence (screenshots, benchmarks, transcripts) to the PR. Most projects skip this.
+
+## Requires
+
+- `noGit` — caller flag
+- `minimal` — caller flag
+- `forge` — from sync
+- `pr_url` — from create-pr (skipped if absent)
+
+## Ensures
+
+- (side effect, when applicable) `## Evidence` PR comment posted with markdown returned by the capture sub-agent
+
+## Strategies
+
+- **If `minimal`**: skip with `status="skipped"` and `reason="--minimal"`. Move to **done**.
+- **If `noGit`**: skip with `status="skipped"` and `reason="--no-git"`. There is no PR to attach evidence to.
+- **If `forge != github`**: skip with `status="skipped"` and `reason="non-<forge> forge: <forge>"`. (Bitbucket comment wiring is tracked in [srid/agency#10](https://github.com/srid/agency/issues/10).)
+- **Otherwise**: read `.agency/do.md` and look for a `## PR evidence` section. If `.agency/do.md` is missing, or the section is missing or empty, skip with `status="skipped"` and `reason="no PR evidence section in .agency/do.md"` — the default for projects that haven't opted in.
+
+### When the section is present
+
+The section is project-specific and free-form: it can be inline prose describing the capture procedure, a pointer to another file (`See ./scripts/capture-evidence.md`), a script reference (`Run ./scripts/capture-pr-evidence.sh and use its stdout`), or any combination. Don't second-guess the form — read it, then **spawn a sub-agent** (`Agent(subagent_type: "general-purpose", ...)`) so the capture work (MCP calls, screenshot uploads, gh API requests) doesn't pollute /do's main context.
+
+The sub-agent prompt should include:
+
+- The literal section content from `.agency/do.md`.
+- Standard PR context: `pr_url`, `branch`, `default_branch`, `git rev-parse HEAD`, and `git diff origin/<default_branch>...HEAD --name-only` so the sub-agent knows which routes/files to exercise.
+- An explicit instruction that the sub-agent's job is to return a single block of markdown (image links embedded, table data inline, etc.) suitable for posting under a `## Evidence` heading. The sub-agent should not post the comment itself — only return the markdown.
+
+After the sub-agent returns, post its output as one PR comment using `gh pr comment` under a `## Evidence` heading. Use the **single-quoted heredoc** pattern (see `forge-pr` → "Passing the body to `gh` safely") so backticks and `$` survive unescaped:
+
+```sh
+gh pr comment --body "$(cat <<'EOF'
+## Evidence
+
+<markdown returned by the sub-agent>
+EOF
+)"
+```
+
+Embed image/asset URLs inline in the markdown — `gh pr comment` itself cannot attach files; the workflow section is responsible for telling the sub-agent how to host any binary artifacts so they end up referenceable.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start evidence
+# under any skip condition, immediately:
+.../skills/do/scripts/do-results step-end skipped "<reason>" "<reason-tag>"
+# otherwise, after sub-agent returns + comment posted:
+.../skills/do/scripts/do-results step-end passed "evidence comment posted to PR"
+```
+
+## Verify
+
+Either the node was skipped per the rules above, or a `## Evidence` PR comment exists (`gh pr view --comments` or equivalent) populated from the sub-agent's output.
+
+## Errors
+
+- `subagent_failed` — the capture sub-agent could not produce evidence. Halt workflow only if the project explicitly opted in to evidence (the section was present and non-empty); otherwise treat as `failed` to surface the issue.

--- a/.apm/skills/do/nodes/fmt.md
+++ b/.apm/skills/do/nodes/fmt.md
@@ -1,0 +1,39 @@
+---
+name: fmt
+kind: node
+---
+
+# fmt
+
+Run the project's format command on changed files. One-shot — no retry pattern.
+
+## Requires
+
+- (none)
+
+## Ensures
+
+- (side effect) changed files are formatted per project conventions
+
+## Strategies
+
+- Read `.agency/do.md` and look for a `## Format command` section. Run it.
+- If no format command is documented, skip with `status="skipped"` and `reason="no format command configured"`.
+- One-shot. If the format command fails, that's a real failure (the project's formatter is broken or the code is malformed in a way the formatter can't handle); halt and surface the failure rather than retry.
+- This node is also called **inside** the `commit-per-fix` arm of `check-loop` (used by police, test, ci) and `fanout-fix` (used by hickey-lowy) — those callers invoke fmt against just the files they changed. Same command, narrower scope.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start fmt
+# ... run the command, or immediate skip ...
+.../skills/do/scripts/do-results step-end {passed|skipped|failed} "<verification>" ["<reason>"]
+```
+
+## Verify
+
+Format command ran without error, or no command configured.
+
+## Errors
+
+- `format_failed` — halt workflow with `do-results set status failed`. The formatter failed; the code is not in a shippable state.

--- a/.apm/skills/do/nodes/hickey-lowy.md
+++ b/.apm/skills/do/nodes/hickey-lowy.md
@@ -1,0 +1,77 @@
+---
+name: hickey-lowy
+kind: node
+pattern: fanout-fix
+---
+
+# hickey-lowy
+
+Structural review: hickey (complecting critique) and lowy (volatility lens), in parallel, on the concrete diff. Each finding lands as its own commit.
+
+## Requires
+
+- `noGit` — caller flag
+- `minimal` — caller flag
+- `forge` — from sync (controls whether the analysis comment is posted to a PR)
+- `default_branch` — from sync (used to scope the diff)
+- `task` — caller arg (passed as `task_context` to sub-agents)
+- `research.plan` — from research (passed as `task_context` to sub-agents)
+
+## Ensures
+
+- `review_findings` — flat findings table (lens, label, rationale, disposition); may be empty
+- (side effect, unless `noGit`) one commit per Fix-in-this-PR finding, all pushed
+- (side effect, deferred to create-pr) findings table posted as a PR comment under `## [Hickey/Lowy](https://kolu.dev/blog/hickey-lowy/) Analysis`
+
+## Pattern
+
+Instances [`fanout-fix`](../patterns/fanout-fix.md) with:
+
+```yaml
+slots:
+  reviewers: [hickey, lowy]
+  applier: apply-review-finding    # one commit per finding
+config:
+  disposition_audit: ["Defer", "out of scope", "follow-up", "pre-existing", "should be its own change"]
+  commit_prefix_per_lens:
+    hickey: "refactor(hickey)"
+    lowy: "refactor(lowy)"
+  comment_under_heading: "## [Hickey/Lowy](https://kolu.dev/blog/hickey-lowy/) Analysis"
+  noGit: noGit
+```
+
+## Strategies
+
+- **If `minimal`**: skip with `status="skipped"` and `reason="--minimal"`. Move to **police** (which also skips under `--minimal`). Do not spawn either sub-agent.
+- Invoke `hickey` and `lowy` as two **parallel sub-agents** via the harness's agent tool (`subagent_type: "hickey"` and `subagent_type: "lowy"`). On Claude Code this is the `Agent` tool. On opencode this is the `task` tool (with `subagent_type` parameter). On Codex this is the sub-agent spawning tool for delegated work. Invoking `/do` is explicit authorization to run these two review agents; do not wait for a second user prompt before spawning them.
+- **Fallback, never skip.** If the harness cannot honor the model declared in the reviewer skill's frontmatter, run hickey and lowy as sub-agents on the available model instead. If a sub-agent invocation fails for harness/tooling reasons before producing a review, retry that reviewer once; if it still cannot produce a sub-agent review, run that review in the main model by loading the reviewer skill against the same diff. This fallback is slower and uses more main-context budget, but it is still the hickey-lowy step. Do not replace it with an informal/manual review, and do not mark the node `skipped` because a preferred model was unavailable.
+- **Why post-implement, not pre-implement.** Hickey's complecting critique and Lowy's volatility lens both bite harder on a concrete diff than on a plan sketch. Reviewing a plan tends to surface generic concerns; reviewing a real diff surfaces the specific interleavings and boundary misalignments that matter. Running here also means the review covers *everything* the diff contains — including whatever the plan glossed over and whatever drifted during implementation.
+- **Sub-agent prompts must be self-contained.** Sub-agents do not inherit context. Brief each one with: the full task prompt + relevant `research.plan` content (file paths, intended approach, key constraints) + the diff scope (`git diff origin/<default_branch>...HEAD` — same scope regardless of entry point, since the branch at this point holds the primary feature commit and no further work is pending). The sub-agent already knows to read its skill file; don't re-state the methodology.
+- **No deferrals.** See [Invariants](../SKILL.md#invariants-workflow-wide) and the `disposition_audit` config above. The pattern flips any deferred-work-for-later finding to "Fix in this PR" before applying.
+- **Apply each Fix finding as its own commit** — see the pattern's `commits_added` invariant.
+
+<use_parallel_tool_calls>
+For maximum efficiency, invoke the `hickey` and `lowy` Agent tools **in parallel** rather than sequentially. You MUST use parallel tool calls: emit both `Agent` tool_use blocks (one with `subagent_type: "hickey"`, one with `subagent_type: "lowy"`) in a single response, with no other tool calls or text in that response.
+</use_parallel_tool_calls>
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start hickey-lowy
+# under --minimal, immediately:
+.../skills/do/scripts/do-results step-end skipped "structural review skipped on trivial diff" "--minimal"
+# otherwise, after pattern delegation:
+.../skills/do/scripts/do-results step-end passed "<N> findings, <M> Fix commits, <K> No-op; analysis posted to PR"
+```
+
+## Verify
+
+- Both hickey and lowy produced review output using their respective skills, either through sub-agents or the main-model fallback.
+- Every finding has an action recorded — either **Fix in this PR** or **No-op** (no Defers; if a sub-agent emitted one, the disposition audit flipped it to Fix).
+- Every "Fix in this PR" finding has a corresponding commit on the feature branch (`git log origin/<default_branch>..HEAD --oneline`), except under `noGit` (where fixes land in the working tree only).
+- No unactioned findings; no deferred findings.
+
+## Errors
+
+- `subagent_persistent_failure` — both sub-agent invocations failed and the main-model fallback also failed. Halt workflow.
+- `findings_unactioned` — the pattern returned with findings still marked Defer (the audit failed to flip them). Halt workflow; this is a sub-agent rule violation that needs investigation.

--- a/.apm/skills/do/nodes/implement.md
+++ b/.apm/skills/do/nodes/implement.md
@@ -1,0 +1,43 @@
+---
+name: implement
+kind: node
+---
+
+# implement
+
+Apply the planned changes. Test-first when applicable.
+
+## Requires
+
+- `research.plan` — from research
+
+## Ensures
+
+- (side effect) working tree mutated to match plan
+- (side effect) tests added (when test-first applies)
+
+## Strategies
+
+The test-first rule depends on what the change is:
+
+- **Bug fix**: write a failing test first (e2e or unit, whichever is appropriate), then fix the bug.
+- **New behavior** — anything that fails at runtime if it's wrong: new endpoints or routes, new services or modules, configuration paths, environment variables, secrets wiring, network connectivity, data persistence (migrations, preStart scripts, schema changes), auth/OIDC flows. Write an integration or unit test covering the new behavior **before** implementing. NixOS service modules need a VM test; new HTTP endpoints need an e2e or integration test; new modules with logic need at least a unit test.
+- **Otherwise** — documentation, refactors with no behavioral change, purely internal cleanups, dependency bumps that don't change behavior. Just implement the planned changes; no test-first requirement.
+
+If you're not sure which bucket the change falls into, treat it as new behavior. The cost of an unnecessary test is small; the cost of a silent deployment failure is not.
+
+Prefer simplicity. Do the boring obvious thing.
+
+**E2E coverage**: When the change introduces multiple user-facing paths (e.g., a dialog that appears under different conditions), write e2e scenarios for **each distinct path**. Enumerate the user-visible paths, then check that every one has a corresponding test.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start implement
+# ... do the work ...
+.../skills/do/scripts/do-results step-end passed "implemented planned changes; <N> tests added covering <list>"
+```
+
+## Verify
+
+Code changes match the planned approach. For bug fixes and new-behavior changes, at least one test exercises the changed behavior; multi-path changes have one test per distinct user-visible path. Refactor/docs/cleanup diffs are exempt.

--- a/.apm/skills/do/nodes/plan-approval.md
+++ b/.apm/skills/do/nodes/plan-approval.md
@@ -1,0 +1,39 @@
+---
+name: plan-approval
+kind: node
+---
+
+# plan-approval
+
+Pause for user plan approval. Conditional — runs only when the caller passed `--review`.
+
+## Requires
+
+- `review` — caller flag; if `false`, this node is not invoked at all (see [`execution.md`](../execution.md))
+- `research.plan` — from research
+
+## Ensures
+
+- (no binding) — control passes back to the caller (the workflow continues from `branch` or `implement`)
+
+## Strategies
+
+- **Clarify ambiguities first** — ask via `AskUserQuestion` if anything in the plan is unclear. Don't guess. This is the **only** node permitted to call `AskUserQuestion`.
+- **High-level plan**: what to do and why, not implementation details. Include an **Architecture section** (affected modules, new abstractions, ripple effects).
+- **Split non-trivial plans into phases** — MVP first, each phase functionally self-sufficient.
+- Use `EnterPlanMode` to enter plan-mode, present the plan, and `ExitPlanMode` to exit.
+- Once approved, continue autonomously to **branch** (or **implement** under `--no-git`).
+
+## Why no review on the diff later
+
+Structural critique from hickey/lowy isn't available at this point — it runs post-implement on a concrete diff and surfaces as commits + a PR comment later. The review point here is **pre-implement**, before any code is written. Reviewing a plan tends to surface generic concerns; reviewing a real diff surfaces the specific interleavings and boundary misalignments that matter.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start plan-approval
+# ... present plan, await approval ...
+.../skills/do/scripts/do-results step-end passed "user approved plan via ExitPlanMode"
+```
+
+This node is not in the default TaskCreate seed list (because `--review` is opt-in). When `--review` is set, insert it after `research` and before `branch` at seed time.

--- a/.apm/skills/do/nodes/police.md
+++ b/.apm/skills/do/nodes/police.md
@@ -1,0 +1,70 @@
+---
+name: police
+kind: node
+pattern: check-loop
+---
+
+# police
+
+Run `/code-police` (rules → fact-check → elegance) and commit each violation fix individually.
+
+## Requires
+
+- `noGit` — caller flag
+- `minimal` — caller flag
+- `default_branch` — from sync (used to scope the diff)
+
+## Ensures
+
+- `verdict` — `pass` | `failed-after-budget` | `no-command-configured`
+- (side effect, unless `noGit`) one commit per violation fix, pushed
+
+## Pattern
+
+Instances [`check-loop`](../patterns/check-loop.md) with:
+
+```yaml
+slots:
+  runner: code-police              # invokes /code-police via the Skill tool, parses violations from output
+  fixer: fix-violation-with-commit  # one commit per violation
+config:
+  max_attempts: 3
+  flaky_classification: false      # police findings are deterministic
+  loop_artifacts: commit-per-fix
+```
+
+## Strategies
+
+- **If `minimal`**: skip with `status="skipped"` and `reason="--minimal"`. Move to **test**. Do not invoke `/code-police`.
+- Use `git diff origin/<default_branch>...HEAD --name-only` to check if the PR contains code changes. If all changed files are documentation-only (e.g., `.md`, `.txt`, `README`, `docs/`) — skip with `status="skipped"` and `reason="docs-only diff"`.
+- Otherwise, invoke the `/code-police` skill via the Skill tool. It runs three passes: rule checklist, fact-check, and elegance (which delegates to `/simplify` when available).
+- When `/code-police` asks about scope: **changes in the current branch/PR only**.
+- **Commit each violation fix individually.** The same rule as `hickey-lowy`: PR history is the story of the work, and a reviewer should see one commit per rule violation or elegance refinement, not a lump "police pass" commit covering eight unrelated things.
+
+For each violation reported by `/code-police` (across all three passes), the `commit-per-fix` arm of the pattern produces a commit:
+
+- Rules pass: `fix(police): <rule-id> — <short description>` (e.g. `fix(police): no-dead-code — remove commented-out fallback`)
+- Fact-check pass: `fix(police): fact-check — <short description>` (e.g. `fix(police): fact-check — propagate error from loader`)
+- Elegance pass: `refactor(police): elegance — <short description>`
+
+For the elegance pass specifically: `/simplify` applies fixes in batches across three lenses (reuse, quality, efficiency). Commit each distinct refactor as a separate commit — do not roll them into one "elegance" commit. If a lens produces multiple independent changes (two reuse-via-helper refactors in different files, say), those are separate commits too.
+
+**Under `noGit`**: pass-through to the pattern, which will skip the commit/push arm. Apply fixes to the working tree and continue. The user reviews the combined delta.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start police
+# under --minimal or docs-only, immediately:
+.../skills/do/scripts/do-results step-end skipped "<reason>" "<reason-tag>"
+# otherwise, after pattern delegation:
+.../skills/do/scripts/do-results step-end passed "<N> violations addressed across <M> passes; all clear"
+```
+
+## Verify
+
+All 3 passes clean ("All clear"). Under `noGit`, the tree reflects the fixes; otherwise `git log origin/<default_branch>..HEAD --oneline` shows one commit per violation addressed.
+
+## Errors
+
+- `failed-after-budget` (3 attempts) — halt workflow. /code-police could not be brought to clean within the budget; further attempts are not productive.

--- a/.apm/skills/do/nodes/research.md
+++ b/.apm/skills/do/nodes/research.md
@@ -1,0 +1,50 @@
+---
+name: research
+kind: node
+---
+
+# research
+
+Research the task thoroughly before writing code.
+
+## Requires
+
+- `task` — caller arg (prompt or issue URL)
+- `forge` — from sync (controls whether issue URLs are fetched)
+- `review` — caller flag (controls whether plan-approval runs after this node)
+
+## Ensures
+
+- `research.plan` — articulation of what needs to change, where, and why, with file:line citations
+- `research.map` — file:line index from Explore subagent(s) (downstream nodes reference this rather than re-reading)
+
+## Strategies
+
+- If given a GitHub issue URL **and** `forge == github`, fetch with `gh issue view`. On non-GitHub forges, treat any issue-like URL as opaque context — use the prompt text as-is and do not attempt to fetch. (Bitbucket issue / Jira fetching is tracked in [srid/agency#10](https://github.com/srid/agency/issues/10).)
+- **Never assume** how something works. Read the code. Check the config.
+- If the prompt involves external tools/libraries, prefer `git clone` to a scratch dir (e.g. `/tmp/<name>`) at the version the project actually uses, then read the source on disk with `Read`/`Grep`/`Glob`. Fall back to `WebSearch`/`WebFetch` only when the source genuinely isn't a clonable repo (vendor docs, blog posts, RFCs).
+
+### Delegation rule — keep the main context lean
+
+Before your third `Read` in this node, stop and delegate the rest via `Agent(subagent_type=Explore)`. Main-context reads are reserved for:
+
+(a) specific files the user named in the prompt,
+(b) verifying a specific file:line an Explore subagent cited — and only with `offset`/`limit`, never full-file.
+
+Anything that smells like "map the codebase", "find all callers", "understand how X works across the repo" — delegate. The Explore subagent returns a file:line map; keep that map (`research.map`) and reference it in later nodes instead of re-reading. Use `Grep`/`Glob` before `Read`: if the question can be answered by searching, don't open the file.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start research
+# ... do the work ...
+.../skills/do/scripts/do-results step-end passed "articulated approach with file:line citations"
+```
+
+## Verify
+
+Can articulate what needs to change, where, and why, with file:line citations drawn from `research.map` (not re-read in main context).
+
+## Then
+
+If `review`, the next node is [`plan-approval`](plan-approval.md). Otherwise, the next node is [`branch`](branch.md) (or [`implement`](implement.md) under `--no-git`).

--- a/.apm/skills/do/nodes/sync.md
+++ b/.apm/skills/do/nodes/sync.md
@@ -1,0 +1,56 @@
+---
+name: sync
+kind: node
+---
+
+# sync
+
+Fetch origin, classify the forge, fast-forward (unless `--no-git`), and stash coordination state.
+
+## Requires
+
+- `noGit` — caller flag (default `false`)
+
+## Ensures
+
+- `forge`: `github` | `bitbucket` | `unknown`
+- `branch`: current git branch name
+- `default_branch`: e.g. `master` or `main`
+- (side effect) origin fetched; if not `noGit` and behind, fast-forwarded with `git pull --ff-only`
+
+## Strategies
+
+- The `scripts/steps/sync` script encapsulates fetching, fast-forwarding, dirty-tree hinting, forge classification, and the do-results init+sync record. Don't reimplement; just invoke.
+- Under `noGit`: fetch happens but the working tree is never touched — uncommitted work is preserved.
+- When the tree is dirty and not `noGit`: print a hint to stderr (no pause) suggesting `--no-git`; continue regardless. The hint:
+
+  > _Dirty tree detected. Continuing will create a fresh branch on top of these changes. If you wanted the agent to extend your WIP in place without touching git, re-run with `--no-git`._
+
+- Forge classification reads `git remote get-url origin`:
+  - `github.com` → `github`
+  - `bitbucket.` (covers `bitbucket.org` and self-hosted servers like `bitbucket.juspay.net`) → `bitbucket`
+  - otherwise → `unknown`
+
+  Only `github` has an active PR/CI integration code path today. Bitbucket and unknown cause forge-dependent nodes (`branch`, `commit`, `create-pr`, `ci`, `evidence`) to skip gracefully. Bitbucket support is tracked in [srid/agency#10](https://github.com/srid/agency/issues/10).
+
+## Receipt
+
+**Special case.** The `scripts/steps/sync` script handles its own bookend internally — it calls `do-results init <forge> <noGit>` then `do-results step sync passed ...`. The agent does **not** call `step-start sync` / `step-end sync` itself for this node.
+
+After the script returns, the agent reads `forge=`, `branch=`, `defaultBranch=` from stdout and re-stashes them via `do-results set forge ...`, `set noGit ...`, `set branch ...`, `set default_branch ...` so downstream nodes can read them as bindings.
+
+## Invocation
+
+```
+.../skills/do/scripts/steps/sync <noGit>
+```
+
+(Pass `true` or `false` for `<noGit>`.)
+
+## Verify
+
+Script exited 0 and printed three lines on stdout: `forge=<value>`, `branch=<value>`, `defaultBranch=<value>`. Sync silences `do-results`' own confirmation echoes so the protocol stays clean.
+
+## Errors
+
+- `script_exit_nonzero` — the sync script failed (network, git error, malformed remote URL). Halt the workflow with `do-results set status failed`. Do not proceed to research; coordination state is required.

--- a/.apm/skills/do/nodes/test.md
+++ b/.apm/skills/do/nodes/test.md
@@ -1,0 +1,59 @@
+---
+name: test
+kind: node
+pattern: check-loop
+---
+
+# test
+
+Run tests relevant to the diff. Verify the new behavior is actually exercised.
+
+## Requires
+
+- `noGit` — caller flag
+- `default_branch` — from sync (used to scope the diff)
+
+## Ensures
+
+- `verdict` — `pass` | `failed-after-budget` | `no-command-configured`
+- (side effect, unless `noGit`) one commit per test-driven fix, pushed
+
+## Pattern
+
+Instances [`check-loop`](../patterns/check-loop.md) with:
+
+```yaml
+slots:
+  runner: run-test-command          # reads .agency/do.md ## Test command, runs scoped to changed files
+  fixer: fix-test-failure-and-commit
+config:
+  max_attempts: 4
+  flaky_classification: true       # tests can be flaky; classification logic in runner
+  flaky_budget: 0                   # test does NOT budget flaky retries; that's ci's job. Real fix-loop only.
+  loop_artifacts: commit-per-fix
+  coverage_check: true             # green run on stale code is not a pass
+```
+
+## Strategies
+
+- Read `.agency/do.md` and look for a `## Test command` section. Run only the tests relevant to the code paths changed in this PR.
+- Use `git diff origin/<default_branch>...HEAD --name-only` to identify changed files and determine which tests are relevant.
+- If changes are purely internal with no user-facing impact, unit tests may suffice — skip e2e if no relevant scenarios exist. If no test command is documented, the runner returns `no-command-configured`; record as `skipped`.
+- **Coverage gap check (the `coverage_check: true` config)**: After the test command exits 0, confirm at least one of the tests run actually exercised the new behavior (per the **implement** node's classification). A green run that didn't touch the changed code paths — e.g., a new NixOS service module with no corresponding VM test, or a new endpoint with no integration test — is a coverage gap, not a pass. Refactor/docs/internal-cleanup diffs are exempt. The implement node should have caught this; if it didn't, the pattern treats it as a real failure and the fixer writes the missing test.
+- **Why `flaky_budget: 0` here but flaky enabled in ci**: at this stage we want to know if the fresh tests are stable; treating flakes as worth retrying without fixing masks real timing issues that should be fixed before CI sees them. The ci node (where flakes are unavoidable in shared infrastructure) sets a real budget.
+
+## Receipt
+
+```
+.../skills/do/scripts/do-results step-start test
+# ... pattern delegation ...
+.../skills/do/scripts/do-results step-end {passed|skipped|failed} "<verification>" ["<reason>"]
+```
+
+## Verify
+
+Tests pass (exit code 0) **and** the new behavior is covered, or the diff is exempt from the coverage check, or no relevant tests to run.
+
+## Errors
+
+- `failed-after-budget` (4 attempts) — halt workflow. Tests cannot be brought green within the fix budget; the implementation is incorrect or the test approach is wrong.

--- a/.apm/skills/do/patterns/check-loop.md
+++ b/.apm/skills/do/patterns/check-loop.md
@@ -1,0 +1,102 @@
+---
+name: check-loop
+kind: pattern
+---
+
+# check-loop
+
+A specialization of [worker-critic](worker-critic.md) for verification-driven retry: a deterministic command (the runner / critic) gates a fix loop (the fixer / worker). Used by **check**, **docs**, **test**, **ci**, and **police**.
+
+## Slots
+
+- `runner`: the command that verifies (e.g. `tsc --noEmit`, `nix flake check`, `/code-police`)
+  - requires: `target` (the diff or files under inspection)
+  - ensures: `verdict` (`pass` | `fail` | `flaky` | `no-command-configured`), `output`
+- `fixer`: applies a corrective edit when runner returns `fail`
+  - requires: `output` (the runner's failure output), `target`
+  - ensures: `attempted_fix` (bool), `files_changed` (list of paths)
+
+## Config
+
+| Param | Default | Meaning |
+|-------|---------|---------|
+| `max_attempts` | `3` | Maximum real-failure fix attempts. Exhaustion halts the workflow. |
+| `flaky_classification` | `false` | When `true`, runner may return `flaky` (re-run without fixing) and `flaky_budget` is consumed separately. |
+| `flaky_budget` | `0` | Re-runs allowed without fixing. Only meaningful when `flaky_classification: true`. |
+| `loop_artifacts` | `none` | `none`: fixes stay in the working tree only. `commit-per-fix`: each fix that lands real changes is followed by `fmt` + `commit` + `push`, with one commit per discrete fix. |
+| `coverage_check` | `false` | When `true`, after `verdict == pass` the runner must also confirm the changed code paths were exercised. A green run on stale code does not satisfy verification. |
+| `rerun_on_new_commit` | `false` | When `true`, before recording `pass` the pattern compares the SHA the runner ran against to current `HEAD`. If they differ, re-runs against current `HEAD`. |
+
+## Requires
+
+- `target`: what's being verified (typically the just-implemented diff, scoped via `git diff origin/HEAD...HEAD --name-only`)
+
+## Ensures
+
+- `verdict`: one of:
+  - `pass` — runner returned success and (if applicable) coverage / SHA checks passed
+  - `failed-after-budget` — exhausted retries; surrounding workflow halts with `status=failed`
+  - `no-command-configured` — runner reports the project hasn't configured this gate; treated as `skipped` by the surrounding node
+
+## Invariants
+
+- `no-command-configured` short-circuits to `skipped` — never treated as failed.
+- On `failed-after-budget`, the surrounding workflow halts (the surrounding node reports `step-end failed`). The pattern does not silently pass.
+- `flaky` re-runs do not consume the `max_attempts` budget; only real failures do. The two budgets are independent.
+- Under `loop_artifacts: commit-per-fix`, each fix is its own commit (never batched). PR history reads as a sequence of discrete fixes, not a grab-bag diff.
+- Under `loop_artifacts: commit-per-fix` AND `noGit: true`: fixes go to the working tree but commit/push are skipped. The user reviews the combined working-tree delta themselves.
+
+## Delegation
+
+```prose
+let attempts_real = 0
+let attempts_flaky = 0
+
+loop:
+  let { verdict, output } = call runner
+    target: target
+
+  if verdict == "no-command-configured":
+    return { verdict: "no-command-configured" }
+
+  if verdict == "pass":
+    if rerun_on_new_commit and runner.ran_against_sha != current_head_sha:
+      continue   # re-run against current HEAD; verdict pass on stale code does not satisfy
+    if coverage_check and not runner.coverage_satisfied:
+      # treat as a real failure: runner exited 0 but didn't exercise the new behavior
+      attempts_real = attempts_real + 1
+      if attempts_real > max_attempts:
+        return { verdict: "failed-after-budget" }
+      call fixer
+        output: "coverage gap: " + describe_gap()
+        target: target
+      if loop_artifacts == "commit-per-fix" and not noGit:
+        call fmt files: fixer.files_changed
+        call commit-fix message: "test: cover <new behavior>"
+      continue
+    return { verdict: "pass" }
+
+  if flaky_classification and verdict == "flaky":
+    attempts_flaky = attempts_flaky + 1
+    if attempts_flaky > flaky_budget:
+      return { verdict: "failed-after-budget" }
+    continue
+
+  # verdict == "fail"
+  attempts_real = attempts_real + 1
+  if attempts_real > max_attempts:
+    return { verdict: "failed-after-budget" }
+  call fixer
+    output: output
+    target: target
+  if loop_artifacts == "commit-per-fix" and not noGit:
+    call fmt files: fixer.files_changed
+    call commit-fix message: <one-line summary derived from fixer's change>
+    call push
+```
+
+## Notes
+
+- The `runner` slot is a thin adapter around the actual command. For `check`, the runner reads `.agency/do.md`'s `## Check command` section, runs it, and classifies the exit code. For `ci`, the runner kicks off the `## CI command` (typically with `run_in_background: true`) and waits for the verification method to report.
+- The flaky/real classification is a heuristic: a test that **passes on a subsequent retry** is flaky; consistent failure is real. Before retrying as flaky, the runner reads the failing test code to judge whether the failure pattern is inherently race-prone (timing, async waits, network).
+- `coverage_check` is currently used by `test`. The check is: at least one of the tests run actually exercised the new behavior (per the implement node's classification). A new HTTP endpoint with no integration test, or a new NixOS service module with no VM test, is a coverage gap regardless of test exit code.

--- a/.apm/skills/do/patterns/fanout-fix.md
+++ b/.apm/skills/do/patterns/fanout-fix.md
@@ -1,0 +1,94 @@
+---
+name: fanout-fix
+kind: pattern
+---
+
+# fanout-fix
+
+Spawn N reviewer sub-agents in parallel, gather a flat list of findings, then apply each finding as its own discrete commit. Used by **hickey-lowy**.
+
+## Slots
+
+- `reviewers`: list of reviewer skills/sub-agents (e.g. `[hickey, lowy]`)
+  - each requires: `diff`, `task_context`
+  - each ensures: `findings` — list of `{ lens, label, rationale, disposition }`
+- `applier`: applies a single finding as a discrete code change
+  - requires: `finding`, `diff`
+  - ensures: `applied` (bool), `files_changed` (list of paths)
+
+## Config
+
+| Param | Default | Meaning |
+|-------|---------|---------|
+| `disposition_audit` | `["Defer"]` | Forbidden dispositions that get flipped to `"Fix in this PR"` automatically. /do passes `["Defer", "out of scope", "follow-up", "pre-existing", "should be its own change"]` to catch all phrasings. |
+| `commit_prefix_per_lens` | `{}` | Map from lens name → conventional-commit prefix. e.g. `{ hickey: "refactor(hickey)", lowy: "refactor(lowy)" }`. |
+| `comment_under_heading` | `null` | Optional markdown heading. When set and `forge == github`, post a flat findings table + per-lens rationale to the PR under this heading. |
+| `noGit` | `false` | When `true`, apply each finding to the working tree but skip fmt/commit/push entirely. |
+
+## Requires
+
+- `diff`: scope to review (typically `git diff origin/HEAD...HEAD`)
+- `task_context`: the original task prompt + research findings (sub-agents do not inherit the calling agent's context)
+
+## Ensures
+
+- `findings_table`: flat list of all findings with their final dispositions (after audit)
+- `commits_added`: count of new commits on the feature branch (zero under `noGit`)
+- `comment_url`: PR comment URL when `comment_under_heading` is set, `forge == github`, and findings posted
+
+## Invariants
+
+- **Reviewers run in parallel.** Single assistant turn with N parallel `Agent` tool_use blocks. Sequential reviewer invocations are a regression — one reviewer at a time blocks the second's start time on the first's full output.
+- **No Defer disposition survives the audit.** Every finding is either `Fix in this PR` or `No-op`. If a sub-agent emitted `Defer #N` / `out of scope` / `follow-up` / `pre-existing` / `should be its own change`, the audit flips it to `Fix in this PR` unconditionally. /do is not optimizing for minimal diff — it is optimizing for the simpler artifact landing in `master`.
+- **One commit per Fix finding.** Never batched. PR history reads as a sequence of structural refinements, not an opaque "review pass" commit covering 8 unrelated things. Under `noGit`, the equivalent is "one discrete edit per finding to the working tree" — the user reviews the combined delta.
+- **`No-op` is narrow.** It survives without code action only when the diff already deletes the offending code, or the finding is verbatim-subsumed by another entry in the same review. Anything resembling deferred-work-for-later is a Fix, not a No-op.
+- **Sub-agent prompts must be self-contained.** Sub-agents do not inherit context. The prompt includes the full task prompt, relevant research findings (file paths, intended approach, key constraints), and the diff scope (`git diff origin/HEAD...HEAD`). The sub-agent already knows to read its skill file — don't re-state the methodology.
+- **Model selection lives in the reviewer skill, not in the pattern.** Both `hickey/SKILL.md` and `lowy/SKILL.md` declare `model: sonnet` in their frontmatter. Don't pass `model:` at the `Agent` tool level — the skill frontmatter is the single source of truth.
+
+## Delegation
+
+```prose
+parallel:
+  for r in reviewers:
+    let r.findings = call r
+      diff: diff
+      task_context: task_context
+
+let all_findings = flatten([r.findings for r in reviewers])
+
+# disposition audit — flip forbidden dispositions to Fix in this PR
+for finding in all_findings:
+  if finding.disposition in disposition_audit:
+    finding.disposition = "Fix in this PR"
+
+# apply each Fix finding as its own commit
+let commits_added = 0
+for finding in all_findings where finding.disposition == "Fix in this PR":
+  call applier
+    finding: finding
+    diff: diff
+  if not noGit:
+    call fmt files: applier.files_changed
+    call commit-fix
+      message: "{commit_prefix_per_lens[finding.lens]}: {finding.label}"
+      body: finding.rationale
+    call push
+    commits_added = commits_added + 1
+
+# post findings comment if requested
+let comment_url = null
+if comment_under_heading and forge == "github":
+  comment_url = post_pr_comment(comment_under_heading, render_findings_table(all_findings) + render_per_lens_rationales(reviewers))
+
+return { findings_table: all_findings, commits_added: commits_added, comment_url: comment_url }
+```
+
+## Fallback (when sub-agent invocation fails)
+
+If a sub-agent invocation fails for harness/tooling reasons before producing a review, retry that reviewer once. If it still cannot produce a sub-agent review, run that review in the main model by loading the reviewer skill against the same diff. This fallback is slower and uses more main-context budget, but it is still the fanout-fix step. Do not replace it with an informal/manual review, and do not mark the surrounding node `skipped` because a preferred model was unavailable.
+
+If the harness cannot honor the model declared in the reviewer skill's frontmatter, run the reviewer as a sub-agent on the available model — this is the expected path on harnesses that ignore Claude Code's `model:` skill extension (opencode, Codex, etc.).
+
+## Coordination findings (out of scope of this PR)
+
+Findings that genuinely require coordination outside this repo (upstream library bug, breaking dep upgrade, schema migration that must ship separately) shouldn't have surfaced as findings of this structural review in the first place; if one did, apply a local workaround or interface boundary in this PR rather than punt. Flag the upstream dependency in the PR description as a strategic note, not as a deferred finding.

--- a/.apm/skills/do/patterns/worker-critic.md
+++ b/.apm/skills/do/patterns/worker-critic.md
@@ -1,0 +1,64 @@
+---
+name: worker-critic
+kind: pattern
+---
+
+# worker-critic
+
+Adapted from OpenProse's bundled `std/patterns/worker-critic` (see [`/tmp/prose/tests/open-prose/smoke/worker-critic.prose.md`](https://github.com/openprose/prose/blob/main/tests/open-prose/smoke/worker-critic.prose.md) for the original).
+
+A reusable shape for produce → critique → revise loops with a bounded round budget.
+
+## Slots
+
+- `worker`: produces or revises the work product
+  - requires: `task`, optional `feedback`
+  - ensures: `output`
+- `critic`: evaluates the worker output against the quality bar
+  - requires: `output`
+  - ensures: `accepted` (bool), `feedback`
+
+## Config
+
+- `max_rounds`: integer, default `2`
+
+## Requires
+
+- `task`: what to produce
+- `quality_bar`: acceptance criteria (often inlined in the critic's prompt rather than passed as data)
+
+## Ensures
+
+- `result`: accepted worker output, or the best-effort output with final critique when the round budget is exhausted
+
+## Invariants
+
+- Stop when `critic.accepted` is true or after `max_rounds`.
+- On exhaustion: return the latest worker output with the latest critique. Do not silently pass.
+- Each iteration is a fresh attempt — never amend earlier rounds.
+
+## Delegation
+
+```prose
+let current = call worker
+  task: task
+let final_review = "not yet evaluated"
+
+repeat max_rounds:
+  let review = call critic
+    output: current
+  if review.accepted:
+    return { result: current }
+  current = call worker
+    task: task
+    feedback: review.feedback
+  final_review = review
+
+return { result: current, final_feedback: final_review }
+```
+
+## Where /do uses this
+
+**Indirectly.** /do does not instance worker-critic directly because its critic loops are mostly `worker = "the implementer"` and `critic = "a deterministic verification command"` (e.g. `tsc --noEmit`, `nix flake check`, `/code-police`). That specialization is captured by [`check-loop.md`](check-loop.md), which shares the same shape but optimizes for runner-as-critic.
+
+The pattern is documented here so future workflow-graph workflows (e.g. `/ship` with a polish phase, or a `/draft` workflow with editor critique) can instance it directly without re-deriving the shape.

--- a/.apm/skills/do/workspace.md
+++ b/.apm/skills/do/workspace.md
@@ -1,0 +1,65 @@
+# Workspace and Bindings
+
+Adapting OpenProse's workspace/bindings boundary: each node has private scratch (working-tree mutations, sub-agent transcripts, do-results internal state, mid-step retry attempts) but only a small declared set of values crosses between nodes. The list below is the complete cross-node binding vocabulary for /do.
+
+## Bindings (cross between nodes)
+
+| Binding | Producer | Consumers | Notes |
+|---------|----------|-----------|-------|
+| `noGit` | caller flag, sync stashes via `do-results set` | branch, commit, hickey-lowy, police, create-pr, ci, evidence, done | bool |
+| `minimal` | caller flag | docs, hickey-lowy, police, evidence | bool |
+| `review` | caller flag | research (controls plan-approval pause) | bool |
+| `forge` | sync (script's stdout) | branch, commit, create-pr, ci, evidence, done | `github` / `bitbucket` / `unknown` |
+| `branch` | sync (current), branch (new feature branch) | commit, create-pr | string |
+| `default_branch` | sync | branch, hickey-lowy, police, test, ci | `master` / `main` |
+| `task` | caller arg | research | the prompt or issue URL |
+| `research.plan` | research | plan-approval, implement | structured plan + file:line citations |
+| `research.map` | research | implement (referenced rather than re-read) | file:line index from Explore subagent |
+| `primary_commit_sha` | commit | hickey-lowy, police | git sha; absent under `noGit` |
+| `review_findings` | hickey-lowy | create-pr (posted as PR comment) | structured table; may be empty |
+| `pr_url` | create-pr | ci, evidence, done | string; absent under `noGit` or non-github forge |
+| `ci_run_sha` | ci | done | git sha CI ran against |
+| `timing_table` | done (via `scripts/steps/done`) | terminal, PR comment | markdown table |
+
+## What is NOT a binding
+
+These are durable but not bindings — they're side effects on shared state. Downstream nodes read them from the world, not from a binding:
+
+- **Git tree state** — implement, hickey-lowy, police, test all mutate it. `git diff origin/HEAD...HEAD` is the canonical query.
+- **Pushed commits** — commit, hickey-lowy, police, test all push. `git log origin/HEAD..HEAD` is the canonical query.
+- **GitHub PR state** — create-pr opens the draft, hickey-lowy posts the analysis comment, evidence posts the evidence comment, done posts the status comment. `gh pr view` is the canonical query.
+- **CI status** — ci writes statuses to GitHub. `gh pr checks` (or equivalent) is the canonical query.
+- **`.do-results.json`** — the receipt envelope. Treat as write-only from per-node code; use the script API, don't read the file directly.
+
+## Scratch (does not cross node boundaries)
+
+Anything not in the bindings table above is scratch. Examples:
+
+- **Sub-agent transcripts.** When `hickey-lowy` spawns hickey + lowy as parallel sub-agents, only the structured `findings` cross back. The internal reasoning, file dumps, and intermediate edits the sub-agents made stay in their sessions.
+- **Mid-step retry attempts.** `check-loop`'s intermediate runner outputs (e.g. the second-to-last failing tsc output) are scratch — only the final verdict crosses.
+- **File reads done for verification.** `git diff --name-only` to count changed files; `gh pr view` to confirm a comment posted. The values are queried, used for a local decision, and discarded.
+- **Tool outputs from research.** Files Explore reads internally are scratch; the file:line *map* it returns crosses as `research.map`.
+
+## Why this boundary matters
+
+Without it, the agent's context bloats with intermediate state by step seven and the original goal gets lost. With it, each node has a clean handoff and the rest of the noise stays in the node that produced it. This is the same insight OpenProse encodes with `workspace/` (per-service scratch) vs. `bindings/` (declared cross-service outputs).
+
+The bindings table above is the contract for how nodes talk to each other. Adding a new binding (or expanding an existing one's consumers) is a deliberate design change to this skill, not an ad-hoc decision in a single node.
+
+## Receipt envelope (the run trace)
+
+The do-results JSON tracks workflow state independently of bindings. Its top-level fields:
+
+| Field | Owner | Set by |
+|-------|-------|--------|
+| `workflow` | do-results script | `init` |
+| `startedAt` | do-results script | `init` |
+| `active` | /do | `set active <working\|waiting\|false>` |
+| `status` | /do | `set status <completed\|failed>` (set by `done`) |
+| `forge` | /do | `set forge <value>` (set by `sync`) |
+| `noGit` | /do | `set noGit <value>` (set by `sync`) |
+| `steps[]` | do-results script | `step-start` / `step-end` / `step` |
+
+Each step record has: `name`, `status`, `verification`, `startedAt`, `completedAt`, optional `reason`.
+
+The receipt envelope is the audit trail of the run. It does not interpret /do-specific concepts — it just remembers them. New /do fields go in via `set`; the script never grows /do-specific knowledge.


### PR DESCRIPTION
**Alternative recast of [#99](https://github.com/srid/agency/pull/99).** Same goal — replace the 500-line `/do` SKILL.md with a graph of small, contracted nodes — using vocabulary lifted from [openprose/prose](https://github.com/openprose/prose) instead of the bespoke `next:`/`depends_on:`/`output_schema:` frontmatter PR #99 invented. No runtime dependency on OpenProse; the agent reads these files directly, same as today and as PR #99.

## Why a separate PR

PR #99's structural instinct is right (small node files, declared per-step contracts, parallel-as-data, session receipts). What it lacks: the standard. Each node's frontmatter (`next`, `depends_on`, `skip_when`, `requires_tool`, `retry`, `output_schema`, `provides`) is invented for /do — no parser will read it consistently, no second workflow benefits from sharing the schema, and the v1 Go engine would have to specify the grammar from scratch.

OpenProse already has that grammar, plus a richer execution language and a pattern abstraction that subsumes several of PR #99's hand-written nodes. This PR shows what /do looks like rebased on it.

## What's lifted from OpenProse

Four things, in order of leverage:

1. **`### Requires` / `### Ensures` per node.** Replaces `output_schema` + `provides` + `depends_on` with one declarative pair. Source: [`skills/open-prose/contract-markdown.md`](https://github.com/openprose/prose/blob/main/skills/open-prose/contract-markdown.md).
2. **The `worker-critic` pattern shape** — generalized into [`patterns/check-loop.md`](.apm/skills/do/patterns/check-loop.md) (verification-driven retry, used by check/docs/test/ci/police) and [`patterns/fanout-fix.md`](.apm/skills/do/patterns/fanout-fix.md) (parallel reviewers + commit-per-finding, used by hickey-lowy). Source: [`tests/open-prose/smoke/worker-critic.prose.md`](https://github.com/openprose/prose/blob/main/tests/open-prose/smoke/worker-critic.prose.md). [`patterns/worker-critic.md`](.apm/skills/do/patterns/worker-critic.md) is included verbatim for future workflows.
3. **ProseScript-style execution shapes** in [`execution.md`](.apm/skills/do/execution.md) — `parallel:`, `loop until: (max: N)`, `try:`, conditional skips. Replaces ad-hoc `retry: { max, on }` and PR #99's parallel-via-`next: [a,b]`. Source: [`skills/open-prose/prosescript.md`](https://github.com/openprose/prose/blob/main/skills/open-prose/prosescript.md).
4. **Workspace / bindings boundary** — [`workspace.md`](.apm/skills/do/workspace.md) declares the complete cross-node binding vocabulary (15 bindings). Per-node scratch (sub-agent transcripts, mid-step retry attempts, file reads done for verification) does not cross. Source: OpenProse's `workspace/` vs `bindings/` split.

What's **not** taken: the `*.prose.md` filename convention, the harness primitive adapter (`spawn_session`/`ask_user`/...), Forme auto-wiring (we pin the order in `execution.md` instead — there's only one workflow here, no value in semantic resolution), Responsibility Runtime, gateways, the `prose run`/`prose serve`/`prose compile` command surface, the `dist/`/`runs/`/`state/` filesystem layout, the `std/`/`co/` package shorthand, and `prose install` deps. None of those are needed for a single-workflow skill.

## Layout

```
.apm/skills/do/
  SKILL.md            (154 lines — was 500)  the loop, the language, cross-cutting concerns
  execution.md        (108 lines, new)        the pinned order + skip taxonomy + entry points
  workspace.md         (65 lines, new)        bindings table + scratch boundary + receipt envelope
  patterns/
    worker-critic.md   (64 lines, new)        produce → critique → revise (documented for future workflows)
    check-loop.md     (102 lines, new)        run → on fail, fix → retry (with optional flaky/real split)
    fanout-fix.md      (94 lines, new)        parallel reviewers → commit-per-finding
  nodes/  (16 files, 37–102 lines each — were inline subsections of SKILL.md)
    sync, research, plan-approval, branch, implement,
    check, docs, fmt, commit,
    hickey-lowy, police, test,
    create-pr, ci, evidence, done
  scripts/             unchanged (do-results, steps/sync, steps/done)
```

Total: 1531 lines across 22 files (vs 500 in one file). Bigger total, but per-file cognitive load is 30–100 lines instead of 500. The agent reads ~3 files per node walk (SKILL + the node + sometimes the pattern), not the whole skill.

## What's preserved 1:1

Behavior is unchanged. Every flag, every conditional skip, every retry budget, every hook integration:

- `--review`, `--no-git`, `--minimal`, `--from <step>` — same parsing, same effects
- All four "counts toward completed" skip reasons (non-github forge, --no-git, --minimal, "no PR evidence section")
- do-results bookend discipline (`step-start` / `step-end`, `set` for /do-specific fields, `init` once, `set status` at end)
- TaskCreate seeding rules (parallel emit, --minimal omits 4, --from marks earlier as completed)
- The "no Defer" disposition audit
- Post-implement hickey/lowy timing on a concrete diff
- `commit-per-fix` history granularity (one commit per finding/violation)
- Coverage gap check in `test`
- `rerun_on_new_commit` discipline in `ci`
- Background CI + `set active waiting/working` for the stop hook
- All the bookend retry budgets: check 3, docs 3, police 3, test 4, ci 5 real / 3 flaky
- The five entry points (default, followup, post-implement, polish, ci-only)
- The 7 workflow-wide invariants (never skip, every commit is NEW, feature branches only, background for CI, no questions, never stop, exhausted retries = halt)
- Scripts (`do-results`, `steps/sync`, `steps/done`) untouched

## Side-by-side with PR #99

| | This PR | [PR #99](https://github.com/srid/agency/pull/99) |
|--|---|---|
| Per-node frontmatter | `name`, `kind: node`, optional `pattern:` | `name`, `next:`, `depends_on:`, `skip_when:`, `requires_tool:`, `retry:`, `output_schema:`, `provides:` |
| Vocabulary source | OpenProse Contract Markdown (published, evolving) | Bespoke to /do (no second user) |
| Conditional skips | Each node's `### Strategies` describes them inline | Central `skip_when:` predicate frontmatter |
| Retry policy | Pattern config (`max_attempts`, `flaky_classification`, `flaky_budget`, `loop_artifacts`) | Per-node `retry: { max, on }` (or `{ max_flaky, max_real }` for compound cases) |
| Reusable shape for hickey+lowy | `fanout-fix` pattern (one file, many possible instances) | None — each reviewer is a hand-written node wrapper |
| Reusable shape for check/docs/test/ci/police | `check-loop` pattern (one file, five callers, all config) | None — each retry loop reimplemented per node |
| Parallel dispatch | `parallel:` block in `fanout-fix` pattern delegation | `next: [hickey, lowy]` array convention |
| Cross-node values | `workspace.md` declares all 15 bindings explicitly | `provides:` per-node; no central index |
| Scratch boundary | `workspace.md` enumerates what does NOT cross | Implicit |
| Session log shape | Existing `do-results` (unchanged) | New `.apm/sessions/do-<timestamp>.md` with bespoke YAML receipts |
| Order definition | `execution.md` pinned ProseScript-style pseudocode | Per-node `next:` edges (graph, no central order doc) |
| Trust model | Agent reads & embodies (same as PR #99) | Agent reads & embodies (v1 Go engine deferred) |
| Future enforcement story | A future `apm-engine` parses these files; the file shape is forward-compatible | Same |

The biggest practical difference: this PR has three reusable patterns instead of zero, so the per-node files are uniform thin shells. PR #99's per-node files duplicate retry/skip logic.

## What this PR is **not**

- **Not** a runtime dependency on OpenProse. We borrow the section vocabulary and pattern shapes; the agent reads these files directly. No `prose run`, no `kind: service`, no harness adapter.
- **Not** a Go engine. `apm-engine` could parse these files later (see PR #99's v1 plan), but this PR is markdown-only.
- **Not** a `/ship` workflow yet. The split is right if a second workflow is 2–3 small node files with zero pattern changes — but proving that belongs in a follow-up PR. (The OpenProse `worker-critic` pattern is included specifically so a future `/ship` polish loop can instance it directly.)
- **Not** a README or website update. PR #99 didn't update them either; both should land alongside whichever recast is approved, not before. CLAUDE.md's "keep README/landing in sync" is on the merger.
- **Not** removing or changing any existing hooks/scripts. `do-results`, `steps/sync`, `steps/done`, `do-stop-guard.sh` all unchanged.

## How to review

Read in order:

1. [`SKILL.md`](.apm/skills/do/SKILL.md) — what changed at the top, how to walk the graph, language vocabulary
2. [`execution.md`](.apm/skills/do/execution.md) — the pinned order, with skip taxonomy and entry points
3. [`workspace.md`](.apm/skills/do/workspace.md) — bindings vs scratch
4. One pattern: [`patterns/check-loop.md`](.apm/skills/do/patterns/check-loop.md) (the most-used)
5. One pattern caller: [`nodes/check.md`](.apm/skills/do/nodes/check.md) (simplest) and [`nodes/ci.md`](.apm/skills/do/nodes/ci.md) (most parameterized)
6. The other pattern: [`patterns/fanout-fix.md`](.apm/skills/do/patterns/fanout-fix.md) and its caller [`nodes/hickey-lowy.md`](.apm/skills/do/nodes/hickey-lowy.md)
7. Skim the remaining nodes — they're 30–80 lines each, no surprises if 1–6 made sense

Compare against:
- Current SKILL.md on `master` (500 lines) — for behavior preservation
- [PR #99](https://github.com/srid/agency/pull/99) — for vocabulary and shape contrast
- [openprose/prose: contract-markdown.md](https://github.com/openprose/prose/blob/main/skills/open-prose/contract-markdown.md) and [worker-critic.prose.md](https://github.com/openprose/prose/blob/main/tests/open-prose/smoke/worker-critic.prose.md) — for the borrowed vocabulary

## Open questions

- **Is `worker-critic.md` worth shipping if /do doesn't instance it?** It's there for a future `/ship` or `/draft` workflow; arguably belongs in its own follow-up. Could move to `.apm/patterns/` (skill-shared) instead of `.apm/skills/do/patterns/`.
- **`execution.md` pseudocode dialect.** Borrowed loosely from ProseScript but not validated against the spec. Should it be tighter (real subset of ProseScript) or looser (just commented pseudocode)? Tighter is forward-compatible with parsing; looser is easier to read.
- **`### Receipt` section.** Codifies the do-results bookend per node. Useful documentation, but the script API is already the source of truth — is the per-node `### Receipt` block adding value or just duplicating?
- **`plan-approval.md` as a separate node file.** It's conditional (`--review`-only) and only ~40 lines. Inline in `research.md` (today's structure) is fewer files; separate is more uniform and matches PR #99's choice. Either works.
- **Pattern config keys.** `loop_artifacts: commit-per-fix`, `flaky_classification: true`, `rerun_on_new_commit: true` — these names are inventions, not lifted from OpenProse. Open to renames if any read better.
- **Where the "borrowed from OpenProse" credit lives.** Currently in `SKILL.md`'s [Provenance](.apm/skills/do/SKILL.md#provenance) section. Could be its own `PROVENANCE.md` or moved into `workspace.md`.

Refs #99, #98, #95.