### PR TITLE
code-police: require Checked by receipts on Pass 1 No verdicts

### DIFF
--- a/.apm/skills/code-police/SKILL.md
+++ b/.apm/skills/code-police/SKILL.md
@@ -58,9 +58,11 @@ Collections, buffers, and listeners that grow with usage must have a bound or a 
 
 _Rationale_: LLM-generated code defaults to the simplest correct implementation, which is often O(n) in session lifetime. These patterns silently degrade performance over hours/days and surface as "the app got slow" with no obvious cause. The fix is almost always straightforward (cap, debounce, stream, share) but must be applied at write time — it's rarely caught in review because the code is functionally correct.
 
-### comments-why-not-what
+### comments-only-for-non-obvious
 
-Add comments where the _why_ isn't obvious from the code. Don't comment the _what_. Also comment where the _what_ isn't obvious — non-obvious guards, CSS workarounds, platform-specific behavior. Non-obvious workarounds (temp files, wrapper scripts, env var shims) must have a comment explaining why they exist.
+Default to writing NO comments. Add one only when the **why** is non-obvious to a reader who can already see the code — a hidden constraint, a subtle invariant, a workaround for a specific bug, behavior that would surprise.
+
+If removing the comment wouldn't confuse a future reader, don't write it.
 
 ## Pass 1: Rule checklist
 
@@ -69,7 +71,12 @@ Present a table with **every rule above**:
 | Rule ID | Violation found? | What was identified | Action taken |
 | ------- | ---------------- | ------------------- | ------------ |
 
-If no violation was found for a rule, mark it as "No" with a brief note on what was checked. Every rule must appear in the table — no skipping.
+Every "No" requires a **`Checked by:`** field whose content is one of:
+
+- For purely-negative rules (e.g. `no-dead-code`, `no-silent-error-swallowing`): the grep that confirmed absence — _"grep'd for `head`, `tail`, `fromJust`, `(!!)`, `Map.!`, `error`, `undefined`; zero matches."_
+- For bidirectional rules (e.g. `comments-only-for-non-obvious`, `prefer-focused-library`): the enumeration of positive candidates ruled out — _"enumerated `am`, `keep`, guard branches, `G.stars`/`G.reachable` calls; for each, named why a fresh reader decodes the why from code alone."_
+
+A "No" without `Checked by:` is malformed and must be rewritten. Every rule must appear in the table — no skipping.
 
 ## Pass 2: Fact-check
 


### PR DESCRIPTION
## Summary

- Replace the "brief note on what was checked" clause in Pass 1 with a mandatory **`Checked by:`** field. Split by rule shape: grep receipt for purely-negative rules, enumeration of positive candidates for bidirectional rules. A "No" without `Checked by:` is malformed.
- Swap `comments-why-not-what` for `comments-only-for-non-obvious`. The old default permits comments when "why isn't obvious"; the new default writes no comments and demands a hidden constraint / subtle invariant / specific-bug workaround to add one.

Closes #167. Live failure that motivated the change: [juspay/ci#2](https://github.com/juspay/ci/pull/2), fixed in [1c1f363](https://github.com/juspay/ci/commit/1c1f363).

## Test plan

- [ ] Run `/code-police` on a small bidirectional-rule diff and verify the table now contains `Checked by:` for every "No" row
- [ ] Run `/code-police` on a purely-negative-rule diff and verify the grep-receipt form is used
- [ ] Confirm a Pass 1 verdict without `Checked by:` is treated as malformed

🤖 Generated with [Claude Code](https://claude.com/claude-code)