### PR TITLE
code-police: rewrite comments rule as `comment-the-non-obvious`

### DIFF
--- a/.apm/skills/code-police/SKILL.md
+++ b/.apm/skills/code-police/SKILL.md
@@ -58,11 +58,11 @@ Collections, buffers, and listeners that grow with usage must have a bound or a 
 
 _Rationale_: LLM-generated code defaults to the simplest correct implementation, which is often O(n) in session lifetime. These patterns silently degrade performance over hours/days and surface as "the app got slow" with no obvious cause. The fix is almost always straightforward (cap, debounce, stream, share) but must be applied at write time — it's rarely caught in review because the code is functionally correct.
 
-### comments-only-for-non-obvious
+### comment-the-non-obvious
 
-Default to writing NO comments. Add one only when the **why** is non-obvious to a reader who can already see the code — a hidden constraint, a subtle invariant, a workaround for a specific bug, behavior that would surprise.
+Write a comment when a reader who didn't write the code can't tell, at first glance, **what it does** or **why it's structured this way**. The comment supplies whichever is missing — design intent (why this shape over the conventional one), control-flow semantics (what the cascade actually dispatches), or a hidden constraint the type system doesn't carry.
 
-If removing the comment wouldn't confuse a future reader, don't write it.
+This is a positive prompt, applied per block: at every non-trivial declaration or block, ask the question. A "obvious to me because I just wrote it" reflex is the failure mode — reviewers and writers both pattern-match on what they already understand and skip the question.
 
 ## Pass 1: Rule checklist
 
@@ -74,7 +74,7 @@ Present a table with **every rule above**:
 Every "No" requires a **`Checked by:`** field whose content is one of:
 
 - For purely-negative rules (e.g. `no-dead-code`, `no-silent-error-swallowing`): the grep that confirmed absence — _"grep'd for `head`, `tail`, `fromJust`, `(!!)`, `Map.!`, `error`, `undefined`; zero matches."_
-- For bidirectional rules (e.g. `comments-only-for-non-obvious`, `prefer-focused-library`): the enumeration of positive candidates ruled out — _"enumerated `am`, `keep`, guard branches, `G.stars`/`G.reachable` calls; for each, named why a fresh reader decodes the why from code alone."_
+- For bidirectional rules (e.g. `comment-the-non-obvious`, `prefer-focused-library`): the enumeration of positive candidates ruled out — _"enumerated `am`, `keep`, guard branches, `G.stars`/`G.reachable` calls; for each, named why a fresh reader decodes the why from code alone."_
 
 A "No" without `Checked by:` is malformed and must be rewritten. Every rule must appear in the table — no skipping.
 


### PR DESCRIPTION
**The `comments-only-for-non-obvious` rule led with a negative default** ("don't write comments") and tucked the positive half into a qualifying sentence. In practice both reviewers and writers read it as a prohibition and skipped the positive question — leaving the *what* unexplained whenever it was as hidden as the *why* (pattern fallthrough, special-case ordering, open-world escape hatches).

This rewrites the rule as an active prompt and renames it to `comment-the-non-obvious` to match.

### What changes

| Before | After |
|---|---|
| _"Default to writing NO comments. Add one only when the **why** is non-obvious…"_ | _"Write a comment when a reader who didn't write the code can't tell, at first glance, **what it does** or **why it's structured this way**."_ |
| Bidirectional in spec, asymmetric in practice (reviewers grep for over-commenting, not under-commenting) | Same rule applied per block as a question the writer/reviewer must actively answer |
| _"If removing the comment wouldn't confuse a future reader, don't write it."_ | _"`Obvious to me because I just wrote it` is the failure mode."_ named explicitly |

No new enumerated triggers — earlier drafts listed _"alternative-deferred code, pattern fallthrough, open-world escape hatches, special-case asymmetries"_ as positive triggers, but specifics become a checklist that obscures the principle and rots as new idioms emerge. The principle is the rule.

### Cross-reference update

The Pass 1 receipt example at line 77 also references the rule by name — updated to match.

### Motivating example

Real failure from a recent `/code-police` run: a hand-written `FromJSON Attribute` instance had three subtle behaviors stacked in seven lines — pattern-guard fallthrough without `otherwise`, equation ordering that's load-bearing, `Other Value` as an intentional open-world catch — none announced by the code. The old rule didn't fire; the reviewer (a Claude Code agent) marked it as compliant and moved on. Restating the rule as an active prompt would have caught it.

_Generated by Claude Code (model `claude-opus-4-7`)._