### PR TITLE
lowy: add the graduation sweep (extraction direction of the boundary question)

### DIFF
--- a/.apm/skills/lowy/SKILL.md
+++ b/.apm/skills/lowy/SKILL.md
@@ -46,6 +46,8 @@ The trigger — "review this boundary", "should we split X", "look at module Y",
 
 **Push back when the evidence contradicts the trigger.** If the prompt narrows the question to one boundary but the surrounding code shows the volatility doesn't track that boundary at all, the redirected finding is the headline, not a footnote. *"Issue #N described a UI extraction; the volatility actually splits the data model into two kinds"* is a valid first finding, not an out-of-scope tangent.
 
+**The graduation sweep (both directions).** Reviewing a diff for boundaries means asking the boundary question in *both* directions: not only "did volatility leak *into* a module where it doesn't belong?" (containment) but also "does this diff *create* app-local machinery that *hides* a hard volatility — transport, connection lifetime, reconnection, multiplicity racing user intent — and therefore wants its own receptacle/package?" (graduation). For each such mechanism, name the volatility it encapsulates and the home it wants, even at a population of one consumer (§6's single-consumer rule already admits this). Report these as recorded opportunities, never blockers: a prove-then-extract discipline governs *when* to extract; the review's job is that candidates are named and land in a ledger instead of staying invisible.
+
 ## The Evaluation
 
 For every module boundary, service split, or new abstraction in the code under review:


### PR DESCRIPTION
Born from a real miss. A four-lens review of a large PR asked lowy only the containment direction of the boundary question — "did volatility leak into a module where it doesn't belong?" — and the lens correctly declared a module clean as a leaf, while three volatility-hiding mechanisms *inside* it went unnamed. Nothing in the skill prompted the reviewer to look the other way: does this diff *create* app-local machinery that hides a hard volatility (transport, connection lifetime, reconnection, multiplicity racing user intent) and therefore wants its own receptacle?

This PR makes that extraction direction a standing part of the lens. A new **graduation sweep** paragraph in §Scope of Review directs the reviewer to ask the boundary question in both directions — containment *and* graduation — and, for each app-local mechanism that hides a hard volatility, to name the volatility it encapsulates and the home it wants, even at a population of one consumer (which §6's single-consumer rule already admits).

Deliberately non-blocking: graduation candidates are reported as recorded opportunities, never blockers. A prove-then-extract discipline governs *when* to extract; the review's job is only that candidates get named and land in a ledger instead of staying invisible.

Only the `.apm/` source is touched — `.claude/` is regenerated by `apm install` and not tracked; verified locally that the regenerated skill carries the clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)