### PR TITLE
do: highlight No-op rows in hickey/lowy findings table

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -340,10 +340,11 @@ Check whether a PR already exists for this branch (`gh pr view`).
    ```md
    ## [Hickey/Lowy](https://kolu.dev/blog/hickey-lowy/) Analysis
 
-   | # | Lens   | Finding                                  | Disposition       |
-   |---|--------|------------------------------------------|-------------------|
-   | 1 | Hickey | viewportDimensions complects two roles   | Fixed in this PR  |
-   | 2 | Lowy   | useViewport encapsulates ghost concern   | Fixed in this PR  |
+   | # | Lens   | Finding                                  | Disposition         |
+   |---|--------|------------------------------------------|---------------------|
+   | 1 | Hickey | viewportDimensions complects two roles   | Fixed in this PR    |
+   | 2 | Lowy   | useViewport encapsulates ghost concern   | Fixed in this PR    |
+   | 3 | Lowy   | clipboard.ts named after a consumer      | ⚠️ **No-op**        |
 
    ### Hickey rationale
    <prose from the hickey sub-agent>
@@ -352,7 +353,7 @@ Check whether a PR already exists for this branch (`gh pr view`).
    <prose from the lowy sub-agent>
    ```
 
-   The Disposition cell mirrors the sub-agent's Actions disposition verbatim — **Fixed in this PR** or **No-op** (deletion-only / subsumed by another finding). There is no Deferred disposition; if a sub-agent emitted one, the audit step above flipped it to Fixed in this PR. The Finding cell is the short bolded label the sub-agent emits at the start of each Actions entry. If both lenses produced zero findings, write a one-line "No findings — analysis below" instead of an empty table.
+   The Disposition cell mirrors the sub-agent's Actions disposition verbatim — **Fixed in this PR** or **No-op** (deletion-only / subsumed by another finding). **Render every No-op as `⚠️ **No-op**`** (warning emoji + bold) so the reviewer's eye lands on it; No-op rows are the ones a human most needs to scrutinize (a finding the reviewer acknowledged but didn't fix), and plain text lets them blend into the Fixed-in-this-PR rows above. There is no Deferred disposition; if a sub-agent emitted one, the audit step above flipped it to Fixed in this PR. The Finding cell is the short bolded label the sub-agent emits at the start of each Actions entry. If both lenses produced zero findings, write a one-line "No findings — analysis below" instead of an empty table.
 
 **If PR already exists** (followup runs, `--from` entry points):
 


### PR DESCRIPTION
## Summary

- **No-op** dispositions are the rows a reviewer most needs to scrutinize — findings the sub-agent acknowledged but didn't fix — but in the current table they render as plain text and blend in with the Fixed-in-this-PR rows above them (see [example PR comment](https://github.com/juspay/kolu/pull/906#issuecomment-…) where two No-op rows are easy to miss in a list of eight findings).
- Update the `/do` post-PR-comment composer in `.apm/skills/do/SKILL.md` so every No-op cell renders as `⚠️ **No-op**` (warning emoji + bold). The example table now includes a No-op row demonstrating the format, and the prose underneath spells out the rule and the rationale (why it's the cell that most deserves the reviewer's eye).

No README / landing-page edits — this is an internal change to how `/do` composes its findings-ledger PR comment, not a change to the user-facing list of skills, commands, or workflow.

## Test plan

- [ ] On the next `/do` run that produces at least one No-op finding, confirm the posted PR comment renders the No-op cell with `⚠️` + bold, visually distinct from the Fixed-in-this-PR rows.
- [ ] Confirm runs where every finding is Fixed-in-this-PR are unaffected (no spurious emoji elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)