### PR TITLE
do: make "prove the fixed behavior" a first-class evidence trigger

### DIFF
--- a/.apm/skills/do/SKILL.md
+++ b/.apm/skills/do/SKILL.md
@@ -389,7 +389,13 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 
 ### evidence
 
-**Opt-in step.** Most projects skip this. The step exists so projects with empirical "did the feature actually work" needs — UI screenshots, performance benchmarks, demo recordings, output transcripts — can attach that evidence to the PR without baking the mechanism into agency.
+**Opt-in step.** Most projects skip this. The step exists so projects with empirical "did this actually work" needs can attach proof to the PR without baking the mechanism into agency. That proof is **visual** _or_ **behavioral** — and the second kind is easy to under-fire on, because it often has zero visual diff:
+
+- **Visual** — UI screenshots, before/after stills, demo recordings; **video** when the change is about motion (an animation, a transition).
+- **Behavioral** — proof that _state survives an interaction or a restart_. When the diff touches a persistence, restore, session, autosave, debounce/coalesce, or reconnect path, the evidence that matters is "does the round-trip still hold?", not a pixel change. These changes routinely have **no visual diff** yet are exactly where a survives-restart capture proves the fix didn't break recoverability (e.g. resize → stop the app → restart → restore session → panel returns at the resized width).
+- **Other empirical** — performance benchmarks, output transcripts.
+
+**Bug fixes default to "demonstrate the fixed behavior."** The bug was usually invisible — a lost write, a storm, a hang, a broken round-trip — so a before→after or survives-restart clip is the evidence even when nothing _looks_ different. Don't gate evidence on a pixel changing; gate it on "is there a behavior worth proving."
 
 **If `--minimal`**: Skip with status `skipped` and reason `"--minimal"`. Move to **done**.
 
@@ -402,6 +408,8 @@ CI commands are typically local (e.g. `nix flake check`, `just ci`, `make ci`) a
 **If the section is present**:
 
 The section is project-specific and free-form: it can be inline prose describing the capture procedure, a pointer to another file (`See ./scripts/capture-evidence.md`), a script reference (`Run ./scripts/capture-pr-evidence.sh and use its stdout`), or any combination. Don't second-guess the form — read it, then **spawn a sub-agent** (`Agent(subagent_type: "general-purpose", ...)`) so the capture work (MCP calls, screenshot uploads, gh API requests) doesn't pollute `/do`'s main context.
+
+**Read the trigger broadly.** A project's section supplies the _capture mechanism_; the criterion for _when to fire_ is the visual-or-behavioral framing above. If the section's wording leans visual ("when the change has visible UI impact") but the diff is a behavioral fix on a persistence/restore/round-trip/debounce/reconnect path, capture the **behavior** anyway — the absence of a visual diff is not a reason to skip. Only skip when there is genuinely no behavior worth proving (a pure refactor, a docs change, an internal cleanup with no observable before→after).
 
 The sub-agent prompt should include:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Agency[^agency] is a near-autonomous workflow for coding agents, packaged as an 
 
 The autonomous loop is only as good as the feedback signal it gets. If the agent can't tell whether its change actually worked, no amount of model capability papers over that gap. End-to-end tests are a prerequisite, not a nice-to-have — unit tests and type-checks alone aren't enough. What "e2e" means depends on the surface:
 
-- **Frontend** → screenshot evidence in PRs ([example](https://github.com/juspay/kolu/pull/791#issuecomment-4352641175)). First-class evidence as a workflow step is tracked in [#106](https://github.com/srid/agency/issues/106).
+- **Frontend** → screenshot evidence in PRs ([example](https://github.com/juspay/kolu/pull/791#issuecomment-4352641175)) for visual changes — and a survives-restart capture for behavioral fixes that have no visual diff (persistence / restore / round-trip paths). First-class evidence as a workflow step is tracked in [#106](https://github.com/srid/agency/issues/106).
 - **Nix-based infra** → NixOS VM tests. Honest tradeoff: a VM isn't a live environment, mocking is often required, and reaching real fidelity for non-trivial infra takes effort — but it's still the closest thing to an executable spec the agent can drive.
 - **Backend / library** → fast, deterministic e2e suites the agent can run in a tight loop. Slow or flaky suites destroy the loop; a 30-second deterministic run beats a 10-minute thorough one.
 
@@ -118,10 +118,14 @@ just ci
 Keep README.md in sync with user-facing changes.
 
 ## PR evidence
-For every PR that touches the UI:
+Capture proof when the change has a behavior worth proving — **visual** (a UI diff) or
+**behavioral** (state survives an interaction or a restart, e.g. a persistence / restore /
+debounce / reconnect fix with no visual diff):
 
-1. Use the `chrome-devtools` MCP to launch `npm run dev` and navigate to the affected route.
-2. Capture a screenshot of the new state and upload it via `gh api` to the repo's release-asset endpoint.
+1. Use the `chrome-devtools` MCP to launch `npm run dev` and exercise the affected route — for
+   a behavioral fix, drive the before→after round-trip (e.g. change state → restart → restore).
+2. Capture a screenshot (or a video, for motion or a round-trip) and upload it via `gh api` to
+   the repo's release-asset endpoint.
 3. Embed the resulting URL inline in the PR comment under `## Evidence`.
 ```
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -99,11 +99,11 @@ const year = new Date().getFullYear();
       <li class="triple-cell" style="border-top-color: var(--color-magenta)">
         <p class="triple-label">frontend</p>
         <p class="triple-body">
-          Screenshot evidence on every PR —
+          Visual <em>and</em> behavioral evidence on PRs — a screenshot
           <a
             href="https://github.com/juspay/kolu/pull/791#issuecomment-4352641175"
             rel="noopener">like kolu#791</a
-          >.
+          >, or a survives-restart clip for an invisible fix.
         </p>
       </li>
       <li class="triple-cell" style="border-top-color: var(--color-cyan)">


### PR DESCRIPTION
Addresses the upstream note in [juspay/kolu#1051](https://github.com/juspay/kolu/issues/1051).

## The concern

`/do`'s **evidence** step gated on **visual** change ("visible UI impact" / "motion"). For a whole class of changes — bug fixes to **persistence / restore / round-trip / write-coalescing / debounce / reconnect** paths — the proof that matters is **behavioral** (*does state survive the interaction or restart?*), and those changes have **zero visual diff**. The literal criterion never fired for them, so evidence was systematically skipped.

The textbook case was kolu's pref-storm fix ([kolu#1050](https://github.com/juspay/kolu/issues/1050)): its entire risk was that a debounced preference write could be *lost* on a quick reload. A clip of *resize → stop the app → restart → restore session → panel returns at the resized width* is the proof — but the visual/motion framing skipped it, and the user had to ask for the video manually. The kolu issue notes the same bias lives upstream in this skill ("Opt-in… empirical 'did the feature actually work' needs"), and asks that "prove the fixed behavior" become a first-class trigger rather than an afterthought.

## What changed

- **`.apm/skills/do/SKILL.md` (evidence step)** — reframe evidence as **visual _or_ behavioral**, call out the behavioral case (state survives an interaction/restart) explicitly, and make **bug fixes default to "demonstrate the fixed behavior"** even when nothing looks different. Add a "read the trigger broadly" clause so a project's visually-worded `## PR evidence` section still fires for a behavioral fix — skip only when there's genuinely no behavior worth proving.
- **`README.md`** — broaden the example `## PR evidence` section (no longer "for every PR that touches the UI") and the frontend feedback bullet to model survives-restart captures for invisible fixes.
- **`website/src/pages/index.astro`** — landing page now promises "visual *and* behavioral evidence," kept in sync per `CLAUDE.md`.

The existing visual / motion branch for feature work is preserved; this just stops the criterion from systematically skipping invisible-but-verifiable fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)