### PR TITLE
feat(forge-pr): require Conventional Commits type in PR titles

### DIFF
--- a/.apm/skills/forge-pr/SKILL.md
+++ b/.apm/skills/forge-pr/SKILL.md
@@ -18,7 +18,7 @@ Write PR descriptions that fellow devs actually want to read. The writing guidan
 
 ## What to write instead
 
-**Title**: Short, specific, interesting. Convey _what changed from a user/dev perspective_, not which files were touched. Use imperative mood. Under 70 chars.
+**Title**: Lead with a [Conventional Commits](https://www.conventionalcommits.org/) type — `feat:` / `fix:` / `perf:` / `refactor:` / `docs:` / `test:` / `chore:` / `ci:`, with `!` (or a `BREAKING CHANGE:` footer) for breaking changes. Pick the type by _user-facing impact_, not which files moved: a repo that squash-merges turns this title into the release changelog line, where `feat` / `fix` surface to users and `chore` / `docs` / `test` / `ci` are dropped — so a user-facing change mislabeled `chore:` silently vanishes from the changelog. After the prefix: short, specific, interesting — convey _what changed from a user/dev perspective_, not which files were touched, in imperative mood. Keep the whole title under 70 chars.
 
 **Body**: Open with a paragraph. Structure:
 
@@ -123,7 +123,7 @@ Title: Update NixOS configuration and add new service
 ### Good (small change — narrative is enough)
 
 ```
-Title: Add kolu service with health monitoring
+Title: feat: add kolu service with health monitoring
 
 **Kolu now runs as a standalone NixOS service** with its own systemd
 unit and a dedicated health-check endpoint. Previously it was bolted
@@ -139,7 +139,7 @@ service on three consecutive failures.*
 When the change has a flow, several discrete features, and a couple of before/after refinements, _show_ those instead of writing them out as prose:
 
 ````
-Title: Export agent session as a self-contained HTML file
+Title: feat: export agent session as a self-contained HTML file
 
 **Kolu can now export the active agent session as a portable,
 self-contained HTML file** — Claude Code, OpenCode, or Codex, no


### PR DESCRIPTION
**`forge-pr` now requires a [Conventional Commits](https://www.conventionalcommits.org/) type prefix on every PR title** — `feat:` / `fix:` / `chore:` / etc., with `!` for breaking changes. The motivation is downstream automation: in a repo that **squash-merges**, the PR title becomes the squash commit subject, which becomes the **release changelog line**. A generated changelog groups by type and surfaces `feat`/`fix` to users while dropping `chore`/`docs`/`test`/`ci` — so a user-facing change mislabeled `chore:` silently vanishes from the release notes.

The skill already drove good, human-readable titles; this just pins the *type* in front so the title is changelog-ready by construction, with no separate "write the changelog" step. The guidance tells the author to pick the type by **user-facing impact**, not which files moved.

- Rewrote the **Title** rule to lead with the type + the squash-changelog rationale.
- Prefixed the two **good** example titles (`feat: add kolu service…`, `feat: export agent session…`) so the examples model the rule.

Context: this came out of designing kolu's 1.0 release runbook, where the changelog is generated from squash-merged PR titles between tags. Rather than patch `/be` or `/do` (both downstream of `forge-pr`), the rule belongs here at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)