### PR TITLE
refactor(do): split monolithic SKILL.md into node-driven workflow graph

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -1,516 +1,87 @@
 ---
 name: do
 description: Do a task end-to-end — implement, PR, CI loop, ship. ONLY invoke when the user explicitly types `/do` or `$do`; never auto-select from a natural-language request, even one that sounds like an end-to-end task.
-argument-hint: "<issue-url | prompt> [--review] [--no-git] [--minimal] [--from <step>]"
+argument-hint: "<issue-url | prompt> [--review] [--no-git] [--minimal] [--from <step-id>]"
 ---
 
 # Do Workflow
 
 Take a task and do it top-to-bottom: research, branch, implement, pass CI, open a PR, and ship. (Under `--no-git`, extend the working tree in place — no branch, commit, or PR.)
 
-**Mostly autonomous.** Do NOT use `AskUserQuestion` at any point (except during the `--review` planning pause). Make sensible default choices and keep moving. If the user wants to skip specific steps, they can say so in the prompt — honor it.
+**This is a workflow graph.** The graph lives in [`execution.md`](execution.md); each step is a node file under [`nodes/`](nodes/); reusable shapes live under [`patterns/`](patterns/). The agent is the runtime — there is no separate engine.
+
+**Mostly autonomous.** Do NOT use `AskUserQuestion` at any point (except during the `--review` planning pause). Make sensible default choices and keep moving.
+
+## How to walk the graph
+
+1. Parse arguments (see [Arguments](#arguments)).
+2. Call `scripts/do-driver init <flags> <task>` to initialize state.
+3. Read [`execution.md`](execution.md) for the pinned order, conditional branches, entry points, and pattern instances.
+4. Seed the task checklist (see [Progress tracking](#progress-tracking)).
+5. For each step in order:
+   - Call `scripts/do-driver start <step>`.
+   - Read `nodes/<step>.md` and do the work.
+   - Call `scripts/do-driver end <step> <status> "<verification>" [reason]`.
+6. Call `scripts/do-driver summary` to emit the timing table.
 
 ## Arguments
 
 Parse the arguments string: `[--review] [--no-git] [--minimal] [--from <step-id>] <task description or issue-url>`
 
-The workflow is **forge-aware**: it auto-detects whether the repo lives on GitHub or elsewhere during the **sync** step (see Forge Detection). Only GitHub has an active code path today — Bitbucket/other forges gracefully skip PR-related steps. Tracking: [srid/agency#10](https://github.com/srid/agency/issues/10).
+The workflow is **forge-aware**: it auto-detects whether the repo lives on GitHub or elsewhere during the **sync** step. Only GitHub has an active code path today — Bitbucket/other forges gracefully skip PR-related steps. Tracking: [srid/agency#10](https://github.com/srid/agency/issues/10).
 
-- `--review`: Pause after **research** for user plan approval via `EnterPlanMode`/`ExitPlanMode`, then continue autonomously. (hickey/lowy now runs post-implement on a concrete diff, so there's no plan-approval moment attached to that step anymore — the review point is pre-implement, before any code is written.)
-- `--no-git`: Extend the working tree **in place** — do not create a branch, commit, push, or touch any PR. Research, implement, check, docs, police, fmt, and test all run; git-mutating steps (**branch**, **commit**, **create-pr**) are skipped. Use this when you have uncommitted local work and want the agent to build on it without taking over git state. Feedback from a Bitbucket user in [#26](https://github.com/srid/agency/issues/26).
-- `--minimal`: Skip the steps whose value is disproportionate on trivially-scoped diffs: **docs**, **hickey+lowy**, **police**, and **evidence**. The remaining flow runs in order: sync → research → branch → implement → check → fmt → commit → test → create-pr → ci → done. Use this when the change is obviously confined (one-line bug fix, typo, config tweak) and structural review / docs sync / quality gate / PR evidence are overkill — PR comments on small `/do` runs frequently note this. The four skipped steps each record `status="skipped"` with `reason="--minimal"`.
-- `--from <step-id>`: Start from a specific step (see entry points below)
+- `--review`: Pause after **research** for user plan approval via `EnterPlanMode`/`ExitPlanMode`, then continue autonomously.
+- `--no-git`: Extend the working tree **in place** — do not create a branch, commit, push, or touch any PR. Git-mutating nodes skip with `reason="--no-git"`.
+- `--minimal`: Skip the steps whose value is disproportionate on trivially-scoped diffs: **docs**, **hickey-lowy**, **police**, and **evidence**.
+- `--from <step-id>`: Start from a specific node. See [`execution.md`](execution.md) for entry points.
 
 ## Results Tracking
 
-Every step is bookended by two `scripts/do-results` calls: `step-start <name>` before the work begins, and `step-end <status> <verification> [reason]` after verification. This is what keeps per-step timing accurate — collapsing both into a single end-of-step call produces zero-second durations and worthless timing tables. The script tracks workflow state and emits the final timing table during **done**.
+Every node is bookended by `scripts/do-driver start <name>` before work and `scripts/do-driver end <name> <status> "<verification>" [reason]` after verification. The driver wraps `scripts/do-results`, which persists step records in `.do-results.json`.
 
-**Trust the script's stdout.** Every mutation echoes a one-line confirmation. Treat that line as your confirmation that the write succeeded; the script is the only public surface, and whatever it persists internally is private.
+**Trust the driver's stdout.** Every mutation echoes a one-line confirmation.
 
-**Lifecycle the script tracks intrinsically**:
+The `scripts/do-results` script tracks:
 
-- Step `status` — `passed`, `failed`, or `skipped`. A `skipped` step must include a `reason` (e.g. `"non-github forge: bitbucket"`, `"--no-git"`, `"--minimal"`, `"no check command configured"`).
-- `active` — state enum (not a boolean). Set to `working` when the workflow starts (**sync**), `waiting` when the agent is idle waiting for an external process (e.g. background CI), back to `working` when that process returns, and `false` when **done** is reached. The stop hook uses this: `working` blocks exits; `waiting` and `false` allow them.
-- Workflow `status` — `completed` when **done** finishes, `failed` if halted. Informational.
+- Step `status` — `passed`, `failed`, or `skipped`.
+- `active` — state enum (`working`, `waiting`, `false`). The stop hook uses this.
+- Workflow `status` — `completed` or `failed`.
 
-**Workflow fields /do also stashes via `set`** (the script doesn't interpret these — it just remembers them):
+**Workflow fields** stashed via `do-driver set <field> <value>`:
 
-- `forge` — `github`, `bitbucket`, or `unknown`. Populated by `scripts/steps/sync` after forge detection.
-- `noGit` — `true` or `false`. Reflects the `--no-git` flag. Git-mutating steps (**branch**, **commit**, **create-pr**) skip with `reason="--no-git"` when set.
-
-**Commands** (invoke with the full path, e.g. `.../skills/do/scripts/do-results ...`):
-
-- `init` — initialize the workflow's lifecycle skeleton. Echoes `init: startedAt=<ts>`.
-- `step-start <name>` — call before step work. Echoes `pending: <name>`.
-- `step-end <status> "<verification>" ["<reason>"]` — call after verification. Echoes `recorded: <name> <status> (steps=<count>, pending=<none|name>)`.
-- `step <name> <status> "<verification>" <startedAt> <completedAt> ["<reason>"]` — single-call form used by `scripts/steps/sync` where `startedAt` was captured in shell. Echoes `recorded: <name> <status> (steps=<count>)`. Agent code should prefer `step-start` / `step-end`.
-- `set <field> <value>` — set an arbitrary top-level field. Used both for lifecycle (`set active waiting`, `set status completed`) and for /do-specific values that sync stashes (`set forge github`, `set noGit false`). Echoes `set: <field>=<value>`.
-
-**Discipline**:
-
-- Bookend every step with `step-start` at the top and `step-end` at the bottom. Calling `step-end` without a prior `step-start` is an error; calling `step` with `now` for both timestamps collapses duration to 0 — neither pattern is allowed. Exceptions: `sync` is recorded by `scripts/steps/sync` itself, and skipped steps (duration always 0) may use back-to-back `step-start` / `step-end skipped`.
-- Don't run `date` yourself or guess timestamps — `do-results` resolves UTC internally.
+- `forge` — `github`, `bitbucket`, or `unknown`.
+- `noGit` — `true` or `false`.
+- `minimal` — `true` or `false`.
 
 ## Progress tracking
 
-Drive Claude Code's native todo UI via the `TaskCreate` tool so the user sees a live checklist of the workflow. At the start of **sync** (or the chosen `--from` entry point), seed a task list with the step names in order:
-
-```
-sync, research, branch, implement, check, docs, fmt, commit, hickey+lowy, police, test, create-pr, ci, evidence, done
-```
-
-**Emit all `TaskCreate` calls as parallel `tool_use` blocks in a single assistant turn** — one model round-trip, not one per task. The seeded steps have no `addBlocks` / `addBlockedBy` dependencies, so there is nothing to serialize on. Sequential seeding (15 round-trips before any real work) is a regression: it adds latency to every `/do` invocation and clutters the transcript with 15 wrapper turns of "Task #N created successfully" before `sync` even starts.
-
-**Under `--minimal`, omit the four steps the flag skips** (`docs`, `hickey+lowy`, `police`, `evidence`) from the seeded list — the user explicitly opted out of them, so they shouldn't clutter the human-facing checklist. The seeded list becomes 11 items in `--minimal` runs. (Run-inherent skips like `--no-git` and forge skips stay in the list — see the Skipped steps rule below.)
-
-The `scripts/do-results` lifecycle still records `--minimal`-skipped steps with `status="skipped"` and `reason="--minimal"` via back-to-back `step-start` / `step-end` calls — that's what keeps the final timing table and `completed`-status logic correct. The task UI is independent of that recording.
-
-At each step boundary, update task state **alongside** the `scripts/do-results` script call — they are not redundant. The script's state drives the stop hook; the task list is the human-facing UI. Miss either and the workflow is inconsistent.
+Drive the harness's native todo UI so the user sees a live checklist. At workflow start, seed all steps in order (omitting `--minimal` skips). Mark `--from` pre-steps as `completed` immediately.
 
 Rules:
 
 - **Flip to `in_progress` when a step starts, `completed` when it verifies.** One step `in_progress` at a time.
-- **Retries stay `in_progress`.** If `check`, `test`, or `ci` loop through their retry budget, do **not** bounce the task state back to `pending` or flicker it — leave it `in_progress` until the step finally verifies (or the retries exhaust and the workflow fails).
-- **`--from <step>` entry points**: still seed the full list (minus any `--minimal` omissions). Mark steps earlier than the entry point as `completed` immediately after seeding, so the checklist shows a consistent view regardless of entry point.
-- **Skipped steps that stay in the list** (e.g. `branch`/`commit`/`create-pr` under `--no-git`, or PR steps on non-GitHub forges) go straight to `completed`. Record the skip with a back-to-back `scripts/do-results step-start <name>` / `scripts/do-results step-end skipped ... "<reason>"`; the task list just shows the step as done. `--minimal` skips are **not** in this category — they're omitted from the seeded list entirely (see above), so there's no task entry to flip.
-- **Failure**: if retries exhaust and the workflow halts, leave the failing step `in_progress`, mark `done` `completed` after the failure summary is written, and run `scripts/do-results set status failed`.
-
-## Steps
-
-### sync
-
-Run the `scripts/steps/sync` script in this skill's directory, passing `true` or `false` for `--no-git`:
-
-```
-.../skills/do/scripts/steps/sync <noGit>
-```
-
-The script:
-
-- Fetches `origin` and pins `origin/HEAD`
-- If `--no-git` is **not** set and the branch is behind origin (ahead-count 0), fast-forwards with `git pull --ff-only`. Under `--no-git`, fetching happens but the working tree is not touched — uncommitted work is preserved.
-- Prints the dirty-tree hint to stderr (no pause) when the tree is dirty and `--no-git` is not set:
-
-  > _Dirty tree detected. Continuing will create a fresh branch on top of these changes. If you wanted the agent to extend your WIP in place without touching git, re-run with `--no-git`._
-
-- Classifies the forge from `git remote get-url origin` — `github.com` → `github`, `bitbucket.` (covers `bitbucket.org` and self-hosted servers like `bitbucket.juspay.net`) → `bitbucket`, otherwise `unknown`.
-- Calls `scripts/do-results init <forge> <noGit>` then `scripts/do-results step sync passed ...`.
-- Prints `forge=<value>`, `branch=<value>`, `defaultBranch=<value>` on stdout for downstream steps.
-
-**Only `github` has an active code path today.** Both `bitbucket` and `unknown` cause forge-dependent steps (PR creation, PR comments, PR edits, CI status) to skip gracefully. Bitbucket support is planned — see [srid/agency#10](https://github.com/srid/agency/issues/10).
-
-**Verify**: Script exited 0 and printed `forge=`, `branch=`, `defaultBranch=` lines on stdout. (Sync silences `do-results`' own confirmation echoes so the protocol stays clean.)
-
----
-
-### research
-
-Research the task thoroughly before writing code.
-
-- If given a GitHub issue URL **and** `forge == github`, fetch with `gh issue view`. On non-GitHub forges, treat any issue-like URL as opaque context — use the prompt text as-is and do not attempt to fetch. (Bitbucket issue/Jira fetching is tracked in #10.)
-- **Never assume** how something works. Read the code. Check the config.
-- If the prompt involves external tools/libraries, prefer `git clone` to a scratch dir (e.g. `/tmp/<name>`) at the version the project actually uses, then read the source on disk with `Read`/`Grep`/`Glob`. Fall back to `WebSearch`/`WebFetch` only when the source genuinely isn't a clonable repo (vendor docs, blog posts, RFCs).
-
-**Delegation rule — keep the main context lean.** Before your third `Read` in this step, stop and delegate the rest via `Agent(subagent_type=Explore)`. Main-context reads are reserved for:
-
-  (a) specific files the user named in the prompt,
-  (b) verifying a specific file:line an Explore subagent cited — and only with `offset`/`limit`, never full-file.
-
-Anything that smells like "map the codebase", "find all callers", "understand how X works across the repo" — delegate. The Explore subagent returns a file:line map; keep that map and reference it in later steps instead of re-reading. Use `Grep`/`Glob` before `Read`: if the question can be answered by searching, don't open the file.
-
-**Verify**: Can articulate what needs to change, where, and why, with file:line citations drawn from the research map (not re-read in main context).
-
-**If `--review`**: Use `EnterPlanMode` to present the approach for user approval:
-
-- **Clarify ambiguities** first — ask via `AskUserQuestion` if anything is unclear. Don't guess.
-- **High-level plan**: what to do and why, not implementation details. Include an **Architecture section** (affected modules, new abstractions, ripple effects).
-- **Split non-trivial plans into phases** — MVP first, each phase functionally self-sufficient.
-
-Use `ExitPlanMode` to present the plan. Once approved, continue autonomously to **branch**. Structural critique from hickey/lowy isn't available at this point — it runs post-implement on a concrete diff and surfaces as commits + a PR comment later.
-
----
-
-### branch
-
-**If `--no-git`**: Skip this step entirely with status `skipped` and reason `"--no-git"`. Stay on the current branch — do not create, commit, or push anything. Move to **implement**.
-
-Detect the default branch: `git symbolic-ref refs/remotes/origin/HEAD`
-
-1. Create a descriptive feature branch from `origin/<default>`
-
-That's it — just the local branch. No commit, no push, no PR. The branch is pushed later in **commit**, and the PR is created in **create-pr** after all changes are done.
-
-**Verify**: On a feature branch (not master/main).
-
----
-
-### implement
-
-The test-first rule depends on what the change is:
-
-- **Bug fix**: write a failing test first (e2e or unit, whichever is appropriate), then fix the bug.
-- **New behavior** — anything that fails at runtime if it's wrong: new endpoints or routes, new services or modules, configuration paths, environment variables, secrets wiring, network connectivity, data persistence (migrations, preStart scripts, schema changes), auth/OIDC flows. Write an integration or unit test covering the new behavior **before** implementing. NixOS service modules need a VM test; new HTTP endpoints need an e2e or integration test; new modules with logic need at least a unit test.
-- **Otherwise** — documentation, refactors with no behavioral change, purely internal cleanups, dependency bumps that don't change behavior. Just implement the planned changes; no test-first requirement.
-
-If you're not sure which bucket the change falls into, treat it as new behavior. The cost of an unnecessary test is small; the cost of a silent deployment failure is not.
-
-Prefer simplicity. Do the boring obvious thing.
-
-**E2E coverage**: When the change introduces multiple user-facing paths (e.g., a dialog that appears under different conditions), write e2e scenarios for **each distinct path**. Enumerate the user-visible paths, then check that every one has a corresponding test.
-
-**Verify**: Code changes match the planned approach. For bug fixes and new-behavior changes, at least one test exercises the changed behavior; multi-path changes have one test per distinct user-visible path. Refactor/docs/cleanup diffs are exempt.
-
----
-
-### check
-
-Read `.agency/do.md` and look for a `## Check command` section — a fast static-correctness gate (e.g. `tsc --noEmit`, `cargo check`, `cabal build`, `mypy`, `dune build @check`). Run it.
-
-This is the cheapest gate in the pipeline, so it runs first — fail fast on broken code before any downstream step does work over it. If no check command is documented, skip this step with a note.
-
-**Verify**: Check ran without errors, or no command configured.
-**If failed** (max 3 attempts): Fix the errors and re-run check. Do not fall back to **implement** — the agent is already in fix mode and the failure is local to just-written code.
-
----
-
-### docs
-
-**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **fmt**.
-
-Read `.agency/do.md` and look for a `## Documentation` section listing which docs to keep in sync (e.g., README.md). Compare those files against changes in this PR.
-
-If no documentation files are documented, skip this step with a note.
-
-**Verify**: Docs match current code.
-**If outdated** (max 3 attempts): Fix the outdated sections and re-verify.
-
----
-
-### fmt
-
-Read `.agency/do.md` and look for a `## Format command` section. Run it.
-
-If no format command is documented, skip this step with a note.
-
-**Verify**: Format command ran without error, or no command configured.
-
----
-
-### commit
-
-**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. Move to **hickey+lowy**. The working-tree changes stay uncommitted — that is the point.
-
-Create a NEW commit (never amend) with a conventional commit message for the primary implementation. Push to the feature branch with `git push -u origin <branch>` (sets upstream on first push).
-
-This is the **primary feature commit**. Downstream **hickey+lowy** and **police** steps produce their own follow-up commits — one per finding or violation addressed — which keeps the PR history a readable progression of "what was built, then what was refined" rather than a single opaque squash.
-
-**Verify**: `git log -1` shows a new commit on the feature branch, and it's pushed to remote.
-
----
-
-### hickey + lowy
-
-**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **police** (which will also skip under `--minimal`). Do not spawn either sub-agent.
-
-Invoke `hickey` and `lowy` as two **parallel sub-agents** via the harness's agent tool (`subagent_type: "hickey"` and `subagent_type: "lowy"`). On Claude Code this is the `Agent` tool. On opencode this is the `task` tool (with `subagent_type` parameter). On Codex this is the sub-agent spawning tool for delegated work. Invoking `/do` is explicit authorization to run these two review agents; do not wait for a second user prompt before spawning them.
-
-**Fallback, never skip.** If the harness cannot honor the model declared in the reviewer skill's frontmatter, run hickey and lowy as sub-agents on the available model instead — this is the expected path on harnesses that ignore Claude Code's `model:` skill extension (opencode, Codex, etc.). If a sub-agent invocation fails for harness/tooling reasons before producing a review, retry that reviewer once; if it still cannot produce a sub-agent review, run that review in the main model by loading the reviewer skill against the same diff. This fallback is slower and uses more main-context budget, but it is still the `/do` hickey+lowy step. Do not replace it with an informal/manual review, and do not mark the step `skipped` because a preferred model was unavailable.
-
-**Why post-implement, not pre-implement.** Hickey's complecting critique and Lowy's volatility lens both bite harder on a concrete diff than on a plan sketch. Reviewing a plan tends to surface generic concerns; reviewing a real diff surfaces the specific interleavings and boundary misalignments that matter. Running here also means the review covers *everything* the diff contains — including whatever the plan glossed over and whatever drifted during implementation.
-
-<use_parallel_tool_calls>
-For maximum efficiency, invoke the `hickey` and `lowy` Agent tools **in parallel** rather than sequentially. You MUST use parallel tool calls: emit both `Agent` tool_use blocks (one with `subagent_type: "hickey"`, one with `subagent_type: "lowy"`) in a single response, with no other tool calls or text in that response.
-</use_parallel_tool_calls>
-
-Each `Agent` prompt must be self-contained (sub-agents do not inherit this conversation's context). Brief each one with:
-
-- The full task prompt plus anything relevant that **research** uncovered (file paths, intended approach, key constraints)
-- The scope to analyze: the actual diff, `git diff origin/HEAD...HEAD` — this is the same scope regardless of entry point (default or followup), since the branch at this point holds the primary feature commit (plus any cumulative followup commits) and no further work is pending
-- **Duplication-audit hint**, when the diff adds new files — check with `git diff --diff-filter=A --name-only origin/HEAD...HEAD` and only include the hint if the output is non-empty. The hint tells the reviewer to start with the codebase survey their skill describes (`hickey` Layer 3, `lowy` §1 "Check for prior encapsulation"): find the canonical in-repo pattern for the same *kind* of operation (picker, dialog, popover, list view, list-edit primitive, scheduler, error type, config loader, fetcher, …) and flag it as the headline finding if the diff reinvents rather than extends it. Skip the hint entirely when the diff has no new files — pure refactors and bug fixes inside existing abstractions don't benefit from the survey and the audit budget isn't worth it there.
-
-The sub-agent already knows to read its skill file and follow that methodology; don't re-state it in the prompt.
-
-**Do not seed structural questions.** The implementer's prompt must NOT include pre-formed questions like _"Is module X the right home for function Y?"_, _"Does the new field complect concerns A and B?"_, or _"Should constructor C be a sum?"_ — that framing shopping-lists the answer and produces circular reasoning at the reviewer (e.g. "primary consumer of `logPathFor` is `CommitStatus`" — true only because the implementer placed it there). Hickey and Lowy each have their own methodologies for generating findings; the reviewer reads the diff cold and surfaces what its lens shows. Anything beyond "here's the diff and the change rationale" is implementer bias bleeding into the review. If a specific concern feels worth flagging to the reviewer, that's evidence the implementer already smelled the problem — fix it in the diff before sending it to review, not by routing the question through a sub-agent for permission.
-
-The **duplication-audit hint** above is the one allowed exception: it's a meta-process reminder (run the survey your skill describes), not a seeded finding about *this* diff. It points the reviewer at the codebase, not at a specific concern within the diff — that's the line. If the diff doesn't add new files, drop the hint and let the lens run unprimed.
-
-**Model selection lives in the skill, not here.** Both `hickey/SKILL.md` and `lowy/SKILL.md` declare `model: sonnet` in their frontmatter — Claude Code honors this and runs the review on Sonnet to keep the per-task cost cheap; opencode/Codex ignore the field (it isn't part of the Agent Skills standard) and fall through to the active model, which is the right behavior for harnesses that don't have Sonnet. Don't pass `model:` at the `Agent` tool level — the skill frontmatter is the single source of truth.
-
-**No deferrals.** The hickey and lowy skills emit two dispositions: **Fix in this PR** and **No-op**. There is no Defer. `/do` is not optimizing for minimal diff — it is optimizing for the simpler artifact landing in `master`. A PR that grows from 50 lines to 400 because hickey caught a real fragmentation bug is a *better* PR, not a worse one; the alternative is shipping the complected version and trusting a "broader refactor" follow-up that statistically never happens.
-
-If a sub-agent emits anything resembling a defer — `Defer #N`, "out of scope", "follow-up", "pre-existing, separate PR", "should be its own change", any phrasing that punts a finding to a future issue — treat it as a sub-agent rule violation. Flip the disposition to **Fix in this PR** unconditionally and apply the fix here. Do not create a follow-up issue, do not record the finding as deferred in the PR body, do not surface it as outstanding structural debt. The only way out of a finding is through it.
-
-(`No-op` survives without code action — but it is narrow: the diff already deletes the offending code, or the finding is subsumed verbatim by another entry in the same review. Anything resembling deferred-work-for-later is a Fix, not a No-op.)
-
-Findings that genuinely require coordination outside this repo (upstream library bug, breaking dep upgrade, schema migration that must ship separately) shouldn't have surfaced as findings of this structural review in the first place; if one did, apply a local workaround or interface boundary in this PR rather than punt — and flag the upstream dependency in the PR description as a strategic note, not as a deferred finding.
-
-**Cross-validate the parallel findings.** Hickey and Lowy ran in parallel without seeing each other's output. Each reviewer's local-optimum call can produce a problem the other lens should have caught — a Lowy "consolidate `helper` into module X" can land in a destination that Hickey would have flagged as two volatility axes braided into one module, and a Hickey "decompose interleaved roles" split can land both halves into modules whose imports Lowy would have called fragmentation. Neither lens, running alone, sees the cross-effect.
-
-Skip this phase if **both** reviewers returned zero findings — there is nothing for the other lens to second-guess. Otherwise, for each reviewer that produced findings, spawn a second invocation of *that same skill* (`subagent_type: "hickey"` or `subagent_type: "lowy"`) with a self-contained prompt containing:
-
-- The actual diff (`git diff origin/HEAD...HEAD`).
-- The other reviewer's full findings output (paste it verbatim — the cross-validator must see the recommendations being audited, not a summary).
-- The question, phrased neutrally: _"Apply your lens to the diff **and** to the other reviewer's recommendations. Does any recommendation, if applied, create a problem your lens would flag? If yes, surface it as a new finding with the same Actions disposition rules (Fix in this PR / No-op, no Defer)."_
-
-Run the two cross-validation calls in parallel (single message, both `Agent` blocks). Each call is cheap because the diff and the other-side findings fit in one prompt. If either cross-validator surfaces a new finding, treat it identically to a first-pass finding — apply as its own commit per the rules below, with commit prefix `refactor(hickey)`/`refactor(lowy)` and a short label indicating it came from cross-validation (e.g. `refactor(hickey): cross-validate — placement audit on logPathFor`).
-
-After the audit (and cross-validation, when run), every finding lands as a commit, except entries dispositioned **No-op**.
-
-**Apply each "Fix in this PR" finding as its own commit** — do not batch multiple findings into one commit. A reviewer reading the PR's commit history should be able to read one "address hickey finding: decomplect viewportDimensions" commit at a time and follow the structural refinement as a sequence, not decode a grab-bag diff. For each finding in turn:
-
-1. Apply the fix narrowly — only the lines that address this specific finding.
-2. Run the project's format command (from **fmt** instructions) on the changed files, if one is configured.
-3. `git add <changed files>` — stage only the files this fix touched.
-4. `git commit -m "refactor(hickey): <short finding label>"` (or `refactor(lowy): …` depending on the lens). The body of the message should restate the finding in one line so the commit is self-explanatory in `git log`.
-5. `git push` — push after each commit so the draft PR (once created) accumulates commits in real time. (The `-u` flag is only needed on the first push, which already happened in **commit**.)
-
-**Under `--no-git`**: Skip the commit/push steps entirely. Apply fixes to the working tree and move on — the user will review the combined working-tree delta themselves. Record the step as passed with verification noting "--no-git: fixes applied to working tree, not committed."
-
-**Verify**: Both hickey and lowy produced review output using their respective skills, either through sub-agents or the main-model fallback. Cross-validation ran (or was correctly skipped because both reviewers returned zero findings). Every finding — first-pass or cross-validation — has an action recorded, either **Fix in this PR** or **No-op** (no defers; if the sub-agent emitted one, the audit step above flipped it to Fix in this PR). Every "Fix in this PR" finding has a corresponding commit on the feature branch (check via `git log origin/HEAD..HEAD --oneline`), except under `--no-git`. No unactioned findings; no deferred findings.
-
----
-
-### police
-
-**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **test**. Do not invoke `/code-police`.
-
-Use `git diff origin/HEAD...HEAD --name-only` to check if the PR contains code changes. If all changed files are documentation-only (e.g., `.md`, `.txt`, `README`, docs/) — skip this step with a note.
-
-Otherwise, invoke the `/code-police` skill via the Skill tool. It runs three passes: rule checklist, fact-check, and elegance (which delegates to `/simplify` when available).
-
-When `/code-police` asks about scope: **changes in the current branch/PR only**.
-
-**Commit each violation fix individually.** The same rule as **hickey + lowy**: PR history is the story of the work, and a reviewer should see one commit per rule violation or elegance refinement, not a lump "police pass" commit covering eight unrelated things.
-
-For each violation reported by `/code-police` (across all three passes), in turn:
-
-1. Apply the fix for that one violation — scope the edit tightly.
-2. Run the project's format command on changed files, if configured.
-3. `git add <changed files>` — stage only this fix.
-4. Commit with a conventional prefix identifying the pass and rule:
-   - Rules pass: `fix(police): <rule-id> — <short description>` (e.g. `fix(police): no-dead-code — remove commented-out fallback`)
-   - Fact-check pass: `fix(police): fact-check — <short description>` (e.g. `fix(police): fact-check — propagate error from loader`)
-   - Elegance pass (`/simplify`-applied or inline-loop-applied): `refactor(police): elegance — <short description>`
-5. `git push`.
-
-For the elegance pass specifically: `/simplify` applies fixes in batches across three lenses (reuse, quality, efficiency). Commit each distinct refactor as a separate commit — do not roll them into one "elegance" commit. If a lens produces multiple independent changes (two reuse-via-helper refactors in different files, say), those are separate commits too.
-
-**Under `--no-git`**: Skip the commit/push steps. Apply fixes to the working tree and continue. The user reviews the combined delta.
-
-**Verify**: All 3 passes clean ("All clear"). Under `--no-git`, the tree reflects the fixes; otherwise `git log origin/HEAD..HEAD --oneline` shows one commit per violation addressed.
-**If violations found** (max 3 attempts): Fix the violations (one commit per fix, as above) and re-invoke `/code-police`.
-
----
-
-### test
-
-Read `.agency/do.md` and look for a `## Test command` section. Run only the tests relevant to the code paths changed in this PR.
-
-Use `git diff origin/HEAD...HEAD --name-only` to identify changed files and determine which tests are relevant.
-
-If changes are purely internal with no user-facing impact, unit tests may suffice — skip e2e if no relevant scenarios exist. If no test command is documented, skip with a note.
-
-**Coverage gap check**: After the test command exits 0, confirm at least one of the tests run actually exercised the new behavior (per the **implement** step's classification). A green run that didn't touch the changed code paths — e.g. a new NixOS service module with no corresponding VM test, or a new endpoint with no integration test — is a coverage gap, not a pass. Refactor/docs/internal-cleanup diffs are exempt. The implement step should have caught this; if it didn't, treat it as a real failure: write the missing test, then loop through **fmt** → **commit** → **test** as below.
-
-**Verify**: Tests pass (exit code 0) **and** the new behavior is covered, or the diff is exempt from the coverage check, or no relevant tests to run.
-**If failed** (max 4 attempts): Analyze the failure. If flaky, re-run. If real: fix → go to **fmt**, then retry.
-
----
-
-### create-pr
-
-**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to create. Proceed to **ci**.
-
-**If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. (Bitbucket `bkt pr edit` wiring is tracked in #10.) Proceed to **ci**.
-
-**If `forge == github`**:
-
-Check whether a PR already exists for this branch (`gh pr view`).
-
-**If no PR exists** (first run, normal path):
-
-1. Create a draft PR: `gh pr create --draft`
-
-   **MANDATORY**: Load the `forge-pr` skill (via Skill tool) BEFORE writing the PR title/body.
-
-2. **Post hickey/lowy results**: Post the hickey and lowy analysis as a PR comment using `gh pr comment` with a `## [Hickey/Lowy](https://kolu.dev/blog/hickey-lowy/) Analysis` header (the heading links to the blog post explaining the two lenses, mirroring how the final step status comment links `/do` to the agency repo). Always post when the steps ran — reviewers should see the structural analysis even if every finding was a No-op.
-
-   **Format the comment with a leading findings ledger.** Compose a single table from both sub-agents' Actions sections — one row per finding — so a reviewer can see disposition at a glance without parsing paragraphs. Put each lens's prose underneath as rationale:
-
-   ```md
-   ## [Hickey/Lowy](https://kolu.dev/blog/hickey-lowy/) Analysis
-
-   | # | Lens   | Finding                                  | Disposition         |
-   |---|--------|------------------------------------------|---------------------|
-   | 1 | Hickey | viewportDimensions complects two roles   | Fixed in this PR    |
-   | 2 | Lowy   | useViewport encapsulates ghost concern   | Fixed in this PR    |
-   | 3 | Lowy   | clipboard.ts named after a consumer      | ⚠️ **No-op**        |
-
-   ### Hickey rationale
-   <prose from the hickey sub-agent>
-
-   ### Lowy rationale
-   <prose from the lowy sub-agent>
-   ```
-
-   The Disposition cell mirrors the sub-agent's Actions disposition verbatim — **Fixed in this PR** or **No-op** (deletion-only / subsumed by another finding). **Render every No-op as `⚠️ **No-op**`** (warning emoji + bold) so the reviewer's eye lands on it; No-op rows are the ones a human most needs to scrutinize (a finding the reviewer acknowledged but didn't fix), and plain text lets them blend into the Fixed-in-this-PR rows above. There is no Deferred disposition; if a sub-agent emitted one, the audit step above flipped it to Fixed in this PR. The Finding cell is the short bolded label the sub-agent emits at the start of each Actions entry. If both lenses produced zero findings, write a one-line "No findings — analysis below" instead of an empty table.
-
-**If PR already exists** (followup runs, `--from` entry points):
-
-Re-check the PR title/body against current scope. If scope changed, update via `gh pr edit` per the `forge-pr` skill.
-
-**Why this runs before `ci`**: The draft PR is the canonical home for CI status. Opening it before CI runs means CI checks land directly on the PR, reviewers see the run history as it happens, and a failing run doesn't leave an orphaned branch with red statuses and no PR to explain them. If retries exhaust in **ci**, the draft PR remains as the artifact of the failed attempt — visible, reviewable, and ready to resume via `--from ci-only`.
-
-**Verify**: Draft PR exists (`gh pr view` succeeds), PR title/body matches the delivered scope, hickey/lowy findings posted if any.
-
----
-
-### ci
-
-Read `.agency/do.md` and look for a `## CI command` section, plus any verification method documented there. Run CI with `run_in_background: true` if the command takes more than a few seconds.
-
-**Never pipe CI to `tail`/`head`**, and **never append `2>&1`** — background mode captures both streams.
-
-**Active state**: Before waiting for background CI, run `scripts/do-results set active waiting`. When CI returns (success or failure), run `scripts/do-results set active working` before proceeding. This lets the stop hook allow graceful exits while the agent is idle.
-
-CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are forge-independent — **run them regardless of forge**. Only the *verification method* may be forge-specific: if `.agency/do.md` describes verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output for verification on non-GitHub forges, and note this in the step record. (Bitbucket `bkt pr checks` wiring is tracked in #10.)
-
-**Verify**: Use the verification method described in `.agency/do.md` (e.g., checking commit statuses on GitHub, reading CI output elsewhere). If no CI command is documented, skip with a note. **The CI result must cover `HEAD`.** Before recording the step as passed, compare the commit SHA that CI ran against with `git rev-parse HEAD`. If they differ (e.g., a commit was pushed after CI started — whether from a fix retry, user-requested changes, or any other source), re-run CI against the current HEAD. CI passing on a stale commit does not satisfy verification.
-
-**On failure** — read logs or output to diagnose.
-
-**Flaky vs real**: A test is flaky only if it **passes on a subsequent retry**. Consistent failure = real bug. Before retrying, read the failing test code to judge if the failure pattern is inherently flaky (race conditions, timing, async waits).
-
-**If flaky** (max 3 retries): Retry just the failing step.
-**If real bug** (max 5 fixes): Fix → **fmt** → **commit** → retry CI. Under `--no-git`, drop **commit** from the loop (Fix → **fmt** → retry CI). The draft PR already exists — subsequent pushes update it automatically, no re-run of **create-pr** needed.
-**If retries exhausted**: Set workflow status to `"failed"`, skip to **done**. The draft PR stays open as the record of the failed attempt.
-
----
-
-### evidence
-
-**Opt-in step.** Most projects skip this. The step exists so projects with empirical "did the feature actually work" needs — UI screenshots, performance benchmarks, demo recordings, output transcripts — can attach that evidence to the PR without baking the mechanism into agency.
-
-**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **done**.
-
-**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to attach evidence to.
-
-**If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. (Bitbucket comment wiring is tracked in #10.)
-
-**Otherwise**: Read `.agency/do.md` and look for a `## PR evidence` section. If `.agency/do.md` is missing, or the section is missing or empty, skip with status `skipped` and reason `"no PR evidence section in .agency/do.md"` — the default for projects that haven't opted in.
-
-**If the section is present**:
-
-The section is project-specific and free-form: it can be inline prose describing the capture procedure, a pointer to another file (`See ./scripts/capture-evidence.md`), a script reference (`Run ./scripts/capture-pr-evidence.sh and use its stdout`), or any combination. Don't second-guess the form — read it, then **spawn a sub-agent** (`Agent(subagent_type: "general-purpose", ...)`) so the capture work (MCP calls, screenshot uploads, gh API requests) doesn't pollute `/do`'s main context.
-
-The sub-agent prompt should include:
-
-- The literal section content from `.agency/do.md`.
-- Standard PR context: PR URL, branch name, base branch, current commit SHA, and `git diff origin/HEAD...HEAD --name-only` so the sub-agent knows which routes/files to exercise.
-- An explicit instruction that the sub-agent's job is to return a single block of markdown (image links embedded, table data inline, etc.) suitable for posting under a `## Evidence` heading. The sub-agent should not post the comment itself — only return the markdown.
-
-After the sub-agent returns, post its output as one PR comment using `gh pr comment` under a `## Evidence` heading. Use the **single-quoted heredoc** pattern (see `forge-pr` → "Passing the body to `gh` safely") so backticks and `$` survive unescaped:
-
-```sh
-gh pr comment --body "$(cat <<'EOF'
-## Evidence
-
-<markdown returned by the sub-agent>
-EOF
-)"
-```
-
-Embed image/asset URLs inline in the markdown — `gh pr comment` itself cannot attach files; the workflow section is responsible for telling the sub-agent how to host any binary artifacts so they end up referenceable.
-
-**Verify**: Either the step was skipped per the rules above, or a `## Evidence` PR comment exists (`gh pr view --comments` or equivalent) populated from the sub-agent's output.
-
----
-
-### done
-
-Present a summary of all steps with their verification status. If any step has a non-success status, retry it (max 3 attempts from done). If still failing after retries, set `status: "failed"`.
-
-`"completed"` requires **all steps `passed`**, with four exceptions that count toward completion:
-
-1. A step `skipped` with `reason` beginning `"non-<forge> forge:"` (detected forge isn't GitHub).
-2. A step `skipped` with `reason` `"--no-git"` (user opted out of git operations).
-3. A step `skipped` with `reason` `"no PR evidence section in .agency/do.md"` (project hasn't opted into the evidence step — this is the default).
-4. A step `skipped` with `reason` `"--minimal"` (user opted out of structural review / docs / quality gate / evidence on a trivial diff).
-
-A `failed` step always blocks `"completed"`. No redefining "passed," no footnote caveats. Update via `scripts/do-results set status completed` or `scripts/do-results set status failed` accordingly.
-
-#### Timing summary
-
-Run `scripts/steps/done` in this skill's directory. It emits:
-
-1. A markdown timing table (step, status, duration, verification), with any step that took ≥30% of total time shown in **bold**.
-2. A total wall-clock line (`startedAt` of first step → `completedAt` of last step).
-3. A `**Slowest step**:` line.
-4. A `<<<FACTS ... FACTS` block with machine-readable summary data (`totalSeconds`, `slowestStep`, `slowestSeconds`, `dominantSteps`, `skippedSteps`, `failedSteps`) — use this to compose optimization suggestions below.
-
-Do not compute durations yourself — the script handles all timestamp arithmetic.
-
-#### Optimization suggestions
-
-Read the `FACTS` block the `done` script emitted and generate 2–4 concrete suggestions for reducing time-to-completion in future runs. Base these on the actual timing data — for example:
-
-- If **ci** dominates: suggest `--from ci-only` for re-runs, or note which CI sub-step was slowest
-- If **research** was slow: suggest pre-reading relevant code before invoking `/do`
-- If **test** had retries: note the flaky test and suggest hardening it
-- If **police** required fix iterations: note which pass caught issues (rules/fact-check/elegance)
-- If **implement** was the bottleneck: suggest breaking the task into smaller PRs
-
-Be specific to this run's data, not generic advice.
-
-#### PR comment & wrap-up
-
-**If `--no-git`**: There is no branch or PR to report against. Print the timing table and optimization suggestions to the terminal only. List the files modified in the working tree (`git status --porcelain`) so the user can see what the agent touched. Remind the user that changes are uncommitted — the commit/push/PR steps are theirs to run.
-
-**If `forge != github`**: Report the branch name (and remote URL, if available via `git remote get-url origin`) instead of a PR URL. Print the timing table and optimization suggestions to the terminal only — do **not** attempt to post a PR comment. (Bitbucket `bkt pr comment` wiring is tracked in #10.)
-
-**If `forge == github`**: Report the PR URL. Then post the final step status table as a **PR comment** using `gh pr comment`. Use the markdown table and slowest-step line emitted by `scripts/steps/done` verbatim (strip the trailing `<<<FACTS ... FACTS` block — that's internal). Format:
-
-```
-gh pr comment --body "$(cat <<'COMMENT'
-## [`/do`](https://github.com/srid/agency) results
-
-| Step | Status | Duration | Verification |
-|------|--------|----------|-------------|
-| sync | ✓ | 3s | ... |
-| research | ✓ | 45s | ... |
-...
-| **Total** | | **4m 32s** | |
-
-### Optimization suggestions
-
-- <2–4 concrete suggestions based on timing data>
-
-Workflow completed at <timestamp>.
-COMMENT
-)"
-```
-
----
+- **Retries stay `in_progress`.** Do not flicker the task state during retry loops.
+- **Skipped steps that stay in the list** (e.g. `branch` under `--no-git`) go straight to `completed`.
+- **`--minimal` skips are omitted from the list entirely.**
+- **Failure**: leave the failing step `in_progress`, mark `done` `completed` after the summary, and run `do-driver set status failed`.
 
 ## Entry Points
 
-| ID               | Starts at             | Use case                                |
-| ---------------- | --------------------- | --------------------------------------- |
-| `default`        | **sync**              | Full workflow from scratch              |
-| `followup`       | **implement**         | Additional changes on existing PR       |
-| `post-implement` | **fmt**               | Skip research/impl, start at formatting |
-| `polish`         | **hickey+lowy**       | Structural review + quality gate        |
-| `ci-only`        | **ci**                | Just run CI                             |
+| ID | Starts at | Use case |
+| -- | --------- | -------- |
+| `default` | sync | Full workflow from scratch |
+| `followup` | implement | Additional changes on existing PR |
+| `post-implement` | fmt | Skip research/impl, start at formatting |
+| `polish` | hickey-lowy | Structural review + quality gate |
+| `ci-only` | ci | Just run CI |
 
 ## Rules
 
 - **Never skip steps** (unless skipped by `--no-git`, forge detection, or — for **evidence** — the project hasn't filled in a `## PR evidence` section in `.agency/do.md`). Run them in order from entry point to **done**.
 - **Every commit is NEW.** Never amend, rebase, or force-push.
-- **Feature branches only.** Never commit to master/main. (Under `--no-git`, no commits happen at all, so this rule is moot — the agent leaves the user on whatever branch they started on.)
+- **Feature branches only.** Never commit to master/main.
 - **Background for CI.** Run CI with `run_in_background: true`.
 - **No questions.** Don't use `AskUserQuestion` outside the `--review` plan pause (post-research).
 - **Never stop between steps.** After completing a step, immediately proceed to the next one.
-- **Complete the full workflow.** Implementing code is one step of many. The task is not done until a PR URL (GitHub), a pushed branch name (non-GitHub forges), or a working-tree summary (`--no-git`) is reported.
-- **Exhausted retries = halt.** If `ci` or `test` retries are exhausted, set status to `"failed"` and skip to **done**. On `ci` failure the draft PR (opened in the preceding **create-pr** step) stays open as the record of the failed attempt — do not close, undraft, or otherwise mutate it.
-
-ARGUMENTS: $ARGUMENTS
+- **Complete the full workflow.** The task is not done until a PR URL (GitHub), a pushed branch name (non-GitHub forges), or a working-tree summary (`--no-git`) is reported.
+- **Exhausted retries = halt.** If `ci` or `test` retries are exhausted, set status to `"failed"` and skip to **done**.

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -8,6 +8,8 @@ argument-hint: "<issue-url | prompt> [--review] [--no-git] [--minimal] [--from <
 
 Take a task and do it top-to-bottom: research, branch, implement, pass CI, open a PR, and ship. (Under `--no-git`, extend the working tree in place — no branch, commit, or PR.)
 
+> All paths in this skill are relative to the skill's base directory.
+
 **This is a workflow graph.** The graph lives in [`execution.md`](execution.md); each step is a node file under [`nodes/`](nodes/); reusable shapes live under [`patterns/`](patterns/). The agent is the runtime — there is no separate engine.
 
 **Mostly autonomous.** Do NOT use `AskUserQuestion` at any point (except during the `--review` planning pause). Make sensible default choices and keep moving.

--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -21,7 +21,7 @@ Take a task and do it top-to-bottom: research, branch, implement, pass CI, open 
 5. For each step in order:
    - Call `scripts/do-driver start <step>`.
    - Read `nodes/<step>.md` and do the work.
-   - Call `scripts/do-driver end <step> <status> "<verification>" [reason]`.
+   - Call `scripts/do-driver end <status> "<verification>" [reason]`.
 6. Call `scripts/do-driver summary` to emit the timing table.
 
 ## Arguments
@@ -37,7 +37,7 @@ The workflow is **forge-aware**: it auto-detects whether the repo lives on GitHu
 
 ## Results Tracking
 
-Every node is bookended by `scripts/do-driver start <name>` before work and `scripts/do-driver end <name> <status> "<verification>" [reason]` after verification. The driver wraps `scripts/do-results`, which persists step records in `.do-results.json`.
+Every node is bookended by `scripts/do-driver start <name>` before work and `scripts/do-driver end <status> "<verification>" [reason]` after verification. The driver wraps `scripts/do-results`, which persists step records in `.do-results.json`.
 
 **Trust the driver's stdout.** Every mutation echoes a one-line confirmation.
 

--- a/.apm/skills/do/execution.md
+++ b/.apm/skills/do/execution.md
@@ -23,9 +23,9 @@ call implement
   plan: research.plan
 
 # Cheapest verification gate first
-call check                             # pattern: check-loop, max_attempts: 3
+call check                             # pattern: check-loop
 if not minimal:
-  call docs                            # pattern: check-loop, max_attempts: 3
+  call docs                            # pattern: check-loop
 
 call fmt                               # one-shot, no retry pattern
 
@@ -34,17 +34,15 @@ if not noGit:
 
 # Structural review fanout (post-implement, on a concrete diff)
 if not minimal:
-  call hickey-lowy                     # pattern: fanout-fix, reviewers: [hickey, lowy]
-  call police                          # pattern: check-loop, loop_artifacts: commit-per-fix
+  call hickey-lowy                     # pattern: fanout-fix
+  call police                          # pattern: check-loop
 
-call test                              # pattern: check-loop, coverage_check: true
+call test                              # pattern: check-loop
 
 # Forge integration
 call create-pr                         # one-shot; skipped under --no-git or non-github
 
-call ci                                # pattern: check-loop, flaky_classification: true
-                                       # max_attempts: 5 real, flaky_budget: 3
-                                       # rerun_on_new_commit: true
+call ci                                # pattern: check-loop
 
 call evidence                          # opt-in; skipped unless .agency/do.md declares it
 
@@ -68,9 +66,9 @@ Read each node for its full rationale. The high-level reasoning:
 |------|---------|-----|
 | check | check-loop | Run a verification command; on failure, fix the just-written code and retry. |
 | docs | check-loop | Verify docs match code; on staleness, update and re-verify. |
-| police | check-loop (`loop_artifacts: commit-per-fix`) | `/code-police` reports violations; each fix is its own commit. |
-| test | check-loop (`coverage_check: true`, `loop_artifacts: commit-per-fix`) | Run tests; on real failure, fix + commit + retry. Coverage check verifies the new behavior is actually exercised. |
-| ci | check-loop (`flaky_classification: true`, `flaky_budget: 3`, `loop_artifacts: commit-per-fix`, `rerun_on_new_commit: true`) | CI flakes are expected; real failures get fix + commit + retry. CI on a stale SHA does not satisfy verification. |
+| police | check-loop | `/code-police` reports violations; each fix is its own commit. |
+| test | check-loop | Run tests; on real failure, fix + commit + retry. Coverage check verifies the new behavior is actually exercised. |
+| ci | check-loop | CI flakes are expected; real failures get fix + commit + retry. CI on a stale SHA does not satisfy verification. |
 | hickey-lowy | fanout-fix | Two reviewers in parallel; one commit per finding. |
 
 ## Entry points

--- a/.apm/skills/do/execution.md
+++ b/.apm/skills/do/execution.md
@@ -1,0 +1,101 @@
+# Execution
+
+The pinned order /do walks. Each step name refers to a node file (e.g. `sync` → `nodes/sync.md`). Conditional skips are baked into each node's `### Strategies`; this file shows the order, the high-level branches, and which patterns each node instances.
+
+This file is the **system-level Execution block** — the single source of truth for workflow topology. The graph lives here and only here; node files describe what to do when they run, not where to go next.
+
+## Order
+
+```prose
+# Coordination + research
+call sync
+call research
+if review:
+  call plan-approval
+    plan: research.plan
+
+# Local in-place work
+if not noGit:
+  call branch
+    default_branch: sync.default_branch
+
+call implement
+  plan: research.plan
+
+# Cheapest verification gate first
+call check                             # pattern: check-loop, max_attempts: 3
+if not minimal:
+  call docs                            # pattern: check-loop, max_attempts: 3
+
+call fmt                               # one-shot, no retry pattern
+
+if not noGit:
+  call commit                          # one-shot
+
+# Structural review fanout (post-implement, on a concrete diff)
+if not minimal:
+  call hickey-lowy                     # pattern: fanout-fix, reviewers: [hickey, lowy]
+  call police                          # pattern: check-loop, loop_artifacts: commit-per-fix
+
+call test                              # pattern: check-loop, coverage_check: true
+
+# Forge integration
+call create-pr                         # one-shot; skipped under --no-git or non-github
+
+call ci                                # pattern: check-loop, flaky_classification: true
+                                       # max_attempts: 5 real, flaky_budget: 3
+                                       # rerun_on_new_commit: true
+
+call evidence                          # opt-in; skipped unless .agency/do.md declares it
+
+call done                              # one-shot; emits timing table + status
+```
+
+## Why this order
+
+Read each node for its full rationale. The high-level reasoning:
+
+- **Cheap gates first** (`check` before `docs` before `fmt`) — fail fast on broken code before any downstream node does work over it. `check` is typically `tsc --noEmit` or `cargo check` or `cabal build`, which is the cheapest verification in the pipeline.
+- **`commit` before `hickey-lowy`** — reviewers operate on a real diff (`git diff origin/HEAD...HEAD`), not a plan. Reviewing a plan tends to surface generic concerns; reviewing a real diff surfaces the specific interleavings and boundary misalignments that matter.
+- **`fmt` before `commit`** — the primary feature commit should land already-formatted; downstream `hickey-lowy` and `police` commits each run `fmt` on their own changes inside the `commit-per-fix` loop.
+- **`create-pr` before `ci`** — the draft PR is the canonical home for CI status. Opening it before CI runs means CI checks land directly on the PR, reviewers see the run history as it happens, and a failing CI doesn't leave an orphaned branch with red statuses and no PR to explain them.
+- **`evidence` after `ci` passes** — capturing screenshots/benchmarks/transcripts of broken code wastes both the capture work and the reviewer's time.
+- **`done` last, always** — the timing table needs every node's bookend already recorded.
+
+## Patterns referenced
+
+| Node | Pattern | Why |
+|------|---------|-----|
+| check | check-loop | Run a verification command; on failure, fix the just-written code and retry. |
+| docs | check-loop | Verify docs match code; on staleness, update and re-verify. |
+| police | check-loop (`loop_artifacts: commit-per-fix`) | `/code-police` reports violations; each fix is its own commit. |
+| test | check-loop (`coverage_check: true`, `loop_artifacts: commit-per-fix`) | Run tests; on real failure, fix + commit + retry. Coverage check verifies the new behavior is actually exercised. |
+| ci | check-loop (`flaky_classification: true`, `flaky_budget: 3`, `loop_artifacts: commit-per-fix`, `rerun_on_new_commit: true`) | CI flakes are expected; real failures get fix + commit + retry. CI on a stale SHA does not satisfy verification. |
+| hickey-lowy | fanout-fix | Two reviewers in parallel; one commit per finding. |
+
+## Entry points
+
+| ID | Starts at | Use case |
+| -- | --------- | -------- |
+| `default` | sync | Full workflow from scratch |
+| `followup` | implement | Additional changes on existing PR |
+| `post-implement` | fmt | Skip research/impl, start at formatting |
+| `polish` | hickey-lowy | Structural review + quality gate |
+| `ci-only` | ci | Just run CI |
+
+Under `--from <step>`, seed the task list with all steps (minus `--minimal` omissions) and mark earlier steps as `completed` immediately.
+
+## Skip taxonomy
+
+Steps skipped with these reasons count toward workflow completion:
+
+| Reason prefix | Example | Counts? |
+|---------------|---------|---------|
+| `non-* forge:` | `non-github forge: bitbucket` | Yes |
+| `--no-git` | `--no-git` | Yes |
+| `--minimal` | `--minimal` | Yes |
+| `no PR evidence section` | `no PR evidence section in .agency/do.md` | Yes |
+| `no * command configured` | `no check command configured` | Yes |
+| `docs-only changes` | `docs-only changes` | Yes |
+
+Any other skip reason (or a `failed` step) blocks completion.

--- a/.apm/skills/do/nodes/branch.md
+++ b/.apm/skills/do/nodes/branch.md
@@ -1,0 +1,27 @@
+---
+name: branch
+description: Create a descriptive feature branch from origin/defaultBranch.
+---
+
+# Branch
+
+## Requires
+
+- `--no-git` flag
+- `defaultBranch` from sync
+
+## Ensures
+
+- Feature branch checked out
+
+## Strategies
+
+**If `--no-git`**: Skip this step entirely with status `skipped` and reason `"--no-git"`. Stay on the current branch — do not create, commit, or push anything. Move to the next step.
+
+Detect the default branch: `git symbolic-ref refs/remotes/origin/HEAD`
+
+1. Create a descriptive feature branch from `origin/<default>`
+
+That's it — just the local branch. No commit, no push, no PR. The branch is pushed later in **commit**, and the PR is created in **create-pr** after all changes are done.
+
+**Verify**: On a feature branch (not master/main).

--- a/.apm/skills/do/nodes/branch.md
+++ b/.apm/skills/do/nodes/branch.md
@@ -16,8 +16,6 @@ description: Create a descriptive feature branch from origin/defaultBranch.
 
 ## Strategies
 
-**If `--no-git`**: Skip this step entirely with status `skipped` and reason `"--no-git"`. Stay on the current branch — do not create, commit, or push anything. Move to the next step.
-
 Detect the default branch: `git symbolic-ref refs/remotes/origin/HEAD`
 
 1. Create a descriptive feature branch from `origin/<default>`

--- a/.apm/skills/do/nodes/check.md
+++ b/.apm/skills/do/nodes/check.md
@@ -1,0 +1,30 @@
+---
+name: check
+description: Fast static-correctness gate.
+---
+
+# Check
+
+## Requires
+
+- Implemented code
+
+## Ensures
+
+- Static correctness verified
+
+## Pattern
+
+Instances [check-loop](../../patterns/check-loop.md) with:
+- `runner`: read `.agency/do.md` for `## Check command`, run it
+- `fixer`: fix errors in just-written code
+- Config: `max_attempts: 3`
+
+## Strategies
+
+Read `.agency/do.md` and look for a `## Check command` section — a fast static-correctness gate (e.g. `tsc --noEmit`, `cargo check`, `cabal build`, `mypy`, `dune build @check`). Run it.
+
+This is the cheapest gate in the pipeline, so it runs first — fail fast on broken code before any downstream step does work over it. If no check command is documented, skip this step with a note.
+
+**Verify**: Check ran without errors, or no command configured.
+**If failed** (max 3 attempts): Fix the errors and re-run check. Do not fall back to **implement** — the agent is already in fix mode and the failure is local to just-written code.

--- a/.apm/skills/do/nodes/check.md
+++ b/.apm/skills/do/nodes/check.md
@@ -15,7 +15,7 @@ description: Fast static-correctness gate.
 
 ## Pattern
 
-Instances [check-loop](../../patterns/check-loop.md) with:
+Instances [check-loop](../patterns/check-loop.md) with:
 - `runner`: read `.agency/do.md` for `## Check command`, run it
 - `fixer`: fix errors in just-written code
 - Config: `max_attempts: 3`

--- a/.apm/skills/do/nodes/ci.md
+++ b/.apm/skills/do/nodes/ci.md
@@ -1,0 +1,42 @@
+---
+name: ci
+description: Run CI and verify it covers HEAD.
+---
+
+# CI
+
+## Requires
+
+- Changes in current branch
+- Draft PR created (if github)
+
+## Ensures
+
+- CI passes on current HEAD
+
+## Pattern
+
+Instances [check-loop](../../patterns/check-loop.md) with:
+- `runner`: read `.agency/do.md` for `## CI command`, run it
+- `fixer`: fix real bugs; retry flaky without fixing
+- Config: `max_attempts: 5`, `flaky_classification: true`, `flaky_budget: 3`, `loop_artifacts: commit-per-fix`, `rerun_on_new_commit: true`
+
+## Strategies
+
+Read `.agency/do.md` and look for a `## CI command` section, plus any verification method documented there. Run CI with `run_in_background: true` if the command takes more than a few seconds.
+
+**Never pipe CI to `tail`/`head`**, and **never append `2>&1`** — background mode captures both streams.
+
+**Active state**: Before waiting for background CI, run `scripts/do-results set active waiting`. When CI returns, run `scripts/do-results set active working` before proceeding.
+
+CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) and are **forge-independent — run them regardless of forge**. Only the *verification method* may be forge-specific: if `.agency/do.md` describes verification via `gh` commit-status checks and `forge != github`, fall back to exit code + command output.
+
+**Verify coverage of `HEAD`.** Before recording the step as passed, compare the commit SHA CI ran against with `git rev-parse HEAD`. If they differ, **re-run CI against the current HEAD**. CI passing on a stale commit does not satisfy verification.
+
+**On failure** — read logs or output to diagnose.
+
+**Flaky vs real**: A failure is flaky only if it **passes on a subsequent retry**. Consistent failure = real bug. Before retrying, read the failing test code to judge whether the pattern is inherently flaky.
+
+**If flaky** (max 3 retries): Retry just the failing step.
+**If real bug** (max 5 fixes): Fix → **fmt** → **commit** → retry CI. Under `--no-git`, drop **commit** from the loop.
+**If retries exhausted**: Record `status: failed`, halt. The draft PR stays open as the record of the failed attempt.

--- a/.apm/skills/do/nodes/ci.md
+++ b/.apm/skills/do/nodes/ci.md
@@ -16,7 +16,7 @@ description: Run CI and verify it covers HEAD.
 
 ## Pattern
 
-Instances [check-loop](../../patterns/check-loop.md) with:
+Instances [check-loop](../patterns/check-loop.md) with:
 - `runner`: read `.agency/do.md` for `## CI command`, run it
 - `fixer`: fix real bugs; retry flaky without fixing
 - Config: `max_attempts: 5`, `flaky_classification: true`, `flaky_budget: 3`, `loop_artifacts: commit-per-fix`, `rerun_on_new_commit: true`

--- a/.apm/skills/do/nodes/commit.md
+++ b/.apm/skills/do/nodes/commit.md
@@ -1,0 +1,26 @@
+---
+name: commit
+description: Create the primary feature commit and push.
+---
+
+# Commit
+
+## Requires
+
+- `--no-git` flag
+- Formatted code
+
+## Ensures
+
+- Primary feature commit on feature branch
+- Branch pushed to remote
+
+## Strategies
+
+**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. Move to the next step. The working-tree changes stay uncommitted — that is the point.
+
+Create a NEW commit (never amend) with a conventional commit message for the primary implementation. Push to the feature branch with `git push -u origin <branch>` (sets upstream on first push).
+
+This is the **primary feature commit**. Downstream **hickey-lowy** and **police** steps produce their own follow-up commits — one per finding or violation addressed — which keeps the PR history a readable progression of "what was built, then what was refined" rather than a single opaque squash.
+
+**Verify**: `git log -1` shows a new commit on the feature branch, and it's pushed to remote.

--- a/.apm/skills/do/nodes/commit.md
+++ b/.apm/skills/do/nodes/commit.md
@@ -17,8 +17,6 @@ description: Create the primary feature commit and push.
 
 ## Strategies
 
-**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. Move to the next step. The working-tree changes stay uncommitted — that is the point.
-
 Create a NEW commit (never amend) with a conventional commit message for the primary implementation. Push to the feature branch with `git push -u origin <branch>` (sets upstream on first push).
 
 This is the **primary feature commit**. Downstream **hickey-lowy** and **police** steps produce their own follow-up commits — one per finding or violation addressed — which keeps the PR history a readable progression of "what was built, then what was refined" rather than a single opaque squash.

--- a/.apm/skills/do/nodes/create-pr.md
+++ b/.apm/skills/do/nodes/create-pr.md
@@ -18,12 +18,6 @@ description: Open a draft PR on GitHub.
 
 ## Strategies
 
-**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to create. Proceed to the next step.
-
-**If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. Proceed to the next step.
-
-**If `forge == github`**:
-
 Check whether a PR already exists for this branch (`gh pr view`).
 
 **If no PR exists** (first run, normal path):

--- a/.apm/skills/do/nodes/create-pr.md
+++ b/.apm/skills/do/nodes/create-pr.md
@@ -1,0 +1,63 @@
+---
+name: create-pr
+description: Open a draft PR on GitHub.
+---
+
+# Create PR
+
+## Requires
+
+- `--no-git` flag
+- `forge` from sync
+- Primary feature commit pushed
+
+## Ensures
+
+- Draft PR exists
+- hickey/lowy findings posted as PR comment
+
+## Strategies
+
+**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`. There is no PR to create. Proceed to the next step.
+
+**If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`. Proceed to the next step.
+
+**If `forge == github`**:
+
+Check whether a PR already exists for this branch (`gh pr view`).
+
+**If no PR exists** (first run, normal path):
+
+1. Create a draft PR: `gh pr create --draft`
+
+   **MANDATORY**: Load the `forge-pr` skill (via Skill tool) BEFORE writing the PR title/body.
+
+2. **Post hickey/lowy results**: Post the hickey and lowy analysis as a PR comment using `gh pr comment` with a `## [Hickey/Lowy](https://kolu.dev/blog/hickey-lowy/) Analysis` header.
+
+   **Format the comment with a leading findings ledger.** Compose a single table from both sub-agents' Actions sections:
+
+   ```md
+   ## [Hickey/Lowy](https://kolu.dev/blog/hickey-lowy/) Analysis
+
+   | # | Lens   | Finding                                  | Disposition         |
+   |---|--------|------------------------------------------|---------------------|
+   | 1 | Hickey | viewportDimensions complects two roles   | Fixed in this PR    |
+   | 2 | Lowy   | useViewport encapsulates ghost concern   | Fixed in this PR    |
+   | 3 | Lowy   | clipboard.ts named after a consumer      | ⚠️ **No-op**        |
+
+   ### Hickey rationale
+   <prose>
+
+   ### Lowy rationale
+   <prose>
+   ```
+
+   The Disposition cell mirrors the sub-agent's Actions disposition verbatim — **Fixed in this PR** or **No-op** (deletion-only / subsumed by another finding). **Render every No-op as `⚠️ **No-op**`** (warning emoji + bold) so the reviewer's eye lands on it; No-op rows are the ones a human most needs to scrutinize (a finding the reviewer acknowledged but didn't fix), and plain text lets them blend into the Fixed-in-this-PR rows above. There is no Deferred disposition; if a sub-agent emitted one, the audit step above flipped it to Fixed in this PR. The Finding cell is the short bolded label the sub-agent emits at the start of each Actions entry. If both lenses produced zero findings, write a one-line "No findings — analysis below" instead of an empty table.
+
+**If PR already exists** (followup runs, `--from` entry points):
+
+Re-check the PR title/body against current scope. If scope changed, update via `gh pr edit` per the `forge-pr` skill.
+
+**Why this runs before `ci`**: The draft PR is the canonical home for CI status. Opening it before CI runs means CI checks land directly on the PR, reviewers see the run history as it happens, and a failing run doesn't leave an orphaned branch with red statuses and no PR to explain them.
+
+**Verify**: Draft PR exists (`gh pr view` succeeds), PR title/body matches the delivered scope, hickey/lowy findings posted if any.

--- a/.apm/skills/do/nodes/docs.md
+++ b/.apm/skills/do/nodes/docs.md
@@ -16,7 +16,7 @@ description: Keep documentation in sync with code changes.
 
 ## Pattern
 
-Instances [check-loop](../../patterns/check-loop.md) with:
+Instances [check-loop](../patterns/check-loop.md) with:
 - `runner`: read `.agency/do.md` for `## Documentation`, compare listed files against changes
 - `fixer`: update outdated sections
 - Config: `max_attempts: 3`

--- a/.apm/skills/do/nodes/docs.md
+++ b/.apm/skills/do/nodes/docs.md
@@ -1,0 +1,33 @@
+---
+name: docs
+description: Keep documentation in sync with code changes.
+---
+
+# Docs
+
+## Requires
+
+- `--minimal` flag
+- Implemented code
+
+## Ensures
+
+- Documentation matches current code
+
+## Pattern
+
+Instances [check-loop](../../patterns/check-loop.md) with:
+- `runner`: read `.agency/do.md` for `## Documentation`, compare listed files against changes
+- `fixer`: update outdated sections
+- Config: `max_attempts: 3`
+
+## Strategies
+
+**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to the next step.
+
+Read `.agency/do.md` and look for a `## Documentation` section listing which docs to keep in sync (e.g., README.md). Compare those files against changes in this PR.
+
+If no documentation files are documented, skip this step with a note.
+
+**Verify**: Docs match current code.
+**If outdated** (max 3 attempts): Fix the outdated sections and re-verify.

--- a/.apm/skills/do/nodes/docs.md
+++ b/.apm/skills/do/nodes/docs.md
@@ -23,8 +23,6 @@ Instances [check-loop](../patterns/check-loop.md) with:
 
 ## Strategies
 
-**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to the next step.
-
 Read `.agency/do.md` and look for a `## Documentation` section listing which docs to keep in sync (e.g., README.md). Compare those files against changes in this PR.
 
 If no documentation files are documented, skip this step with a note.

--- a/.apm/skills/do/nodes/done.md
+++ b/.apm/skills/do/nodes/done.md
@@ -19,18 +19,20 @@ description: Timing summary, optimization suggestions, and wrap-up.
 
 Present a summary of all steps with their verification status. If any step has a non-success status, retry it (max 3 attempts from done). If still failing after retries, set `status: "failed"`.
 
-`"completed"` requires **all steps `passed`**, with four exceptions that count toward completion:
+`"completed"` requires **all steps `passed`**, with six exceptions that count toward completion:
 
 1. A step `skipped` with `reason` beginning `"non-<forge> forge:"`.
 2. A step `skipped` with `reason` `"--no-git"`.
 3. A step `skipped` with `reason` `"no PR evidence section in .agency/do.md"`.
 4. A step `skipped` with `reason` `"--minimal"`.
+5. A step `skipped` with `reason` beginning `"no * command configured"`.
+6. A step `skipped` with `reason` `"docs-only changes"`.
 
 A `failed` step always blocks `"completed"`.
 
 #### Timing summary
 
-Run `scripts/steps/done` in this skill's directory. It emits:
+Call `scripts/do-driver summary`. It delegates to `scripts/steps/done` and emits:
 
 1. A markdown timing table (step, status, duration, verification), with any step that took ≥30% of total time shown in **bold**.
 2. A total wall-clock line.

--- a/.apm/skills/do/nodes/done.md
+++ b/.apm/skills/do/nodes/done.md
@@ -1,0 +1,60 @@
+---
+name: done
+description: Timing summary, optimization suggestions, and wrap-up.
+---
+
+# Done
+
+## Requires
+
+- All prior steps completed
+
+## Ensures
+
+- Timing table emitted
+- Final PR comment posted (if github)
+- Workflow status set to completed or failed
+
+## Strategies
+
+Present a summary of all steps with their verification status. If any step has a non-success status, retry it (max 3 attempts from done). If still failing after retries, set `status: "failed"`.
+
+`"completed"` requires **all steps `passed`**, with four exceptions that count toward completion:
+
+1. A step `skipped` with `reason` beginning `"non-<forge> forge:"`.
+2. A step `skipped` with `reason` `"--no-git"`.
+3. A step `skipped` with `reason` `"no PR evidence section in .agency/do.md"`.
+4. A step `skipped` with `reason` `"--minimal"`.
+
+A `failed` step always blocks `"completed"`.
+
+#### Timing summary
+
+Run `scripts/steps/done` in this skill's directory. It emits:
+
+1. A markdown timing table (step, status, duration, verification), with any step that took ≥30% of total time shown in **bold**.
+2. A total wall-clock line.
+3. A `**Slowest step**:` line.
+4. A `<<<FACTS ... FACTS` block with machine-readable summary data.
+
+Do not compute durations yourself — the script handles all timestamp arithmetic.
+
+#### Optimization suggestions
+
+Read the `FACTS` block the `done` script emitted and generate **2–4 concrete suggestions** for reducing time-to-completion in future runs. Base these on the actual timing data — for example:
+
+- If **ci** dominates: suggest `--from ci-only` for re-runs.
+- If **research** was slow: suggest pre-reading relevant code before invoking `/do`.
+- If **test** had retries: note the flaky test and suggest hardening it.
+- If **police** required fix iterations: note which pass caught issues.
+- If **implement** was the bottleneck: suggest breaking the task into smaller PRs.
+
+Be specific to this run's data, not generic advice.
+
+#### PR comment & wrap-up
+
+**If `--no-git`**: Print the timing table and optimization suggestions to the terminal only. List files modified in the working tree (`git status --porcelain`). Remind the user that changes are uncommitted.
+
+**If `forge != github`**: Report the branch name (and remote URL via `git remote get-url origin`). Print timing table and suggestions to the terminal only.
+
+**If `forge == github`**: Report the PR URL. Then post the final step status table as a **PR comment** using `gh pr comment`.

--- a/.apm/skills/do/nodes/evidence.md
+++ b/.apm/skills/do/nodes/evidence.md
@@ -1,0 +1,43 @@
+---
+name: evidence
+description: Attach empirical evidence to the PR (opt-in).
+---
+
+# Evidence
+
+## Requires
+
+- `--minimal` flag
+- `--no-git` flag
+- `forge` from sync
+- CI passed
+
+## Ensures
+
+- Evidence posted as PR comment (if configured)
+
+## Strategies
+
+**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`.
+
+**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`.
+
+**If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`.
+
+**Otherwise**: Read `.agency/do.md` and look for a `## PR evidence` section. If missing or empty, skip with status `skipped` and reason `"no PR evidence section in .agency/do.md"`.
+
+**If the section is present**:
+
+The section is project-specific and free-form: inline prose, pointer to another file, script reference, or any combination. Read it, then **spawn a sub-agent** (`Agent`/`task` with `subagent_type: "general-purpose"`) so the capture work doesn't pollute `/do`'s main context.
+
+The sub-agent prompt should include:
+
+- The literal section content from `.agency/do.md`.
+- Standard PR context: PR URL, branch name, base branch, current commit SHA, and `git diff origin/HEAD...HEAD --name-only`.
+- An explicit instruction that the sub-agent's job is to return a single block of markdown suitable for posting under a `## Evidence` heading.
+
+After the sub-agent returns, post its output as one PR comment using `gh pr comment` under a `## Evidence` heading. Use the **single-quoted heredoc** pattern so backticks and `$` survive unescaped.
+
+Embed image/asset URLs inline in the markdown — `gh pr comment` itself cannot attach files.
+
+**Verify**: Either the step was skipped per the rules above, or a `## Evidence` PR comment exists.

--- a/.apm/skills/do/nodes/evidence.md
+++ b/.apm/skills/do/nodes/evidence.md
@@ -18,13 +18,7 @@ description: Attach empirical evidence to the PR (opt-in).
 
 ## Strategies
 
-**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`.
-
-**If `--no-git`**: Skip with status `skipped` and reason `"--no-git"`.
-
-**If `forge != github`**: Skip with status `skipped` and reason `"non-<forge> forge: <forge>"`.
-
-**Otherwise**: Read `.agency/do.md` and look for a `## PR evidence` section. If missing or empty, skip with status `skipped` and reason `"no PR evidence section in .agency/do.md"`.
+Read `.agency/do.md` and look for a `## PR evidence` section. If missing or empty, skip with status `skipped` and reason `"no PR evidence section in .agency/do.md"`.
 
 **If the section is present**:
 

--- a/.apm/skills/do/nodes/fmt.md
+++ b/.apm/skills/do/nodes/fmt.md
@@ -1,0 +1,22 @@
+---
+name: fmt
+description: Run the project's format command.
+---
+
+# Fmt
+
+## Requires
+
+- Code changes (implementation or fixes)
+
+## Ensures
+
+- Formatted code
+
+## Strategies
+
+Read `.agency/do.md` and look for a `## Format command` section. Run it.
+
+If no format command is documented, skip this step with a note.
+
+**Verify**: Format command ran without error, or no command configured.

--- a/.apm/skills/do/nodes/hickey-lowy.md
+++ b/.apm/skills/do/nodes/hickey-lowy.md
@@ -1,0 +1,69 @@
+---
+name: hickey-lowy
+description: Parallel structural review with hickey and lowy sub-agents.
+---
+
+# Hickey + Lowy
+
+## Requires
+
+- `--minimal` flag
+- `--no-git` flag
+- Diff `git diff origin/HEAD...HEAD`
+- Full task prompt + research context
+
+## Ensures
+
+- Review findings applied as individual commits (or working-tree fixes under --no-git)
+- Findings ledger for PR comment
+
+## Pattern
+
+Instances [fanout-fix](../../patterns/fanout-fix.md) with:
+- `reviewer_a`: `hickey` sub-agent
+- `reviewer_b`: `lowy` sub-agent
+- Config: `cross_validate: true`
+
+## Strategies
+
+**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to the next step. Do not spawn either sub-agent.
+
+Invoke `hickey` and `lowy` as two **parallel sub-agents** via the harness's agent tool (`subagent_type: "hickey"` and `subagent_type: "lowy"`). On opencode this is the `task` tool (with `subagent_type` parameter).
+
+**Fallback, never skip.** If the harness cannot honor the model declared in the reviewer skill's frontmatter, run hickey and lowy as sub-agents on the available model instead. If a sub-agent invocation fails for harness/tooling reasons before producing a review, retry that reviewer once; if it still cannot produce a sub-agent review, run that review in the main model by loading the reviewer skill against the same diff.
+
+**Why post-implement, not pre-implement.** Hickey's complecting critique and Lowy's volatility lens both bite harder on a concrete diff than on a plan sketch. Reviewing a plan tends to surface generic concerns; reviewing a real diff surfaces the specific interleavings and boundary misalignments that matter.
+
+<use_parallel_tool_calls>
+For maximum efficiency, invoke the `hickey` and `lowy` Agent tools **in parallel** rather than sequentially. You MUST use parallel tool calls: emit both `Agent`/`task` tool_use blocks in a single response, with no other tool calls or text in that response.
+</use_parallel_tool_calls>
+
+Each prompt must be self-contained. Brief each one with:
+
+- The full task prompt plus anything relevant that **research** uncovered
+- Scope: the actual diff, `git diff origin/HEAD...HEAD`
+- **Duplication-audit hint**, when the diff adds new files — check with `git diff --diff-filter=A --name-only origin/HEAD...HEAD` and only include the hint if the output is non-empty
+
+**Do not seed structural questions.** The implementer's prompt must NOT include pre-formed questions like _"Is module X the right home for function Y?"_
+
+**Model selection lives in the skill, not here.** Both skills declare `model: sonnet` in their frontmatter — Claude Code honors this; opencode/Codex ignore the field and fall through to the active model.
+
+**No deferrals.** There is no "Defer" disposition. `/do` is not optimizing for minimal diff — it is optimizing for the simpler artifact landing in `master`. A PR that grows because hickey caught a real fragmentation bug is a *better* PR.
+
+If a sub-agent emits anything resembling a defer, flip the disposition to **Fix in this PR** unconditionally and apply the fix here.
+
+**Cross-validate the parallel findings.** After first-pass reviews, for each reviewer that produced findings, spawn a second invocation of *that same skill* with a self-contained prompt containing the diff and the other reviewer's full findings output. Ask: _"Apply your lens to the diff **and** to the other reviewer's recommendations. Does any recommendation, if applied, create a problem your lens would flag?"_
+
+Run the two cross-validation calls in parallel. If either surfaces a new finding, treat it identically to a first-pass finding.
+
+**Apply each "Fix in this PR" finding as its own commit** — do not batch:
+
+1. Apply the fix narrowly — only the lines that address this specific finding.
+2. Run the project's format command on the changed files, if configured.
+3. `git add <changed files>` — stage only the files this fix touched.
+4. `git commit -m "refactor(hickey): <short finding label>"` (or `refactor(lowy): …`). Body restates the finding in one line.
+5. `git push` — push after each commit.
+
+**Under `--no-git`**: Skip commit/push. Apply fixes to working tree.
+
+**Verify**: Both hickey and lowy produced review output. Cross-validation ran (or skipped because zero findings). Every finding has action recorded: **Fix in this PR** or **No-op**. Every "Fix" has a corresponding commit, except under `--no-git`.

--- a/.apm/skills/do/nodes/hickey-lowy.md
+++ b/.apm/skills/do/nodes/hickey-lowy.md
@@ -20,8 +20,7 @@ description: Parallel structural review with hickey and lowy sub-agents.
 ## Pattern
 
 Instances [fanout-fix](../patterns/fanout-fix.md) with:
-- `reviewer_a`: `hickey` sub-agent
-- `reviewer_b`: `lowy` sub-agent
+- `reviewers`: [`hickey` sub-agent, `lowy` sub-agent]
 - Config: `cross_validate: true`
 
 ## Strategies

--- a/.apm/skills/do/nodes/hickey-lowy.md
+++ b/.apm/skills/do/nodes/hickey-lowy.md
@@ -25,8 +25,6 @@ Instances [fanout-fix](../patterns/fanout-fix.md) with:
 
 ## Strategies
 
-**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to the next step. Do not spawn either sub-agent.
-
 Invoke `hickey` and `lowy` as two **parallel sub-agents** via the harness's agent tool (`subagent_type: "hickey"` and `subagent_type: "lowy"`). On opencode this is the `task` tool (with `subagent_type` parameter).
 
 **Fallback, never skip.** If the harness cannot honor the model declared in the reviewer skill's frontmatter, run hickey and lowy as sub-agents on the available model instead. If a sub-agent invocation fails for harness/tooling reasons before producing a review, retry that reviewer once; if it still cannot produce a sub-agent review, run that review in the main model by loading the reviewer skill against the same diff.

--- a/.apm/skills/do/nodes/hickey-lowy.md
+++ b/.apm/skills/do/nodes/hickey-lowy.md
@@ -19,7 +19,7 @@ description: Parallel structural review with hickey and lowy sub-agents.
 
 ## Pattern
 
-Instances [fanout-fix](../../patterns/fanout-fix.md) with:
+Instances [fanout-fix](../patterns/fanout-fix.md) with:
 - `reviewer_a`: `hickey` sub-agent
 - `reviewer_b`: `lowy` sub-agent
 - Config: `cross_validate: true`

--- a/.apm/skills/do/nodes/implement.md
+++ b/.apm/skills/do/nodes/implement.md
@@ -1,0 +1,31 @@
+---
+name: implement
+description: Implement the planned changes.
+---
+
+# Implement
+
+## Requires
+
+- Plan from research
+
+## Ensures
+
+- Code changes in working tree
+- Tests covering changed behavior (for bug fixes and new behavior)
+
+## Strategies
+
+The test-first rule depends on what the change is:
+
+- **Bug fix**: write a failing test first (e2e or unit, whichever is appropriate), then fix the bug.
+- **New behavior** — anything that fails at runtime if it's wrong: new endpoints or routes, new services or modules, configuration paths, environment variables, secrets wiring, network connectivity, data persistence (migrations, preStart scripts, schema changes), auth/OIDC flows. Write an integration or unit test covering the new behavior **before** implementing. NixOS service modules need a VM test; new HTTP endpoints need an e2e or integration test; new modules with logic need at least a unit test.
+- **Otherwise** — documentation, refactors with no behavioral change, purely internal cleanups, dependency bumps that don't change behavior. Just implement the planned changes; no test-first requirement.
+
+If you're not sure which bucket the change falls into, treat it as new behavior. The cost of an unnecessary test is small; the cost of a silent deployment failure is not.
+
+Prefer simplicity. Do the boring obvious thing.
+
+**E2E coverage**: When the change introduces multiple user-facing paths (e.g., a dialog that appears under different conditions), write e2e scenarios for **each distinct path**. Enumerate the user-visible paths, then check that every one has a corresponding test.
+
+**Verify**: Code changes match the planned approach. For bug fixes and new-behavior changes, at least one test exercises the changed behavior; multi-path changes have one test per distinct user-visible path. Refactor/docs/cleanup diffs are exempt.

--- a/.apm/skills/do/nodes/plan-approval.md
+++ b/.apm/skills/do/nodes/plan-approval.md
@@ -1,0 +1,27 @@
+---
+name: plan-approval
+description: Pause after research for user plan approval (only when --review).
+---
+
+# Plan Approval
+
+## Requires
+
+- `--review` flag
+- Plan from research
+
+## Ensures
+
+- Approved plan
+
+## Strategies
+
+Use `EnterPlanMode` to present the approach for user approval:
+
+- **Clarify ambiguities** first — ask via `AskUserQuestion` if anything is unclear. Don't guess.
+- **High-level plan**: what to do and why, not implementation details. Include an **Architecture section** (affected modules, new abstractions, ripple effects).
+- **Split non-trivial plans into phases** — MVP first, each phase functionally self-sufficient.
+
+Use `ExitPlanMode` to present the plan. Once approved, continue autonomously.
+
+Structural critique from hickey/lowy isn't available at this point — it runs post-implement on a concrete diff and surfaces as commits + a PR comment later.

--- a/.apm/skills/do/nodes/police.md
+++ b/.apm/skills/do/nodes/police.md
@@ -1,0 +1,52 @@
+---
+name: police
+description: Three-pass quality gate.
+---
+
+# Police
+
+## Requires
+
+- `--minimal` flag
+- `--no-git` flag
+- Diff `git diff origin/HEAD...HEAD`
+
+## Ensures
+
+- All 3 passes clean
+- Violation fixes committed individually (or working-tree fixes under --no-git)
+
+## Pattern
+
+Instances [check-loop](../../patterns/check-loop.md) with:
+- `runner`: invoke `/code-police` skill
+- `fixer`: apply one violation fix at a time
+- Config: `max_attempts: 3`, `loop_artifacts: commit-per-fix`
+
+## Strategies
+
+**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to the next step.
+
+Use `git diff origin/HEAD...HEAD --name-only` to check if the PR contains code changes. If all changed files are documentation-only (e.g., `.md`, `.txt`, `README`, docs/) — skip this step with a note.
+
+Otherwise, invoke the `/code-police` skill via the Skill tool. It runs three passes: rule checklist, fact-check, and elegance.
+
+When `/code-police` asks about scope: **changes in the current branch/PR only**.
+
+**Commit each violation fix individually.** The same rule as **hickey + lowy**: one commit per violation, not a lump.
+
+For each violation reported by `/code-police` (across all three passes), in turn:
+
+1. Apply the fix for that one violation — scope the edit tightly.
+2. Run the project's format command on changed files, if configured.
+3. `git add <changed files>` — stage only this fix.
+4. Commit with a conventional prefix:
+   - Rules pass: `fix(police): <rule-id> — <short description>`
+   - Fact-check pass: `fix(police): fact-check — <short description>`
+   - Elegance pass: `refactor(police): elegance — <short description>`
+5. `git push`.
+
+**Under `--no-git`**: Skip commit/push. Apply fixes to working tree.
+
+**Verify**: All 3 passes clean ("All clear").
+**If violations found** (max 3 attempts): Fix the violations and re-invoke `/code-police`.

--- a/.apm/skills/do/nodes/police.md
+++ b/.apm/skills/do/nodes/police.md
@@ -25,8 +25,6 @@ Instances [check-loop](../patterns/check-loop.md) with:
 
 ## Strategies
 
-**If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to the next step.
-
 Use `git diff origin/HEAD...HEAD --name-only` to check if the PR contains code changes. If all changed files are documentation-only (e.g., `.md`, `.txt`, `README`, docs/) — skip this step with a note.
 
 Otherwise, invoke the `/code-police` skill via the Skill tool. It runs three passes: rule checklist, fact-check, and elegance.

--- a/.apm/skills/do/nodes/police.md
+++ b/.apm/skills/do/nodes/police.md
@@ -18,7 +18,7 @@ description: Three-pass quality gate.
 
 ## Pattern
 
-Instances [check-loop](../../patterns/check-loop.md) with:
+Instances [check-loop](../patterns/check-loop.md) with:
 - `runner`: invoke `/code-police` skill
 - `fixer`: apply one violation fix at a time
 - Config: `max_attempts: 3`, `loop_artifacts: commit-per-fix`

--- a/.apm/skills/do/nodes/research.md
+++ b/.apm/skills/do/nodes/research.md
@@ -1,0 +1,31 @@
+---
+name: research
+description: Research the task thoroughly before writing code.
+---
+
+# Research
+
+## Requires
+
+- Task prompt or issue URL
+- `forge` from sync
+
+## Ensures
+
+- Research map: file paths, intended approach, key constraints
+- Plan (if `--review`)
+
+## Strategies
+
+- If given a GitHub issue URL **and** `forge == github`, fetch with `gh issue view`. On non-GitHub forges, treat any issue-like URL as opaque context — use the prompt text as-is and do not attempt to fetch. (Bitbucket issue/Jira fetching is tracked in #10.)
+- **Never assume** how something works. Read the code. Check the config.
+- If the prompt involves external tools/libraries, prefer `git clone` to a scratch dir (e.g. `/tmp/<name>`) at the version the project actually uses, then read the source on disk with `Read`/`Grep`/`Glob`. Fall back to `WebSearch`/`WebFetch` only when the source genuinely isn't a clonable repo (vendor docs, blog posts, RFCs).
+
+**Delegation rule — keep the main context lean.** Before your third `Read` in this step, stop and delegate the rest via `Agent(subagent_type=Explore)`. Main-context reads are reserved for:
+
+  (a) specific files the user named in the prompt,
+  (b) verifying a specific file:line an Explore subagent cited — and only with `offset`/`limit`, never full-file.
+
+Anything that smells like "map the codebase", "find all callers", "understand how X works across the repo" — delegate. The Explore subagent returns a file:line map; keep that map and reference it in later steps instead of re-reading. Use `Grep`/`Glob` before `Read`: if the question can be answered by searching, don't open the file.
+
+**Verify**: Can articulate what needs to change, where, and why, with file:line citations drawn from the research map (not re-read in main context).

--- a/.apm/skills/do/nodes/sync.md
+++ b/.apm/skills/do/nodes/sync.md
@@ -1,0 +1,40 @@
+---
+name: sync
+description: Fetch origin, detect forge, initialize workflow state.
+---
+
+# Sync
+
+## Requires
+
+- `--no-git` flag (parsed by `do-driver init`)
+
+## Ensures
+
+- `forge` — `github`, `bitbucket`, or `unknown`
+- `branch` — current branch name
+- `defaultBranch` — origin HEAD ref name
+
+## Strategies
+
+Run the `scripts/steps/sync` script in this skill's directory, passing `true` or `false` for `--no-git`:
+
+```
+.../skills/do/scripts/steps/sync <noGit>
+```
+
+The script:
+
+- Fetches `origin` and pins `origin/HEAD`
+- If `--no-git` is **not** set and the branch is behind origin (ahead-count 0), fast-forwards with `git pull --ff-only`. Under `--no-git`, fetching happens but the working tree is not touched — uncommitted work is preserved.
+- Prints the dirty-tree hint to stderr (no pause) when the tree is dirty and `--no-git` is not set:
+
+  > _Dirty tree detected. Continuing will create a fresh branch on top of these changes. If you wanted the agent to extend your WIP in place without touching git, re-run with `--no-git`._
+
+- Classifies the forge from `git remote get-url origin` — `github.com` → `github`, `bitbucket.` (covers `bitbucket.org` and self-hosted servers like `bitbucket.juspay.net`) → `bitbucket`, otherwise `unknown`.
+- Calls `scripts/do-results init <forge> <noGit>` then `scripts/do-results step sync passed ...`.
+- Prints `forge=<value>`, `branch=<value>`, `defaultBranch=<value>` on stdout for downstream steps.
+
+**Only `github` has an active code path today.** Both `bitbucket` and `unknown` cause forge-dependent steps (PR creation, PR comments, PR edits, CI status) to skip gracefully. Bitbucket support is planned — see [srid/agency#10](https://github.com/srid/agency/issues/10).
+
+**Verify**: Script exited 0 and printed `forge=`, `branch=`, `defaultBranch=` lines on stdout. (Sync silences `do-results`' own confirmation echoes so the protocol stays clean.)

--- a/.apm/skills/do/nodes/test.md
+++ b/.apm/skills/do/nodes/test.md
@@ -17,7 +17,7 @@ description: Run relevant tests.
 
 ## Pattern
 
-Instances [check-loop](../../patterns/check-loop.md) with:
+Instances [check-loop](../patterns/check-loop.md) with:
 - `runner`: read `.agency/do.md` for `## Test command`, run relevant tests
 - `fixer`: fix test failures
 - Config: `max_attempts: 4`, `coverage_check: true`, `loop_artifacts: commit-per-fix`

--- a/.apm/skills/do/nodes/test.md
+++ b/.apm/skills/do/nodes/test.md
@@ -1,0 +1,36 @@
+---
+name: test
+description: Run relevant tests.
+---
+
+# Test
+
+## Requires
+
+- Implemented code
+- Changes in current branch
+
+## Ensures
+
+- Tests pass
+- New behavior is actually exercised
+
+## Pattern
+
+Instances [check-loop](../../patterns/check-loop.md) with:
+- `runner`: read `.agency/do.md` for `## Test command`, run relevant tests
+- `fixer`: fix test failures
+- Config: `max_attempts: 4`, `coverage_check: true`, `loop_artifacts: commit-per-fix`
+
+## Strategies
+
+Read `.agency/do.md` and look for a `## Test command` section. Run only the tests relevant to the code paths changed in this PR.
+
+Use `git diff origin/HEAD...HEAD --name-only` to identify changed files and determine which tests are relevant.
+
+If changes are purely internal with no user-facing impact, unit tests may suffice — skip e2e if no relevant scenarios exist. If no test command is documented, skip with a note.
+
+**Coverage gap check**: After the test command exits 0, confirm at least one of the tests run actually exercised the new behavior (per the **implement** step's classification). A green run that didn't touch the changed code paths is a coverage gap, not a pass. Refactor/docs/internal-cleanup diffs are exempt. If a gap is found, treat it as a real failure: write the missing test, then loop through **fmt** → **commit** → **test**.
+
+**Verify**: Tests pass (exit code 0) **and** the new behavior is covered, or the diff is exempt from the coverage check, or no relevant tests to run.
+**If failed** (max 4 attempts): Analyze the failure. If flaky, re-run. If real: fix → go to **fmt**, then retry.

--- a/.apm/skills/do/patterns/check-loop.md
+++ b/.apm/skills/do/patterns/check-loop.md
@@ -1,0 +1,88 @@
+# check-loop
+
+A specialization of [worker-critic](worker-critic.md) for verification-driven retry: a deterministic command (the runner / critic) gates a fix loop (the fixer / worker). Used by **check**, **docs**, **test**, **ci**, and **police**.
+
+## Slots
+
+- `runner`: the command that verifies (e.g. `tsc --noEmit`, `nix flake check`, `/code-police`)
+  - requires: `target` (the diff or files under inspection)
+  - ensures: `verdict` (`pass` | `fail` | `flaky` | `no-command-configured`), `output`
+- `fixer`: applies a corrective edit when runner returns `fail`
+  - requires: `output` (the runner's failure output), `target`
+  - ensures: `attempted_fix` (bool), `files_changed` (list of paths)
+
+## Config
+
+| Param | Default | Meaning |
+|-------|---------|---------|
+| `max_attempts` | `3` | Maximum real-failure fix attempts. Exhaustion halts the workflow. |
+| `flaky_classification` | `false` | When `true`, runner may return `flaky` (re-run without fixing) and `flaky_budget` is consumed separately. |
+| `flaky_budget` | `0` | Re-runs allowed without fixing. Only meaningful when `flaky_classification: true`. |
+| `loop_artifacts` | `none` | `none`: fixes stay in the working tree only. `commit-per-fix`: each fix that lands real changes is followed by `fmt` + `commit` + `push`, with one commit per discrete fix. |
+| `coverage_check` | `false` | When `true`, after `verdict == pass` the runner must also confirm the changed code paths were exercised. A green run on stale code does not satisfy verification. |
+| `rerun_on_new_commit` | `false` | When `true`, before recording `pass` the pattern compares the SHA the runner ran against to current `HEAD`. If they differ, re-runs against current `HEAD`. |
+
+## Requires
+
+- `target`: what's being verified (typically the just-implemented diff, scoped via `git diff origin/HEAD...HEAD --name-only`)
+
+## Ensures
+
+- `verdict`: one of:
+  - `pass` — runner returned success and (if applicable) coverage / SHA checks passed
+  - `failed-after-budget` — exhausted retries; surrounding workflow halts with `status=failed`
+  - `no-command-configured` — runner reports the project hasn't configured this gate; treated as `skipped` by the surrounding node
+
+## Invariants
+
+- `no-command-configured` short-circuits to `skipped` — never treated as failed.
+- On `failed-after-budget`, the surrounding workflow halts (the surrounding node reports `step-end failed`). The pattern does not silently pass.
+- `flaky` re-runs do not consume the `max_attempts` budget; only real failures do. The two budgets are independent.
+- Under `loop_artifacts: commit-per-fix`, each fix is its own commit (never batched). PR history reads as a sequence of discrete fixes, not a grab-bag diff.
+- Under `loop_artifacts: commit-per-fix` AND `noGit: true`: fixes go to the working tree but commit/push are skipped. The user reviews the combined working-tree delta themselves.
+
+## Delegation
+
+```prose
+let attempts_real = 0
+let attempts_flaky = 0
+
+loop:
+  let { verdict, output } = call runner
+    target: target
+
+  if verdict == "no-command-configured":
+    return { verdict: "no-command-configured" }
+
+  if verdict == "pass":
+    if coverage_check:
+      confirm coverage via test logs / SHA comparison
+    if rerun_on_new_commit:
+      if runner_sha != HEAD:
+        continue  # re-run against current HEAD
+    return { verdict: "pass" }
+
+  if verdict == "flaky":
+    attempts_flaky += 1
+    if attempts_flaky > flaky_budget:
+      return { verdict: "failed-after-budget" }
+    continue  # re-run without fixing
+
+  if verdict == "fail":
+    attempts_real += 1
+    if attempts_real > max_attempts:
+      return { verdict: "failed-after-budget" }
+
+    let { attempted_fix, files_changed } = call fixer
+      output: output
+      target: target
+
+    if loop_artifacts == "commit-per-fix" and attempted_fix:
+      call fmt on files_changed
+      if not noGit:
+        git add files_changed
+        git commit -m "<prefix>: <short description>"
+        git push
+
+    continue  # re-run runner
+```

--- a/.apm/skills/do/patterns/fanout-fix.md
+++ b/.apm/skills/do/patterns/fanout-fix.md
@@ -4,12 +4,9 @@ Parallel reviewers produce findings; each finding is applied as its own commit. 
 
 ## Slots
 
-- `reviewer_a`: first reviewer (e.g. `hickey`)
-  - requires: `diff`, `task`, `context`
-  - ensures: `findings` (list of `{label, disposition, rationale}`)
-- `reviewer_b`: second reviewer (e.g. `lowy`)
-  - requires: `diff`, `task`, `context`
-  - ensures: `findings` (list of `{label, disposition, rationale}`)
+- `reviewers`: list of reviewer slots (e.g. `[hickey, lowy]`)
+  - each requires: `diff`, `task`, `context`
+  - each ensures: `findings` (list of `{label, disposition, rationale}`)
 - `fixer`: applies a single finding
   - requires: `finding`, `diff`
   - ensures: `commit_sha` (string or null if no-op)
@@ -18,7 +15,7 @@ Parallel reviewers produce findings; each finding is applied as its own commit. 
 
 | Param | Default | Meaning |
 |-------|---------|---------|
-| `cross_validate` | `true` | When `true` and both reviewers produced findings, run each reviewer a second time against the other reviewer's findings to catch cross-effects. |
+| `cross_validate` | `true` | When `true` and at least two reviewers produced findings, run each reviewer a second time against the other reviewers' findings to catch cross-effects. |
 
 ## Requires
 
@@ -43,18 +40,20 @@ Parallel reviewers produce findings; each finding is applied as its own commit. 
 
 ```prose
 # Phase 1: parallel first-pass
-let findings_a = spawn reviewer_a(diff, task, context)
-let findings_b = spawn reviewer_b(diff, task, context)
-await both
+let all_first_pass = []
+for reviewer in reviewers:
+  all_first_pass.push(spawn reviewer(diff, task, context))
+await all
 
-let all_findings = findings_a + findings_b
+let all_findings = concat all_first_pass
 
-# Phase 2: cross-validation (if both found something)
-if cross_validate and findings_a.nonempty and findings_b.nonempty:
-  let cv_a = spawn reviewer_a(diff, task, context, other_findings: findings_b)
-  let cv_b = spawn reviewer_b(diff, task, context, other_findings: findings_a)
-  await both
-  merge new findings into all_findings
+# Phase 2: cross-validation (if at least two reviewers found something)
+if cross_validate and count_nonempty(all_first_pass) >= 2:
+  for reviewer in reviewers where reviewer.findings.nonempty:
+    let others = all_findings excluding this reviewer's findings
+    let cv = spawn reviewer(diff, task, context, other_findings: others)
+    await cv
+    merge new findings into all_findings
 
 # Phase 3: apply fixes
 let commits = []

--- a/.apm/skills/do/patterns/fanout-fix.md
+++ b/.apm/skills/do/patterns/fanout-fix.md
@@ -1,0 +1,67 @@
+# fanout-fix
+
+Parallel reviewers produce findings; each finding is applied as its own commit. Used by **hickey-lowy**.
+
+## Slots
+
+- `reviewer_a`: first reviewer (e.g. `hickey`)
+  - requires: `diff`, `task`, `context`
+  - ensures: `findings` (list of `{label, disposition, rationale}`)
+- `reviewer_b`: second reviewer (e.g. `lowy`)
+  - requires: `diff`, `task`, `context`
+  - ensures: `findings` (list of `{label, disposition, rationale}`)
+- `fixer`: applies a single finding
+  - requires: `finding`, `diff`
+  - ensures: `commit_sha` (string or null if no-op)
+
+## Config
+
+| Param | Default | Meaning |
+|-------|---------|---------|
+| `cross_validate` | `true` | When `true` and both reviewers produced findings, run each reviewer a second time against the other reviewer's findings to catch cross-effects. |
+
+## Requires
+
+- `diff`: `git diff origin/HEAD...HEAD`
+- `task`: the original task prompt
+- `context`: file paths, approach, constraints from research
+
+## Ensures
+
+- `commits`: list of commit SHAs, one per "Fix in this PR" finding
+- `findings_ledger`: markdown table of all findings with dispositions
+
+## Invariants
+
+- Reviewers run in parallel, not sequentially.
+- Each "Fix in this PR" finding gets its own commit — never batched.
+- `No-op` findings require no commit.
+- There is no "Defer" disposition. Any reviewer output resembling a defer is treated as "Fix in this PR".
+- Under `--no-git`: fixes go to working tree, no commits.
+
+## Delegation
+
+```prose
+# Phase 1: parallel first-pass
+let findings_a = spawn reviewer_a(diff, task, context)
+let findings_b = spawn reviewer_b(diff, task, context)
+await both
+
+let all_findings = findings_a + findings_b
+
+# Phase 2: cross-validation (if both found something)
+if cross_validate and findings_a.nonempty and findings_b.nonempty:
+  let cv_a = spawn reviewer_a(diff, task, context, other_findings: findings_b)
+  let cv_b = spawn reviewer_b(diff, task, context, other_findings: findings_a)
+  await both
+  merge new findings into all_findings
+
+# Phase 3: apply fixes
+let commits = []
+for finding in all_findings where disposition == "Fix in this PR":
+  call fixer(finding, diff)
+  if not noGit and commit_sha:
+    commits.push(commit_sha)
+
+return { commits, findings_ledger }
+```

--- a/.apm/skills/do/patterns/worker-critic.md
+++ b/.apm/skills/do/patterns/worker-critic.md
@@ -1,0 +1,57 @@
+# worker-critic
+
+Produce → critique → revise (with budget). The general shape of which `check-loop` is a specialization.
+
+## Slots
+
+- `worker`: produces an artifact
+  - requires: `spec`
+  - ensures: `artifact`
+- `critic`: evaluates the artifact against a standard
+  - requires: `artifact`
+  - ensures: `verdict` (`pass` | `fail` | `flaky`), `critique`
+- `reviser`: revises the artifact given the critique
+  - requires: `artifact`, `critique`
+  - ensures: `revised_artifact`, `changed` (bool)
+
+## Config
+
+| Param | Default | Meaning |
+|-------|---------|---------|
+| `max_attempts` | `3` | Maximum revision rounds. |
+| `early_exit` | `true` | If critic returns `pass` on first attempt, stop immediately. |
+
+## Requires
+
+- `spec`: what the worker should produce
+
+## Ensures
+
+- `final_artifact`: the artifact after zero or more revision rounds
+- `attempts`: how many rounds were consumed
+- `verdict`: `pass` | `failed-after-budget`
+
+## Invariants
+
+- The critic is always applied to the latest artifact, not the original.
+- Each round that produces a real change counts as one attempt.
+- If `early_exit` is `true` and the first round passes, `attempts == 0`.
+
+## Delegation
+
+```prose
+let artifact = call worker(spec: spec)
+let attempts = 0
+
+loop:
+  let { verdict, critique } = call critic(artifact: artifact)
+  if verdict == "pass":
+    return { final_artifact: artifact, attempts: attempts, verdict: "pass" }
+  if attempts >= max_attempts:
+    return { final_artifact: artifact, attempts: attempts, verdict: "failed-after-budget" }
+  let { revised_artifact, changed } = call reviser(artifact: artifact, critique: critique)
+  if not changed:
+    return { final_artifact: artifact, attempts: attempts, verdict: "pass" }
+  artifact = revised_artifact
+  attempts += 1
+```

--- a/.apm/skills/do/scripts/do-driver
+++ b/.apm/skills/do/scripts/do-driver
@@ -69,10 +69,9 @@ case "$cmd" in
     ;;
 
   end)
-    step="${1:?step required}"
-    status="${2:?status required}"
-    verif="${3:?verification required}"
-    reason="${4:-}"
+    status="${1:?status required}"
+    verif="${2:?verification required}"
+    reason="${3:-}"
     if [ -n "$reason" ]; then
       "$DO_RESULTS" step-end "$status" "$verif" "$reason"
     else

--- a/.apm/skills/do/scripts/do-driver
+++ b/.apm/skills/do/scripts/do-driver
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# /do workflow's driver — a thin state wrapper around do-results.
+#
+# Does NOT sequence, skip, or retry. The agent reads execution.md for
+# choreography and calls this script only to record state and emit summaries.
+#
+# Usage:
+#   do-driver init [--no-git] [--minimal] [--from=<step>] <task>
+#   do-driver start <step>
+#   do-driver end <step> <status> <verification> [reason]
+#   do-driver skip <step> <reason>
+#   do-driver set <field> <value>
+#   do-driver summary
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DO_RESULTS="$SCRIPT_DIR/do-results"
+
+if [ $# -lt 1 ]; then
+  echo "Usage: do-driver <init|start|end|skip|set|summary> ..." >&2
+  exit 1
+fi
+
+cmd="${1}"
+shift
+
+case "$cmd" in
+  init)
+    noGit="false"
+    minimal="false"
+    from=""
+    task=""
+
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --no-git) noGit="true"; shift ;;
+        --minimal) minimal="true"; shift ;;
+        --from=*)
+          from="${1#*=}"
+          shift
+          ;;
+        --*)
+          echo "do-driver: unknown flag: $1" >&2
+          exit 2
+          ;;
+        *)
+          task="$1"
+          shift
+          ;;
+      esac
+    done
+
+    "$DO_RESULTS" init >/dev/null
+    "$DO_RESULTS" set noGit "$noGit" >/dev/null
+    "$DO_RESULTS" set minimal "$minimal" >/dev/null
+    if [ -n "$from" ]; then
+      "$DO_RESULTS" set from "$from" >/dev/null
+    fi
+    if [ -n "$task" ]; then
+      "$DO_RESULTS" set task "$task" >/dev/null
+    fi
+    echo "init: noGit=$noGit minimal=$minimal from=${from:-default}"
+    ;;
+
+  start)
+    step="${1:?step required}"
+    "$DO_RESULTS" step-start "$step"
+    ;;
+
+  end)
+    step="${1:?step required}"
+    status="${2:?status required}"
+    verif="${3:?verification required}"
+    reason="${4:-}"
+    if [ -n "$reason" ]; then
+      "$DO_RESULTS" step-end "$status" "$verif" "$reason"
+    else
+      "$DO_RESULTS" step-end "$status" "$verif"
+    fi
+    ;;
+
+  skip)
+    step="${1:?step required}"
+    reason="${2:?reason required}"
+    "$DO_RESULTS" step-start "$step"
+    "$DO_RESULTS" step-end skipped "" "$reason"
+    ;;
+
+  set)
+    field="${1:?field required}"
+    value="${2:?value required}"
+    "$DO_RESULTS" set "$field" "$value"
+    ;;
+
+  summary)
+    "$SCRIPT_DIR/steps/done"
+    ;;
+
+  *)
+    echo "Unknown command: $cmd" >&2
+    echo "Usage: do-driver <init|start|end|skip|set|summary> ..." >&2
+    exit 1
+    ;;
+esac

--- a/.apm/skills/do/scripts/steps/sync
+++ b/.apm/skills/do/scripts/steps/sync
@@ -57,7 +57,7 @@ esac
 # the generic `set` command, then record the sync step. Suppress do-results'
 # stdout confirmations — sync emits its own forge/branch/defaultBranch
 # protocol below and shouldn't pollute it with do-results' echo lines.
-"$DO_RESULTS" init >/dev/null
+[ -f ".do-results.json" ] || "$DO_RESULTS" init >/dev/null
 "$DO_RESULTS" set forge "$forge" >/dev/null
 "$DO_RESULTS" set noGit "$noGit" >/dev/null
 "$DO_RESULTS" step sync passed \


### PR DESCRIPTION
# refactor(do): split monolithic SKILL.md into node-driven workflow graph

**The /do skill is now a workflow graph instead of a 515-line monolith.** Each step lives in its own node file, shared retry-loop logic is abstracted into reusable patterns, and a thin driver script enforces state tracking.

### What changed

| Before | After |
|--------|-------|
| One `SKILL.md` (515 lines) | Thin root `SKILL.md` (~50 lines) + `execution.md` + 16 node files |
| Retry logic inlined 5× | Single `patterns/check-loop.md` instanced by nodes |
| Parallel review (hickey+lowy) described inline | `patterns/fanout-fix.md` with N-reviewer list |
| Agent calls `do-results` directly | Agent calls `scripts/do-driver` for bookends and summary |

### The graph

```prose
call sync → research → [plan-approval if --review] → branch → implement
  → check → [docs if not --minimal] → fmt → commit
  → [hickey-lowy + police if not --minimal] → test → create-pr → ci → evidence → done
```

Topology lives only in `execution.md` — node files describe what to do, not where to go next. Skip conditions (`--no-git`, `--minimal`, forge) are declared in `execution.md` and removed from individual nodes to avoid drift.

### Why not the prior RFCs?

This work builds on ideas from two prior RFC branches (`33174cd` v0 graph, `23f8c78` OpenProse-derived). The delta is editorial: no YAML frontmatter in nodes, no `workspace.md` (bindings stay in node `Requires`/`Ensures`), and the driver is a thin state wrapper rather than a sequencer.

> _The driver does not dictate "what's next" — `execution.md` owns that. The driver only enforces bookend discipline (`start` → `end`) and emits the timing summary._

### Files added

- `execution.md` — single source of truth for order, entry points, skip taxonomy
- `nodes/*.md` (16) — one per workflow step
- `patterns/*.md` (3) — `check-loop`, `fanout-fix`, `worker-critic`
- `scripts/do-driver` — thin `do-results` wrapper

### Notable

- `SKILL.md` shrank from 515 to ~50 lines
- Behavior preserved 1:1 — all flags, all skip reasons, all retry budgets
- No changes to `do-results`, `steps/sync`, or `steps/done` (except a guard to prevent `init` overwrite)

_Generated by [`/do`](https://github.com/srid/agency) on opencode (model `kimi-k2.6`)._

Note: I've tested it on small to medium-size tasks and it seems to work much better on non-frontier models than the original skill — doesn't lose track to begin with